### PR TITLE
[JobHandler._clean_workplace()] cleaner debug log

### DIFF
--- a/packit_service/worker/handler.py
+++ b/packit_service/worker/handler.py
@@ -127,14 +127,14 @@ class JobHandler:
         raise NotImplementedError("This should have been implemented.")
 
     def _clean_workplace(self):
-        logger.debug("remove contents of the PV")
+        logger.debug("removing contents of the PV")
         p = Path(self.config.command_handler_work_dir)
         # remove everything in the volume, but not the volume dir
-        globz = list(p.glob("*"))
-        if globz:
-            logger.info("volume was not empty")
-            logger.debug("content of the volume: %s" % globz)
-        for item in globz:
+        dir_items = list(p.iterdir())
+        if dir_items:
+            logger.info("volume is not empty")
+            logger.debug("content: %s" % [g.name for g in dir_items])
+        for item in dir_items:
             if item.is_file() or item.is_symlink():
                 item.unlink()
             else:

--- a/packit_service/worker/handler.py
+++ b/packit_service/worker/handler.py
@@ -135,10 +135,10 @@ class JobHandler:
             logger.info("volume is not empty")
             logger.debug("content: %s" % [g.name for g in dir_items])
         for item in dir_items:
-            if item.is_file() or item.is_symlink():
-                item.unlink()
-            else:
+            if item.is_dir():
                 shutil.rmtree(item)
+            else:
+                item.unlink()
 
     def clean(self):
         """ clean up the mess once we're done """


### PR DESCRIPTION
[PosixPath('README.md'), PosixPath('CONTRIBUTING.md')] -> ['README.md', 'CONTRIBUTING.md']