### PR TITLE
Change Handler message to more intuitive.

### DIFF
--- a/packit_service/worker/copr_build.py
+++ b/packit_service/worker/copr_build.py
@@ -190,5 +190,11 @@ class CoprBuildHandler(object):
         else:
             return HandlerResults(
                 success=False,
-                details={"msg": f"No Handler for {str(self.event.trigger)}"},
+                details={
+                    "msg": (
+                        f"Copr build {build_id} failed {build_state}."
+                        f"Copr build URL is {repo_url}."
+                        f"Handler used by Copr build is {str(self.event.trigger)}"
+                    )
+                },
             )


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

This pull request changes the message in case copr_build fails.
Error message shown by an error in #132 is not intuitive.