### PR TITLE
Collaborators can trigger Packit-as-a-Service

### DIFF
--- a/files/install-rpm-packages.yaml
+++ b/files/install-rpm-packages.yaml
@@ -25,7 +25,7 @@
       - python3-ogr
       - python3-packaging
       - python3-pip
-      - python3-pygithub
+      # - python3-pygithub Install it from PyPi. Fedora repository has old version
       - python3-pyyaml
       - python3-requests
       - python3-rpm

--- a/files/recipe.yaml
+++ b/files/recipe.yaml
@@ -72,6 +72,10 @@
       src: run_worker.sh
       dest: /usr/bin/run_worker.sh
       mode: 0777
+  - name: Install PyGithub from PyPi
+    pip:
+      name: PyGithub>=1.43
+      executable: pip3
   - name: Install sandcastle
     pip:
       name: git+https://github.com/packit-service/sandcastle.git

--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -121,6 +121,7 @@ class PullRequestEvent(AbstractGithubEvent):
         target_repo: str,
         https_url: str,
         commit_sha: str,
+        github_login: str,
     ):
         super(PullRequestEvent, self).__init__(JobTriggerType.pull_request)
         self.action = action
@@ -131,6 +132,7 @@ class PullRequestEvent(AbstractGithubEvent):
         self.target_repo = target_repo
         self.https_url = https_url
         self.commit_sha = commit_sha
+        self.github_login = github_login
 
     def get_dict(self) -> dict:
         result = self.__dict__

--- a/packit_service/worker/github_handlers.py
+++ b/packit_service/worker/github_handlers.py
@@ -253,7 +253,7 @@ class GithubCoprBuildHandler(AbstractGithubJobHandler):
         r = BuildStatusReporter(self.project, self.event.commit_sha)
         if self.event.github_login not in collaborators:
             msg = "Only collaborators can trigger Packit-as-a-Service"
-            r.reset_status("failure", msg)
+            r.set_status("failure", msg)
             return HandlerResults(success=False, details={"msg": msg})
         try:
             build_id, repo_url = self.api.run_copr_build(

--- a/packit_service/worker/github_handlers.py
+++ b/packit_service/worker/github_handlers.py
@@ -247,10 +247,14 @@ class GithubCoprBuildHandler(AbstractGithubJobHandler):
         default_project_name = (
             f"{self.project.namespace}-{self.project.repo}-{self.event.pr_id}"
         )
+        collaborators = self.project.who_can_merge_pr()
         project = self.job.metadata.get("project") or default_project_name
         owner = self.job.metadata.get("owner") or self.api.copr.config.get("username")
         r = BuildStatusReporter(self.project, self.event.commit_sha)
-
+        if self.event.github_login not in collaborators:
+            msg = "Only collaborators can trigger Packit-as-a-Service"
+            r.reset_status("failure", msg)
+            return HandlerResults(success=False, details={"msg": msg})
         try:
             build_id, repo_url = self.api.run_copr_build(
                 project=project, chroots=self.job.metadata.get("targets"), owner=owner

--- a/packit_service/worker/handler.py
+++ b/packit_service/worker/handler.py
@@ -63,7 +63,7 @@ class BuildStatusReporter:
             self.commit_sha, state, url, description, "packit/rpm-build"
         )
 
-    def reset_status(self, state: str, description: str):
+    def set_status(self, state: str, description: str):
         logger.debug(description)
         self.gh_proj.set_commit_status(
             self.commit_sha, state, "", description, "packit/rpm-build"

--- a/packit_service/worker/handler.py
+++ b/packit_service/worker/handler.py
@@ -63,6 +63,12 @@ class BuildStatusReporter:
             self.commit_sha, state, url, description, "packit/rpm-build"
         )
 
+    def reset_status(self, state: str, description: str):
+        logger.debug(description)
+        self.gh_proj.set_commit_status(
+            self.commit_sha, state, "", description, "packit/rpm-build"
+        )
+
 
 class HandlerResults(dict):
     """

--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -110,6 +110,10 @@ class Parser:
             if not base_ref:
                 logger.warning("Ref where the PR is coming from is not set.")
                 return None
+            github_login = nested_get(event, "pull_request", "user", "login")
+            if not github_login:
+                logger.warning("We could not figure out GitHub login name from event.")
+                return None
             target_repo = nested_get(event, "repository", "full_name")
             logger.info(f"GitHub pull request {pr_id} event for repo {target_repo}.")
 
@@ -124,6 +128,7 @@ class Parser:
                 target_repo,
                 https_url,
                 commit_sha,
+                github_login,
             )
         return None
 

--- a/tests/integration/test_copr.py
+++ b/tests/integration/test_copr.py
@@ -61,7 +61,7 @@ def test_wrong_collaborator(pr_event):
         full_repo_name="packit-service/hello-world",
     )
     flexmock(GithubProject).should_receive("who_can_merge_pr").and_return({"foobar"})
-    flexmock(BuildStatusReporter).should_receive("reset_status").and_return(None)
+    flexmock(BuildStatusReporter).should_receive("set_status").and_return(None)
     flexmock(
         LocalProject,
         refresh_the_arguments=lambda: None,


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

This pull request adds function when only `collaborators` for given repo can trigger Packit-as-a-Service.

- [x] test for collaborators is included.