### PR TITLE
playbooks: use file module instead of rm in shell

### DIFF
--- a/files/recipe-tests.yaml
+++ b/files/recipe-tests.yaml
@@ -22,4 +22,6 @@
     pip:
       name: git+https://github.com/user-cont/frambo.git
   - name: Clean all the cache files (especially pip)
-    shell: rm -rf ~/.cache/*
+    file:
+      state: absent
+      path: ~/.cache/

--- a/files/recipe-worker.yaml
+++ b/files/recipe-worker.yaml
@@ -47,4 +47,6 @@
       name: /src
       executable: pip3
   - name: Clean all the cache files (especially pip)
-    shell: rm -rf ~/.cache/*
+    file:
+      state: absent
+      path: ~/.cache/

--- a/files/recipe.yaml
+++ b/files/recipe.yaml
@@ -46,4 +46,6 @@
       name: /src
       executable: pip3
   - name: Clean all the cache files (especially pip)
-    shell: rm -rf ~/.cache/*
+    file:
+      state: absent
+      path: ~/.cache/


### PR DESCRIPTION
to avoid
```
 [WARNING]: Consider using the file module with state=absent rather than
running 'rm'.  If you need to use command because file is insufficient you can
add 'warn: false' to this command task or set 'command_warnings=False' in
ansible.cfg to get rid of this message.
```