### PR TITLE
Fix 122

### DIFF
--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -202,14 +202,13 @@ class SteveJobs:
 
         jobs_results = {}
 
-        project = event_object.get_project()
         is_private_repository = False
-
-        if not project:
+        try:
+            project = event_object.get_project()
+            is_private_repository = self._is_private(project)
+        except NotImplementedError:
             logger.warning("Cannot obtain project from this event!")
             logger.warning("Skipping private repository check!")
-        else:
-            is_private_repository = self._is_private(event_object.get_project())
 
         if is_private_repository:
             logger.error("We do not interact with private repositories!")

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -201,9 +201,18 @@ class SteveJobs:
             return None
 
         jobs_results = {}
-        if self._is_private(event_object.get_project()):
-            logger.error("We do not interact with private repositories!")
 
+        project = event_object.get_project()
+        is_private_repository = False
+
+        if not project:
+            logger.warning("Cannot obtain project from this event!")
+            logger.warning("Skipping private repository check!")
+        else:
+            is_private_repository = self._is_private(event_object.get_project())
+
+        if is_private_repository:
+            logger.error("We do not interact with private repositories!")
         else:
             # installation is handled differently b/c app is installed to GitHub account
             # not repository, so package config with jobs is missing


### PR DESCRIPTION
fix #122 

Only `Event` which does not implement the `get_project` method is `InstallationEvent`. In that case, we cannot check if the repository is private.

Not sure if this is the best solution.