### PR TITLE
Stuff [lazy to open more PRs]

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -5,14 +5,15 @@ FROM docker.io/usercont/packit
 ENV LANG=en_US.UTF-8 \
     ANSIBLE_STDOUT_CALLBACK=debug \
     USER=packit \
-    HOME=/home/packit
+    HOME=/home/packit \
+    PS_PATH=/src-packit-service
 
 RUN mkdir ${HOME} && chmod 0776 ${HOME}
 COPY files/passwd ${HOME}/passwd
 
 # Ansible doesn't like /tmp
-COPY files/install-deps-worker.yaml /src/files/
-RUN cd /src/ && \
+COPY files/install-deps-worker.yaml $PS_PATH/files/
+RUN cd $PS_PATH/ && \
     ansible-playbook -vv -c local -i localhost, files/install-deps-worker.yaml \
     && dnf clean all
 
@@ -21,12 +22,14 @@ ENV LD_PRELOAD=libnss_wrapper.so \
     NSS_WRAPPER_PASSWD=${HOME}/passwd \
     NSS_WRAPPER_GROUP=/etc/group
 
-COPY setup.py setup.cfg files/recipe-worker.yaml files/run_worker.sh files/fedmsg-ssl.py files/gitconfig .git_archival.txt .gitattributes /src/
+COPY setup.py setup.cfg files/recipe-worker.yaml files/run_worker.sh files/fedmsg-ssl.py files/gitconfig .git_archival.txt .gitattributes $PS_PATH/
 # setuptools-scm
-COPY .git /src/.git
-COPY packit_service/ /src/packit_service/
+COPY .git $PS_PATH/.git
+COPY packit_service/ $PS_PATH/packit_service/
 
-RUN cd /src/ && \
+RUN cd $PS_PATH && \
     ansible-playbook -vv -c local -i localhost, recipe-worker.yaml
+
+COPY . $PS_PATH
 
 CMD ["/usr/bin/run_worker.sh"]

--- a/Dockerfile.worker.prod
+++ b/Dockerfile.worker.prod
@@ -6,14 +6,15 @@ FROM docker.io/usercont/packit:prod
 ENV LANG=en_US.UTF-8 \
     ANSIBLE_STDOUT_CALLBACK=debug \
     USER=packit \
-    HOME=/home/packit
+    HOME=/home/packit \
+    PS_PATH=/src-packit-service
 
 RUN mkdir ${HOME} && chmod 0776 ${HOME}
 COPY files/passwd ${HOME}/passwd
 
 # Ansible doesn't like /tmp
-COPY files/install-deps-worker.yaml /src/files/
-RUN cd /src/ && \
+COPY files/install-deps-worker.yaml $PS_PATH/files/
+RUN cd $PS_PATH/ && \
     ansible-playbook -vv -c local -i localhost, files/install-deps-worker.yaml \
     && dnf clean all
 
@@ -22,12 +23,14 @@ ENV LD_PRELOAD=libnss_wrapper.so \
     NSS_WRAPPER_PASSWD=${HOME}/passwd \
     NSS_WRAPPER_GROUP=/etc/group
 
-COPY setup.py setup.cfg files/recipe-worker.yaml files/run_worker.sh files/fedmsg-ssl.py files/gitconfig .git_archival.txt .gitattributes /src/
+COPY setup.py setup.cfg files/recipe-worker.yaml files/run_worker.sh files/fedmsg-ssl.py files/gitconfig .git_archival.txt .gitattributes $PS_PATH/
 # setuptools-scm
-COPY .git /src/.git
-COPY packit_service/ /src/packit_service/
+COPY .git $PS_PATH/.git
+COPY packit_service/ $PS_PATH/packit_service/
 
-RUN cd /src/ && \
+RUN cd $PS_PATH && \
     ansible-playbook -vv -c local -i localhost, recipe-worker.yaml
+
+COPY . $PS_PATH
 
 CMD ["/usr/bin/run_worker.sh"]

--- a/files/recipe-worker.yaml
+++ b/files/recipe-worker.yaml
@@ -3,6 +3,7 @@
   hosts: all
   vars:
     home_path: "{{ lookup('env', 'HOME') }}"
+    packit_service_path: /src-packit-service
     ansible_bender:
       base_image: docker.io/usercont/packit
       target_image:
@@ -10,7 +11,7 @@
         cmd: run_worker.sh
       working_container:
         volumes:
-        - '{{ playbook_dir }}:/src:Z'
+        - '{{ playbook_dir }}:{{ packit_service_path }}:Z'
   tasks:
   - name: Create /usr/share/packit directory
     file:
@@ -23,9 +24,9 @@
     copy:
       src: gitconfig
       dest: '{{ home_path }}/.gitconfig'
-  - name: stat /src
+  - name: stat {{ packit_service_path }}
     stat:
-      path: /src
+      path: '{{ packit_service_path }}'
     tags:
     - no-cache
     register: src_path
@@ -33,7 +34,7 @@
     copy:
       src: fedmsg-ssl.py
       dest: /etc/fedmsg.d/ssl.py
-  - name: Let's make sure /src is present
+  - name: Let's make sure {{ packit_service_path }} is present
     assert:
       that:
       - 'src_path.stat.isdir'
@@ -42,9 +43,9 @@
       src: run_worker.sh
       dest: /usr/bin/run_worker.sh
       mode: 0777
-  - name: Install packit-service from /src
+  - name: Install packit-service from {{ packit_service_path }}
     pip:
-      name: /src
+      name: '{{ packit_service_path }}'
       executable: pip3
   - name: Clean all the cache files (especially pip)
     shell: rm -rf ~/.cache/*

--- a/files/run_worker.sh
+++ b/files/run_worker.sh
@@ -14,4 +14,4 @@ install -m 0400 /packit-ssh/id_rsa ${PACKIT_HOME}/.ssh/
 install -m 0400 /packit-ssh/id_rsa.pub ${PACKIT_HOME}/.ssh/
 install -m 0400 /packit-ssh/config ${PACKIT_HOME}/.ssh/config
 
-exec celery-3 worker --app=${APP} --loglevel=debug --concurrency=1
+exec celery-3 worker --app=${APP} --loglevel=info --concurrency=1

--- a/packit_service/service/web_hook.py
+++ b/packit_service/service/web_hook.py
@@ -62,6 +62,7 @@ def github_webhook():
         return "Pong!"
 
     if not validate_signature():
+        logger.info("webhook secret is not correct")
         abort(401)  # Unauthorized
 
     # TODO: define task names at one place

--- a/packit_service/worker/copr_build.py
+++ b/packit_service/worker/copr_build.py
@@ -67,6 +67,7 @@ class CoprBuildHandler(object):
             self._local_project = LocalProject(
                 git_project=self.project,
                 working_dir=self.config.command_handler_work_dir,
+                ref=self.event.base_ref,
             )
         return self._local_project
 
@@ -95,7 +96,6 @@ class CoprBuildHandler(object):
         return None
 
     def run_copr_build(self) -> HandlerResults:
-
         check_name = PRCheckName.get_build_check()
         # add suffix stg when using stg app
         stg = "-stg" if self.config.deployment == Deployment.stg else ""


### PR DESCRIPTION
```
worker: put p-s in a different path than /src

because packit is in /src
```

```
celery: set logs to info

openshift healthchecks clutter the logs like m4d
```

```
log when webhook secret is not correct
```

```
copr-pr-builds: check out the PR actually
```
Fixes #106
