### PR TITLE
Update passwd properly

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -9,18 +9,13 @@ ENV LANG=en_US.UTF-8 \
     PS_PATH=/src-packit-service
 
 RUN mkdir ${HOME} && chmod 0776 ${HOME}
-COPY files/passwd ${HOME}/passwd
+COPY files/passwd ${HOME}/passwd.packit
 
 # Ansible doesn't like /tmp
 COPY files/install-deps-worker.yaml $PS_PATH/files/
 RUN cd $PS_PATH/ && \
     ansible-playbook -vv -c local -i localhost, files/install-deps-worker.yaml \
     && dnf clean all
-
-# The passwd/nss_wrapper magic is needed for fedpkg
-ENV LD_PRELOAD=libnss_wrapper.so \
-    NSS_WRAPPER_PASSWD=${HOME}/passwd \
-    NSS_WRAPPER_GROUP=/etc/group
 
 COPY setup.py setup.cfg files/recipe-worker.yaml files/run_worker.sh files/fedmsg-ssl.py files/gitconfig .git_archival.txt .gitattributes $PS_PATH/
 # setuptools-scm

--- a/files/run_worker.sh
+++ b/files/run_worker.sh
@@ -6,9 +6,17 @@ if [[ -z ${APP} ]]; then
     exit 1
 fi
 
-printf "packit:x:$(id -u):0:Packit Service:/home/packit:/bin/bash\n" >>/home/packit/passwd
-
 export PACKIT_HOME=/home/packit
+
+cp ${PACKIT_HOME}/passwd.packit ${PACKIT_HOME}/passwd
+
+# The passwd/nss_wrapper magic is needed for fedpkg
+export LD_PRELOAD=libnss_wrapper.so
+export NSS_WRAPPER_PASSWD=${HOME}/passwd
+export NSS_WRAPPER_GROUP=/etc/group
+
+printf "packit:x:$(id -u):0:Packit Service:/home/packit:/bin/bash\n" >> ${PACKIT_HOME}/passwd
+
 mkdir --mode=0700 -p ${PACKIT_HOME}/.ssh
 install -m 0400 /packit-ssh/id_rsa ${PACKIT_HOME}/.ssh/
 install -m 0400 /packit-ssh/id_rsa.pub ${PACKIT_HOME}/.ssh/


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

This pull request fixes issue #93 .

Before that fix, once the image is built, `/home/packit/passwd` has permissions `root:root` and rights`644` which means, that image on OpenShift is not able to add userid into `/home/packit/passwd`.

This fix does following:
- Copy file `/home/packit/passwd.packit` into `/home/packit/passwd` with permissinog `user_id:root` and `644`
- Setting NSS_WRAPPER variables to `/home/packit/passwd`

A similar code is done in `betka` bot.