### PR TITLE
packit-service config and PR status reports from stg app

### DIFF
--- a/packit_service/cli/listen_to_fedmsg.py
+++ b/packit_service/cli/listen_to_fedmsg.py
@@ -26,7 +26,6 @@ Watch for new upstream releases.
 import logging
 
 import click
-from packit.config import pass_config
 
 from packit_service.celerizer import celery_app
 from packit_service.fed_mes_consume import Consumerino
@@ -37,14 +36,12 @@ logger = logging.getLogger(__name__)
 
 @click.command("listen-to-fedmsg")
 @click.argument("message-id", nargs=-1)
-@pass_config
-def listen_to_fedmsg(config, message_id):
+def listen_to_fedmsg(message_id):
     """
     Listen to events on fedmsg and process them.
 
     if MESSAGE-ID is specified, process only the selected messages
     """
-
     consumerino = Consumerino()
 
     if message_id:

--- a/packit_service/cli/packit_base.py
+++ b/packit_service/cli/packit_base.py
@@ -23,11 +23,12 @@
 import logging
 
 import click
-from packit.config import Config, get_context_settings
+from packit.config import get_context_settings
 from packit.utils import set_logging
 from pkg_resources import get_distribution
 
 from packit_service.cli.listen_to_fedmsg import listen_to_fedmsg
+from packit_service.config import Config
 
 logger = logging.getLogger("packit_service")
 
@@ -39,7 +40,7 @@ logger = logging.getLogger("packit_service")
 @click.pass_context
 def packit_base(ctx, debug, fas_user, keytab):
     """Integrate upstream open source projects into Fedora operating system."""
-    c = Config.get_user_config()
+    c = Config.get_service_config()
     c.debug = debug or c.debug
     c.fas_user = fas_user or c.fas_user
     c.keytab_path = keytab or c.keytab_path

--- a/packit_service/config.py
+++ b/packit_service/config.py
@@ -1,0 +1,167 @@
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import enum
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+from packit.config import BaseConfig, RunCommandType
+from packit.exceptions import PackitException
+from yaml import safe_load
+
+from packit_service.constants import (
+    SANDCASTLE_WORK_DIR,
+    SANDCASTLE_PVC,
+    SANDCASTLE_IMAGE,
+    SANDCASTLE_DEFAULT_PROJECT,
+    CONFIG_FILE_NAMES,
+)
+from packit_service.schema import SERVICE_CONFIG_SCHEMA
+
+logger = logging.getLogger(__name__)
+
+
+class Deployment(enum.Enum):
+    dev = "dev"
+    stg = "stg"
+    prod = "prod"
+
+    @staticmethod
+    def from_str(label):
+        if label == "stg":
+            return Deployment.stg
+        elif label == "prod":
+            return Deployment.prod
+        elif label == "dev":
+            return Deployment.dev
+        else:
+            raise NotImplementedError
+
+
+class Config(BaseConfig):
+    SCHEMA = SERVICE_CONFIG_SCHEMA
+
+    def __init__(self):
+
+        self.debug: bool = False
+        self.fas_user: Optional[str] = None
+        self.keytab_path: Optional[str] = None
+        self._pagure_user_token: str = ""
+        self._pagure_fork_token: str = ""
+        self.dry_run: bool = False
+
+        self.deployment: Deployment = Deployment.stg
+
+        self.github_app_id: Optional[str] = None
+        self.github_app_cert_path: Optional[str] = None
+        self._github_token: str = ""
+        self.webhook_secret: str = ""
+        self.validate_webhooks: bool = True
+
+        # %%% ACTIONS HANDLER CONFIGURATION %%%
+        # these values are specific to packit service when we run actions in a sandbox
+
+        # name of the handler to run actions and commands, default to current env
+        self.command_handler: RunCommandType = RunCommandType.local
+        # a dir where the PV is mounted: both in sandbox and in worker
+        self.command_handler_work_dir: str = ""
+        # name of the PVC so that the sandbox has the same volume mounted
+        self.command_handler_pvc_env_var: str = ""  # pointer to pointer, lol
+        # name of sandbox container image
+        self.command_handler_image_reference: str = SANDCASTLE_IMAGE
+        # do I really need to explain this?
+        self.command_handler_k8s_namespace: str = SANDCASTLE_DEFAULT_PROJECT
+
+        # path to a file where OGR should store HTTP requests
+        self.github_requests_log_path: str = ""
+
+    @classmethod
+    def get_from_dict(cls, raw_dict: dict, validate=True) -> "Config":
+        if validate:
+            cls.validate(raw_dict)
+
+        config = Config()
+
+        config.debug = raw_dict.get("debug", False)
+        config.dry_run = raw_dict.get("dry_run", False)
+        config.fas_user = raw_dict.get("fas_user", None)
+        config.keytab_path = raw_dict.get("keytab_path", None)
+        config._pagure_user_token = raw_dict.get("pagure_user_token", "")
+        config._pagure_fork_token = raw_dict.get("pagure_fork_token", "")
+        config.github_app_id = raw_dict.get("github_app_id", "")
+        config.github_app_cert_path = raw_dict.get("github_app_cert_path", "")
+        config.webhook_secret = raw_dict.get("webhook_secret", "")
+        config.deployment = Deployment.from_str(raw_dict.get("deployment", ""))
+        config.validate_webhooks = raw_dict.get("validate_webhooks", False)
+
+        config.command_handler = RunCommandType.local
+        a_h = raw_dict.get("command_handler")
+        if a_h:
+            config.command_handler = RunCommandType(a_h)
+        config.command_handler_work_dir = raw_dict.get(
+            "command_handler_work_dir", SANDCASTLE_WORK_DIR
+        )
+        config.command_handler_pvc_env_var = raw_dict.get(
+            "command_handler_pvc_env_var", SANDCASTLE_PVC
+        )
+        config.command_handler_image_reference = raw_dict.get(
+            "command_handler_image_reference", SANDCASTLE_IMAGE
+        )
+        # default project for oc cluster up
+        config.command_handler_k8s_namespace = raw_dict.get(
+            "command_handler_k8s_namespace", SANDCASTLE_DEFAULT_PROJECT
+        )
+
+        return config
+
+    @classmethod
+    def get_service_config(cls) -> "Config":
+        xdg_config_home = os.getenv("XDG_CONFIG_HOME")
+        if xdg_config_home:
+            directory = Path(xdg_config_home)
+        else:
+            directory = Path.cwd() / ".config"
+
+        logger.debug(f"Loading service config from directory: {directory}")
+
+        loaded_config: dict = {}
+        for config_file_name in CONFIG_FILE_NAMES:
+            config_file_name_full = directory / config_file_name
+            logger.debug(f"Trying to load service config from: {config_file_name_full}")
+            if config_file_name_full.is_file():
+                try:
+                    loaded_config = safe_load(open(config_file_name_full))
+                except Exception as ex:
+                    logger.error(
+                        f"Cannot load service config '{config_file_name_full}'."
+                    )
+                    raise PackitException(f"Cannot load service config: {ex}.")
+                break
+        return Config.get_from_dict(raw_dict=loaded_config)
+
+    @property
+    def github_token(self) -> str:
+        token = os.getenv("GITHUB_TOKEN", "")
+        if token:
+            return token
+        return self._github_token

--- a/packit_service/config.py
+++ b/packit_service/config.py
@@ -143,3 +143,18 @@ class Config(BaseConfig):
         if token:
             return token
         return self._github_token
+
+    @property
+    def pagure_user_token(self) -> str:
+        token = os.getenv("PAGURE_USER_TOKEN", "")
+        if token:
+            return token
+        return self._pagure_user_token
+
+    @property
+    def pagure_fork_token(self) -> str:
+        """ this is needed to create pull requests """
+        token = os.getenv("PAGURE_FORK_TOKEN", "")
+        if token:
+            return token
+        return self._pagure_fork_token

--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -12,3 +12,6 @@ CONFIG_FILE_NAMES = [
     "packit-service.yml",
     "packit-service.json",
 ]
+
+PACKIT_PROD_CHECK = "packit/rpm-build"
+PACKIT_STG_CHECK = "packit-stg/rpm-build"

--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -4,7 +4,7 @@ SANDCASTLE_IMAGE = "docker.io/usercont/sandcastle"
 SANDCASTLE_DEFAULT_PROJECT = "myproject"
 SANDCASTLE_PVC = "SANDCASTLE_PVC"
 
-CONFIG_FILE_NAME = ".packit-service.yaml"
+CONFIG_FILE_NAME = "packit-service.yaml"
 
 PACKIT_PROD_CHECK = "packit/rpm-build"
 PACKIT_STG_CHECK = "packit-stg/rpm-build"

--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -4,14 +4,7 @@ SANDCASTLE_IMAGE = "docker.io/usercont/sandcastle"
 SANDCASTLE_DEFAULT_PROJECT = "myproject"
 SANDCASTLE_PVC = "SANDCASTLE_PVC"
 
-CONFIG_FILE_NAMES = [
-    ".packit-service.yaml",
-    ".packit-service.yml",
-    ".packit-service.json",
-    "packit-service.yaml",
-    "packit-service.yml",
-    "packit-service.json",
-]
+CONFIG_FILE_NAME = ".packit-service.yaml"
 
 PACKIT_PROD_CHECK = "packit/rpm-build"
 PACKIT_STG_CHECK = "packit-stg/rpm-build"

--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -1,1 +1,14 @@
 FAQ_URL = "https://packit.dev/packit-as-a-service/#faq"
+SANDCASTLE_WORK_DIR = "/sandcastle"
+SANDCASTLE_IMAGE = "docker.io/usercont/sandcastle"
+SANDCASTLE_DEFAULT_PROJECT = "myproject"
+SANDCASTLE_PVC = "SANDCASTLE_PVC"
+
+CONFIG_FILE_NAMES = [
+    ".packit-service.yaml",
+    ".packit-service.yml",
+    ".packit-service.json",
+    "packit-service.yaml",
+    "packit-service.yml",
+    "packit-service.json",
+]

--- a/packit_service/schema.py
+++ b/packit_service/schema.py
@@ -36,4 +36,5 @@ SERVICE_CONFIG_SCHEMA = {
         "webhook_secret": {"type": "string"},
         "validate_webhooks": {"type": "boolean"},
     },
+    "required": ["deployment", "github_app_id", "github_app_cert_path"],
 }

--- a/packit_service/schema.py
+++ b/packit_service/schema.py
@@ -1,0 +1,39 @@
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+SERVICE_CONFIG_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "debug": {"type": "boolean"},
+        "dry_run": {"type": "boolean"},
+        "fas_user": {"type": "string"},
+        "keytab_path": {"type": "string"},
+        "pagure_user_token": {"type": "string"},
+        "pagure_fork_token": {"type": "string"},
+        "deployment": {"type": "string"},
+        "github_app_id": {"type": "string"},
+        "github_app_cert_path": {"type": "string"},
+        "webhook_secret": {"type": "string"},
+        "validate_webhooks": {"type": "boolean"},
+    },
+}

--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -33,8 +33,9 @@ from packit.config import (
     JobTriggerType,
     get_package_config_from_repo,
     PackageConfig,
-    Config,
 )
+
+from packit_service.config import Config
 
 
 class PullRequestAction(enum.Enum):
@@ -61,16 +62,16 @@ class Event:
         self._user_config = None
 
     @property
-    def user_config(self) -> Config:
+    def service_config(self) -> Config:
         if not self._user_config:
-            self._user_config = Config.get_user_config()
+            self._user_config = Config.get_service_config()
         return self._user_config
 
 
 class AbstractGithubEvent(Event):
     def __get_private_key(self) -> Optional[str]:
-        if self.user_config.github_app_cert_path:
-            return Path(self.user_config.github_app_cert_path).read_text()
+        if self.service_config.github_app_cert_path:
+            return Path(self.service_config.github_app_cert_path).read_text()
         return None
 
     @property
@@ -215,11 +216,9 @@ class DistGitEvent(Event):
         return get_package_config_from_repo(self.get_project(), self.ref)
 
     def get_project(self) -> GitProject:
-        config = Config.get_user_config()
+        config = Config.get_service_config()
         pagure_service = PagureService(
-            token=config.pagure_user_token,
-            read_only=config.dry_run,
-            # TODO: how do we change to stg here? ideally in self.config
+            token=config.pagure_user_token, read_only=config.dry_run
         )
         return pagure_service.get_project(
             repo=self.repo_name, namespace=self.repo_namespace

--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -29,11 +29,7 @@ from typing import Optional
 
 from ogr import PagureService, GithubService
 from ogr.abstract import GitProject
-from packit.config import (
-    JobTriggerType,
-    get_package_config_from_repo,
-    PackageConfig,
-)
+from packit.config import JobTriggerType, get_package_config_from_repo, PackageConfig
 
 from packit_service.config import Config
 
@@ -59,13 +55,13 @@ class WhitelistStatus(enum.Enum):
 class Event:
     def __init__(self, trigger: JobTriggerType):
         self.trigger: JobTriggerType = trigger
-        self._user_config = None
+        self._service_config: Config = None
 
     @property
     def service_config(self) -> Config:
-        if not self._user_config:
-            self._user_config = Config.get_service_config()
-        return self._user_config
+        if not self._service_config:
+            self._service_config = Config.get_service_config()
+        return self._service_config
 
 
 class AbstractGithubEvent(Event):
@@ -77,8 +73,8 @@ class AbstractGithubEvent(Event):
     @property
     def github_service(self) -> GithubService:
         return GithubService(
-            token=self.user_config.github_token,
-            github_app_id=self.user_config.github_app_id,
+            token=self.service_config.github_token,
+            github_app_id=self.service_config.github_app_id,
             github_app_private_key=self.__get_private_key(),
         )
 

--- a/packit_service/service/models.py
+++ b/packit_service/service/models.py
@@ -54,8 +54,8 @@ class Model:
         """ reverse operation as serialize """
         # this is pretty nasty: we could possibly replace this with a serialization
         # library or an ORM framework
-        if "_user_config" in inp:
-            del inp["_user_config"]
+        if "_service_config" in inp:
+            del inp["_service_config"]
         self.__dict__ = inp
 
     @classmethod
@@ -95,8 +95,8 @@ class Installation(Model):
     def serialize(self):
         cp = super().serialize()
         cp["event_data"] = self.event_data.get_dict()
-        if "_user_config" in cp["event_data"]:
-            del cp["event_data"]["_user_config"]
+        if "_service_config" in cp["event_data"]:
+            del cp["event_data"]["_service_config"]
         return cp
 
     def deserialize(self, inp: Dict):

--- a/packit_service/service/web_hook.py
+++ b/packit_service/service/web_hook.py
@@ -28,7 +28,7 @@ from flask import Flask, abort, request, jsonify
 
 from packit.utils import set_logging
 from packit_service.celerizer import celery_app
-from packit_service.config import Config, Deployment
+from packit_service.config import Config
 
 
 class PackitWebhookReceiver(Flask):
@@ -77,7 +77,7 @@ def validate_signature() -> bool:
     if "X-Hub-Signature" not in request.headers:
         # no signature -> no validation
         # don't validate signatures when testing locally
-        return config.deployment == Deployment.dev
+        return not config.validate_webhooks
 
     sig = request.headers["X-Hub-Signature"]
     if not sig.startswith("sha1="):

--- a/packit_service/service/web_hook.py
+++ b/packit_service/service/web_hook.py
@@ -22,14 +22,13 @@
 
 import hmac
 import logging
-import os
 from hashlib import sha1
 
 from flask import Flask, abort, request, jsonify
 
-from packit.config import Config
 from packit.utils import set_logging
 from packit_service.celerizer import celery_app
+from packit_service.config import Config, Deployment
 
 
 class PackitWebhookReceiver(Flask):
@@ -39,7 +38,7 @@ class PackitWebhookReceiver(Flask):
 
 
 app = PackitWebhookReceiver(__name__)
-config = Config.get_user_config()
+config = Config.get_service_config()
 logger = logging.getLogger("packit_service")
 
 
@@ -78,7 +77,7 @@ def validate_signature() -> bool:
     if "X-Hub-Signature" not in request.headers:
         # no signature -> no validation
         # don't validate signatures when testing locally
-        return os.getenv("DEPLOYMENT") == "dev"
+        return config.deployment == Deployment.dev
 
     sig = request.headers["X-Hub-Signature"]
     if not sig.startswith("sha1="):

--- a/packit_service/worker/fedmsg_handlers.py
+++ b/packit_service/worker/fedmsg_handlers.py
@@ -51,6 +51,7 @@ PROCESSED_FEDMSG_TOPICS = []
 def add_topic(kls: Type["FedmsgHandler"]):
     if issubclass(kls, FedmsgHandler):
         PROCESSED_FEDMSG_TOPICS.append(kls.topic)
+    return kls
 
 
 def do_we_process_fedmsg_topic(topic: str) -> bool:
@@ -106,7 +107,6 @@ class NewDistGitCommit(FedmsgHandler):
         self.package_config.upstream_project_url = (
             dg.get_project_url_from_distgit_spec()
         )
-
         if not self.package_config.upstream_project_url:
             return HandlerResults(
                 success=False,

--- a/packit_service/worker/github_handlers.py
+++ b/packit_service/worker/github_handlers.py
@@ -32,7 +32,6 @@ from ogr import GithubService
 from ogr.abstract import GitProject
 from packit.api import PackitAPI
 from packit.config import (
-    Config,
     JobConfig,
     JobTriggerType,
     JobType,
@@ -43,6 +42,7 @@ from packit.exceptions import FailedCreateSRPM
 from packit.local_project import LocalProject
 from sandcastle import SandcastleCommandFailed, SandcastleTimeoutReached
 
+from packit_service.config import Config, Deployment
 from packit_service.service.events import (
     PullRequestEvent,
     InstallationEvent,
@@ -249,8 +249,10 @@ class GithubCoprBuildHandler(AbstractGithubJobHandler):
         )
         self.api = PackitAPI(self.config, self.package_config, self.local_project)
 
+        # add suffix stg when using stg app
+        stg = "-stg" if self.config.deployment == Deployment.stg else ""
         default_project_name = (
-            f"{self.project.namespace}-{self.project.repo}-{self.event.pr_id}"
+            f"{self.project.namespace}-{self.project.repo}-{self.event.pr_id}{stg}"
         )
         collaborators = self.project.who_can_merge_pr()
         project = self.job.metadata.get("project") or default_project_name

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -28,7 +28,6 @@ import logging
 from typing import Optional, Dict, Any
 
 from packit.config import JobTriggerType, JobType
-from packit.exceptions import PackitException
 
 from packit_service.config import Config
 from packit_service.worker.github_handlers import GithubAppInstallationHandler
@@ -134,6 +133,6 @@ class SteveJobs:
 
         if any(not v["success"] for v in jobs_results.values()):
             # Any job handler failed, mark task state as FAILURE
-            raise PackitException(task_results)
+            logger.error(task_results)
         # Task state SUCCESS
         return task_results

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -60,6 +60,18 @@ class SteveJobs:
         """
         handlers_results = {}
         package_config = event.get_package_config()
+
+        if not package_config:
+            # this happens when service receives fedmsg topic which we process,
+            # but package has no packit.yaml
+            msg = "Failed to obtain package config!"
+            logger.warning(msg)
+            handlers_results[event.trigger.value] = HandlerResults(
+                success=False, details={"msg": msg}
+            )
+
+            return handlers_results
+
         for job in package_config.jobs:
             if event.trigger == job.trigger:
                 handler_kls: Any = JOB_NAME_HANDLER_MAPPING.get(job.job, None)

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -27,8 +27,10 @@ We love you, Steve Jobs.
 import logging
 from typing import Optional, Dict, Any
 
-from packit.config import JobTriggerType, JobType, Config
+from packit.config import JobTriggerType, JobType
 from packit.exceptions import PackitException
+
+from packit_service.config import Config
 from packit_service.worker.github_handlers import GithubAppInstallationHandler
 from packit_service.worker.handler import HandlerResults, JOB_NAME_HANDLER_MAPPING
 from packit_service.worker.parser import Parser
@@ -49,7 +51,7 @@ class SteveJobs:
     @property
     def config(self):
         if self._config is None:
-            self._config = Config.get_user_config()
+            self._config = Config.get_service_config()
         return self._config
 
     def process_jobs(self, event: Optional[Any]) -> Dict[str, HandlerResults]:

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -30,6 +30,9 @@ from packit_service.worker.jobs import SteveJobs
 
 logging.getLogger("requests").setLevel(logging.WARNING)
 logging.getLogger("urllib3").setLevel(logging.WARNING)
+logging.getLogger("github").setLevel(logging.WARNING)  # pygithub
+logging.getLogger("ogr").setLevel(logging.WARNING)  # b/c of pagure requests
+logging.getLogger("kubernetes").setLevel(logging.WARNING)
 
 
 @celery_app.task(bind=True, name="task.steve_jobs.process_message")

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -19,7 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
+import logging
 from typing import Optional
 
 from celery.task import Task as CeleryTask
@@ -27,6 +27,9 @@ from celery.task import Task as CeleryTask
 from packit_service.celerizer import celery_app
 from packit_service.service.models import Task
 from packit_service.worker.jobs import SteveJobs
+
+logging.getLogger("requests").setLevel(logging.WARNING)
+logging.getLogger("urllib3").setLevel(logging.WARNING)
 
 
 @celery_app.task(bind=True, name="task.steve_jobs.process_message")

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -10,6 +10,8 @@ from packit.api import PackitAPI
 from packit.config import JobTriggerType
 from packit.local_project import LocalProject
 
+from packit_service.config import Config
+from packit_service.constants import SANDCASTLE_WORK_DIR
 from tests.spellbook import DATA_DIR
 from packit_service.worker.jobs import SteveJobs
 from packit_service.worker.whitelist import Whitelist
@@ -34,6 +36,9 @@ def test_dist_git_push_release_handle(release_event):
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
     flexmock(Whitelist, check_and_report=True)
     steve = SteveJobs()
+    config = Config()
+    config.command_handler_work_dir = SANDCASTLE_WORK_DIR
+    flexmock(Config).should_receive("get_service_config").and_return(config)
     # it would make sense to make LocalProject offline
     flexmock(PackitAPI).should_receive("sync_release").with_args(
         dist_git_branch="master", version="0.3.0", create_pr=False

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,86 @@
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import pytest
+from packit.exceptions import PackitInvalidConfigException
+
+from packit_service.config import Config, Deployment
+
+
+def get_service_config_missing():
+    # missing required fields
+    return {"deployment": "dev"}
+
+
+def get_service_config_invalid():
+    # wrong option
+    return {
+        "deployment": "prod",
+        "github_app_id": False,
+        "github_app_cert_path": "/path/lib",
+        "webhook_secret": "secret",
+        "command_handler_work_dir": "/sandcastle",
+        "command_handler_image_reference": "docker.io/usercont/sandcastle",
+        "command_handler_k8s_namespace": "packit-test-sandbox",
+    }
+
+
+def get_service_config_valid():
+    return {
+        "deployment": "prod",
+        "github_app_id": "11111",
+        "github_app_cert_path": "/path/lib",
+        "webhook_secret": "secret",
+        "command_handler": "sandcastle",
+        "command_handler_work_dir": "/sandcastle",
+        "command_handler_image_reference": "docker.io/usercont/sandcastle",
+        "command_handler_k8s_namespace": "packit-test-sandbox",
+    }
+
+
+@pytest.fixture()
+def service_config_missing():
+    return get_service_config_missing()
+
+
+@pytest.fixture()
+def service_config_valid():
+    return get_service_config_valid()
+
+
+@pytest.fixture()
+def service_config_invalid():
+    return get_service_config_invalid()
+
+
+def test_parse_valid(service_config_valid):
+    config = Config.get_from_dict(service_config_valid)
+    assert config.deployment == Deployment("prod")
+
+
+def test_parse_invalid(service_config_invalid):
+    with pytest.raises(PackitInvalidConfigException):
+        Config.get_from_dict(service_config_invalid)
+
+
+def test_parse_missing(service_config_missing):
+    with pytest.raises(PackitInvalidConfigException):
+        Config.get_from_dict(service_config_missing)

--- a/tests/unit/test_steve.py
+++ b/tests/unit/test_steve.py
@@ -33,6 +33,8 @@ from packit.api import PackitAPI
 from packit.config import JobTriggerType
 from packit.local_project import LocalProject
 
+from packit_service.config import Config
+from packit_service.constants import SANDCASTLE_WORK_DIR
 from packit_service.worker.jobs import SteveJobs
 from packit_service.worker.whitelist import Whitelist
 
@@ -66,6 +68,10 @@ def test_process_message(event):
         full_repo_name="foo/bar",
     )
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
+    config = Config()
+    config.command_handler_work_dir = SANDCASTLE_WORK_DIR
+    flexmock(Config).should_receive("get_service_config").and_return(config)
+
     flexmock(PackitAPI).should_receive("sync_release").with_args(
         dist_git_branch="master", version="1.2.3", create_pr=False
     ).once()


### PR DESCRIPTION
TODO:

- [x] tests 

In the ideal case, this PR will be followed up by:
 * Remove sandcastle from packit completely
 * Packit API is using user config in the constructor, but now we are passing the service config there. This is why there is still `github_token` even if it is not necessary for the service. A solution could be to create an abstract class for these two configs.

Tested here.
https://github.com/packit-service/hello-world/pull/10