### PR TITLE
install celery from fedora

### DIFF
--- a/files/install-rpm-packages.yaml
+++ b/files/install-rpm-packages.yaml
@@ -17,6 +17,9 @@
       - python3-devel
       - python3-fedmsg
       - python3-flask
+      - python3-celery
+      - python3-redis
+      - redis  # redis-cli for debugging
       - python3-ipdb  # for easy debugging
       - python3-jsonschema
       - python3-libpagure

--- a/files/run_worker.sh
+++ b/files/run_worker.sh
@@ -14,4 +14,4 @@ install -m 0400 /packit-ssh/id_rsa ${PACKIT_HOME}/.ssh/
 install -m 0400 /packit-ssh/id_rsa.pub ${PACKIT_HOME}/.ssh/
 install -m 0400 /packit-ssh/config ${PACKIT_HOME}/.ssh/config
 
-exec celery worker --app=${APP} --loglevel=debug --concurrency=1
+exec celery-3 worker --app=${APP} --loglevel=debug --concurrency=1


### PR DESCRIPTION
celery from PyPI is broken: the CLI command does not process any
commands so the CLI is worthless