### PR TITLE
whitelist: use repo namespace instead of repo name for releases

### DIFF
--- a/packit_service/worker/whitelist.py
+++ b/packit_service/worker/whitelist.py
@@ -164,7 +164,7 @@ class Whitelist:
         if isinstance(event, PullRequestEvent):
             account_name = event.base_repo_namespace
         if isinstance(event, ReleaseEvent):
-            account_name = event.repo_name
+            account_name = event.repo_namespace
 
         if account_name:
             if not self.is_approved(account_name):


### PR DESCRIPTION
fixes #62 