### PR TITLE
Make fedpkg clone work in openshift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.py[co]
 .tox
+secrets/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,12 @@ COPY files/ /src/files/
 # We need to install packages. In httpd:2.4 container is user set to 1001
 USER 0
 
+RUN mkdir /home/packit
+COPY files/passwd /home/packit/passwd
+ENV LD_PRELOAD=libnss_wrapper.so
+ENV NSS_WRAPPER_PASSWD=/home/packit/passwd
+ENV NSS_WRAPPER_GROUP=/etc/group
+
 # Install packages first and reuse the cache as much as possible
 RUN dnf install -y ansible \
     && cd /src/ \
@@ -28,5 +34,7 @@ RUN /usr/libexec/httpd-prepare && rpm-file-permissions \
     && chmod -R a+rwx /var/log/httpd
 
 USER 1001
+ENV USER=packit
+ENV HOME=/home/packit
 
 CMD ["/usr/bin/run-httpd"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY files/ /src/files/
 # We need to install packages. In httpd:2.4 container is user set to 1001
 USER 0
 
-RUN mkdir /home/packit
+RUN mkdir /home/packit && chmod 0776 /home/packit
 COPY files/passwd /home/packit/passwd
 ENV LD_PRELOAD=libnss_wrapper.so
 ENV NSS_WRAPPER_PASSWD=/home/packit/passwd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,14 +38,19 @@ services:
       dockerfile: Dockerfile
     image: docker.io/usercont/packit-service:master
     command: /usr/bin/run_worker.sh
+    tty: true
     depends_on:
       - redis
     environment:
       REDIS_SERVICE_HOST: redis
       APP: packit_service.worker.tasks
+      KRB5CCNAME: FILE:/tmp/krb5cc_packit
     volumes:
       - ./packit_service:/usr/local/lib/python3.7/site-packages/packit_service:ro,z
-      - ./secrets/packit.yaml:/opt/app-root/src/.config/.packit.yaml:ro,z
+      - ./secrets/packit.yaml:/home/packit/.config/.packit.yaml:ro,z
+      - ./secrets:/packit-ssh:ro,z
+      - ./secrets:/secrets:ro,z
+      - .:/src:ro,z
     # user: "123123"
 
   packit-service:

--- a/files/gitconfig
+++ b/files/gitconfig
@@ -1,0 +1,5 @@
+[user]
+    name = Packit Service
+    email = user-cont-team+packit-service@redhat.com
+[push]
+    default = current

--- a/files/install-rpm-packages.yaml
+++ b/files/install-rpm-packages.yaml
@@ -37,6 +37,7 @@
       - python3-kubernetes
       - rebase-helper
       - rpm-build
+      - nss_wrapper  # openshift anyuid passwd madness
       state: present
 #  - name: Install python-kube
 #    block:

--- a/files/passwd
+++ b/files/passwd
@@ -1,0 +1,15 @@
+root:x:0:0:root:/root:/bin/bash
+bin:x:1:1:bin:/bin:/sbin/nologin
+daemon:x:2:2:daemon:/sbin:/sbin/nologin
+adm:x:3:4:adm:/var/adm:/sbin/nologin
+lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
+sync:x:5:0:sync:/sbin:/bin/sync
+operator:x:11:0:operator:/root:/sbin/nologin
+nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin
+dbus:x:81:81:System message bus:/:/sbin/nologin
+systemd-coredump:x:999:997:systemd Core Dumper:/:/sbin/nologin
+systemd-network:x:192:192:systemd Network Management:/:/sbin/nologin
+systemd-resolve:x:193:193:systemd Resolver:/:/sbin/nologin
+apache:x:48:48:Apache:/usr/share/httpd:/sbin/nologin
+unbound:x:998:996:Unbound DNS resolver:/etc/unbound:/sbin/nologin
+fedmsg:x:997:993:FedMsg:/usr/share/fedmsg:/sbin/nologin

--- a/files/recipe.yaml
+++ b/files/recipe.yaml
@@ -36,10 +36,6 @@
       regexp: '^(Listen.+)$'
       line: '# \1'
       backrefs: yes
-  - name: "Set up git: user.email"
-    command: git config --global user.email "user-cont-team@redhat.com"
-  - name: "Set up git: user.name"
-    command: git config --global user.name "Pack It"
   - name: Create some home dirs
     file:
       state: directory
@@ -57,6 +53,10 @@
     copy:
       src: ssh_config
       dest: /etc/ssh/ssh_config.d/01-packit.conf
+  - name: Copy gitconfig
+    copy:
+      src: gitconfig
+      dest: '{{ home_path }}/.gitconfig'
   - name: stat /src
     stat:
       path: /src

--- a/files/recipe.yaml
+++ b/files/recipe.yaml
@@ -18,7 +18,11 @@
   - name: Create /usr/share/packit directory
     file:
       state: directory
-      path: /usr/share/packit
+      path: '{{ item }}'
+    with_items:
+    - /usr/share/packit
+    - /packit-ssh  # this is where we put ssh creds
+    - /sandcastle  # working dir for the upstream git which is mapped to the sandbox pod
   - name: Copy packit.wsgi file
     copy:
       src: packit.wsgi

--- a/files/run_worker.sh
+++ b/files/run_worker.sh
@@ -6,4 +6,6 @@ if [[ -z ${APP} ]]; then
     exit 1
 fi
 
+printf "packit:x:$(id -u):0:Packit Service:/home/packit:/bin/bash\n" >>/home/packit/passwd
+
 exec celery worker --app=${APP} --loglevel=debug --concurrency=1

--- a/files/run_worker.sh
+++ b/files/run_worker.sh
@@ -8,4 +8,10 @@ fi
 
 printf "packit:x:$(id -u):0:Packit Service:/home/packit:/bin/bash\n" >>/home/packit/passwd
 
+export PACKIT_HOME=/home/packit
+mkdir --mode=0700 -p ${PACKIT_HOME}/.ssh
+install -m 0400 /packit-ssh/id_rsa ${PACKIT_HOME}/.ssh/
+install -m 0400 /packit-ssh/id_rsa.pub ${PACKIT_HOME}/.ssh/
+install -m 0400 /packit-ssh/config ${PACKIT_HOME}/.ssh/config
+
 exec celery worker --app=${APP} --loglevel=debug --concurrency=1

--- a/packit_service/cli/packit_base.py
+++ b/packit_service/cli/packit_base.py
@@ -27,6 +27,7 @@ from packit.config import get_context_settings
 from packit.utils import set_logging
 from pkg_resources import get_distribution
 
+from packit_service.cli.process_message import process_message
 from packit_service.cli.listen_to_fedmsg import listen_to_fedmsg
 from packit_service.config import Config
 
@@ -60,6 +61,7 @@ def version():
 
 
 packit_base.add_command(listen_to_fedmsg)
+packit_base.add_command(process_message)
 
 if __name__ == "__main__":
     packit_base()

--- a/packit_service/cli/process_message.py
+++ b/packit_service/cli/process_message.py
@@ -1,0 +1,55 @@
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Accept a message from commandline and process it directly - bypass celery
+"""
+import json
+import logging
+import sys
+from pathlib import Path
+
+import click
+
+from packit_service.worker.jobs import SteveJobs
+
+logger = logging.getLogger(__name__)
+
+
+@click.command("process-message")
+@click.argument("path", nargs=1, required=False)
+def process_message(path):
+    """
+    Accept a message from commandline and process it directly - bypass celery
+
+    Either provide a filename with the message or pipe it:
+      cat event.json | packit-service process-message
+
+    if MESSAGE-ID is specified, process only the selected messages
+    """
+    if path:
+        logger.info(f"reading the message from file {path}")
+        event = json.loads(Path(path).read_text())
+    else:
+        logger.info("reading the message from stdin")
+        event = sys.stdin.read()
+    SteveJobs().process_message(event=event)

--- a/packit_service/config.py
+++ b/packit_service/config.py
@@ -125,7 +125,7 @@ class Config(BaseConfig):
 
     @classmethod
     def get_service_config(cls) -> "Config":
-        directory = Path.cwd() / ".config"
+        directory = Path.home() / ".config"
         config_file_name_full = directory / CONFIG_FILE_NAME
         logger.debug(f"Loading service config from directory: {directory}")
 


### PR DESCRIPTION
Fixes https://github.com/packit-service/packit/issues/431

Edit: description on Rado's request
* passwd: fedpkg needs that otherwise it complains that current user doesn't have an entry in /etc/passwd - SCL uses this method in their images
* .ssh - ssh command is very picky about perms of .ssh and id_rsa; stolen from Betka
* I also added a new command which accepts events via CLI and processes them directly for easier local development
* and a gitconfig which makes a nice commit author instead of (not using `git config` b/c we change users and it likely ends up in /opt and not in /home/packit): https://src.fedoraproject.org/rpms/python-ogr/c/07797442e8b27e6ea785b39b4b6d5cfc5f6ef0a1?branch=master