### PR TITLE
worker image: installation fixes

### DIFF
--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -8,6 +8,7 @@
       - python3-ipdb  # for easy debugging
       - nss_wrapper  # openshift anyuid passwd madness
       - python3-celery # (#107)
+      - rebase-helper
       - python3-redis
       - redis  # redis-cli for debugging
       - origin-clients # for sandcastle


### PR DESCRIPTION
rebase-helper from Fedora repos: traceback in fedmsg listener that marshmallow has incorrect version

packit from git master: let's have the latest greatest