### PR TITLE
Do not clean directory if it does not exists

### DIFF
--- a/packit_service/worker/handler.py
+++ b/packit_service/worker/handler.py
@@ -157,6 +157,9 @@ class JobHandler:
         p = Path(self.config.command_handler_work_dir)
         # Do not clean dir if does not exist
         if not p.is_dir():
+            logger.debug(
+                f"Directory {self.config.command_handler_work_dir} does not exist."
+            )
             return
 
         # remove everything in the volume, but not the volume dir

--- a/packit_service/worker/handler.py
+++ b/packit_service/worker/handler.py
@@ -155,6 +155,10 @@ class JobHandler:
     def _clean_workplace(self):
         logger.debug("removing contents of the PV")
         p = Path(self.config.command_handler_work_dir)
+        # Do not clean dir if does not exist
+        if not p.is_dir():
+            return
+
         # remove everything in the volume, but not the volume dir
         dir_items = list(p.iterdir())
         if dir_items:


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

Do not clean workspace if a directory does not exist.