### PR TITLE
Unify config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,3 +152,14 @@ Once we have jobs defined in `packit` config we are ready to move on to next ste
 
 Thank you for your interest!
 packit team.
+
+### Service configuration
+
+The service configuration is an extension of the user configuration from packit. (`Config` class in [packit/config.py](https://github.com/packit-service/packit/blob/master/packit/config.py).)
+
+To add a new service-related property you need to:
+
+1. Add a property to `ServiceConfig.__init__` in [packit/config.py](https://github.com/packit-service/packit/blob/master/packit/config.py).
+2. Load the property in `ServiceConfig.get_from_dict`.
+2. Add it to the validation schema (`_SERVICE_CONFIG_SCHEMA_PROPERTIES`) in [schema.py](/packit_service/schema.py).
+    - Add the property to the `_SERVICE_CONFIG_SCHEMA_REQUIRED` if the property is required.

--- a/packit_service/cli/packit_base.py
+++ b/packit_service/cli/packit_base.py
@@ -27,9 +27,9 @@ from packit.config import get_context_settings
 from packit.utils import set_logging
 from pkg_resources import get_distribution
 
-from packit_service.cli.process_message import process_message
 from packit_service.cli.listen_to_fedmsg import listen_to_fedmsg
-from packit_service.config import Config
+from packit_service.cli.process_message import process_message
+from packit_service.config import ServiceConfig
 
 logger = logging.getLogger("packit_service")
 
@@ -41,7 +41,7 @@ logger = logging.getLogger("packit_service")
 @click.pass_context
 def packit_base(ctx, debug, fas_user, keytab):
     """Integrate upstream open source projects into Fedora operating system."""
-    c = Config.get_service_config()
+    c = ServiceConfig.get_service_config()
     c.debug = debug or c.debug
     c.fas_user = fas_user or c.fas_user
     c.keytab_path = keytab or c.keytab_path

--- a/packit_service/schema.py
+++ b/packit_service/schema.py
@@ -19,23 +19,17 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+from packit.schema import USER_CONFIG_SCHEMA
 
-
-SERVICE_CONFIG_SCHEMA = {
-    "type": "object",
-    "properties": {
-        "debug": {"type": "boolean"},
-        "dry_run": {"type": "boolean"},
-        "fas_user": {"type": "string"},
-        "keytab_path": {"type": "string"},
-        "pagure_user_token": {"type": "string"},
-        "pagure_fork_token": {"type": "string"},
-        "deployment": {"type": "string"},
-        "github_app_id": {"type": "string"},
-        "github_app_cert_path": {"type": "string"},
-        "webhook_secret": {"type": "string"},
-        "testing_farm_secret": {"type": "string"},
-        "validate_webhooks": {"type": "boolean"},
-    },
-    "required": ["deployment", "github_app_id", "github_app_cert_path"],
+_SERVICE_CONFIG_SCHEMA_PROPERTIES = {
+    "deployment": {"type": "string"},
+    "webhook_secret": {"type": "string"},
+    "testing_farm_secret": {"type": "string"},
+    "validate_webhooks": {"type": "boolean"},
 }
+_SERVICE_CONFIG_SCHEMA_REQUIRED = ["deployment"]
+
+SERVICE_CONFIG_SCHEMA = USER_CONFIG_SCHEMA.copy()
+SERVICE_CONFIG_SCHEMA["properties"].update(_SERVICE_CONFIG_SCHEMA_PROPERTIES)
+SERVICE_CONFIG_SCHEMA.setdefault("required", [])
+SERVICE_CONFIG_SCHEMA["required"] += _SERVICE_CONFIG_SCHEMA_REQUIRED

--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -26,15 +26,13 @@ This file defines classes for events which are sent by GitHub or FedMsg.
 import copy
 import enum
 import logging
-from pathlib import Path
 from typing import Optional, List
 
-from ogr import PagureService, GithubService
+from ogr import PagureService
 from ogr.abstract import GitProject
 from packit.config import JobTriggerType, get_package_config_from_repo, PackageConfig
 
 from packit_service.config import service_config
-
 
 logger = logging.getLogger(__name__)
 
@@ -97,19 +95,7 @@ class Event:
 
 
 class AbstractGithubEvent(Event):
-    @staticmethod
-    def __get_private_key() -> Optional[str]:
-        if service_config.github_app_cert_path:
-            return Path(service_config.github_app_cert_path).read_text()
-        return None
-
-    @property
-    def github_service(self) -> GithubService:
-        return GithubService(
-            token=service_config.github_token,
-            github_app_id=service_config.github_app_id,
-            github_app_private_key=self.__get_private_key(),
-        )
+    pass
 
 
 class ReleaseEvent(AbstractGithubEvent):
@@ -135,9 +121,7 @@ class ReleaseEvent(AbstractGithubEvent):
         return package_config
 
     def get_project(self) -> GitProject:
-        return self.github_service.get_project(
-            repo=self.repo_name, namespace=self.repo_namespace
-        )
+        return service_config.get_project(url=self.https_url)
 
 
 class PullRequestEvent(AbstractGithubEvent):
@@ -185,9 +169,7 @@ class PullRequestEvent(AbstractGithubEvent):
         return package_config
 
     def get_project(self) -> GitProject:
-        return self.github_service.get_project(
-            repo=self.base_repo_name, namespace=self.base_repo_namespace
-        )
+        return service_config.get_project(url=self.https_url)
 
 
 class PullRequestCommentEvent(AbstractGithubEvent):
@@ -239,9 +221,7 @@ class PullRequestCommentEvent(AbstractGithubEvent):
         return package_config
 
     def get_project(self) -> GitProject:
-        return self.github_service.get_project(
-            repo=self.base_repo_name, namespace=self.base_repo_namespace
-        )
+        return service_config.get_project(url=self.https_url)
 
 
 class IssueCommentEvent(AbstractGithubEvent):
@@ -297,9 +277,7 @@ class IssueCommentEvent(AbstractGithubEvent):
         return package_config
 
     def get_project(self) -> GitProject:
-        return self.github_service.get_project(
-            repo=self.base_repo_name, namespace=self.base_repo_namespace
-        )
+        return service_config.get_project(url=self.https_url)
 
 
 class InstallationEvent(Event):
@@ -418,6 +396,4 @@ class TestingFarmResultsEvent(AbstractGithubEvent):
         return package_config
 
     def get_project(self) -> GitProject:
-        return self.github_service.get_project(
-            repo=self.repo_name, namespace=self.repo_namespace
-        )
+        return service_config.get_project(url=self.https_url)

--- a/packit_service/service/testing_farm_api.py
+++ b/packit_service/service/testing_farm_api.py
@@ -24,14 +24,13 @@ import json
 import logging
 
 from flask import Blueprint, abort, request
-from packit_service.config import Config
 
 from packit_service.celerizer import celery_app
+from packit_service.config import ServiceConfig
 
 logger = logging.getLogger("packit_service")
 
-config = Config.get_service_config()
-
+config = ServiceConfig.get_service_config()
 
 testing_farm_api = Blueprint("testing_farm_api", __name__)
 

--- a/packit_service/service/web_hook.py
+++ b/packit_service/service/web_hook.py
@@ -25,10 +25,10 @@ import logging
 from hashlib import sha1
 
 from flask import Flask, abort, request, jsonify
-
 from packit.utils import set_logging
+
 from packit_service.celerizer import celery_app
-from packit_service.config import Config
+from packit_service.config import ServiceConfig
 from packit_service.service.testing_farm_api import testing_farm_api
 
 
@@ -39,7 +39,7 @@ class PackitWebhookReceiver(Flask):
 
 
 app = PackitWebhookReceiver(__name__)
-config = Config.get_service_config()
+config = ServiceConfig.get_service_config()
 logger = logging.getLogger("packit_service")
 
 # testing farm API is defined in /packit_service/service/testing_farm_api.py

--- a/packit_service/worker/comment_action_handler.py
+++ b/packit_service/worker/comment_action_handler.py
@@ -27,14 +27,12 @@ This file defines classes for issue comments which are sent by GitHub.
 import enum
 import logging
 import shutil
-
-from typing import Dict, Type, Optional, Union
 from pathlib import Path
+from typing import Dict, Type, Optional, Union
 
-from ogr import GithubService
 from packit.api import PackitAPI
-from packit.config import Config
 
+from packit_service.config import ServiceConfig
 from packit_service.service.events import PullRequestCommentEvent, IssueCommentEvent
 from packit_service.worker.handler import HandlerResults
 
@@ -58,25 +56,14 @@ class CommentActionHandler:
     name: CommentAction
 
     def __init__(
-        self, config: Config, event: Union[PullRequestCommentEvent, IssueCommentEvent]
+        self,
+        config: ServiceConfig,
+        event: Union[PullRequestCommentEvent, IssueCommentEvent],
     ):
-        self.config: Config = config
+        self.config: ServiceConfig = config
         self.event: Union[PullRequestCommentEvent, IssueCommentEvent] = event
         self.api: Optional[PackitAPI] = None
         self.local_project: Optional[PackitAPI] = None
-
-    def __get_private_key(self):
-        if self.config.github_app_cert_path:
-            return Path(self.config.github_app_cert_path).read_text()
-        return None
-
-    @property
-    def github_service(self) -> GithubService:
-        return GithubService(
-            token=self.config.github_token,
-            github_app_id=self.config.github_app_id,
-            github_app_private_key=self.__get_private_key(),
-        )
 
     def run(self) -> HandlerResults:
         raise NotImplementedError("This should have been implemented.")

--- a/packit_service/worker/copr_build.py
+++ b/packit_service/worker/copr_build.py
@@ -22,22 +22,21 @@
 import logging
 from typing import Union, List, Optional
 
-
 from ogr.abstract import GitProject
 from packit.api import PackitAPI
-from packit.exceptions import FailedCreateSRPM
-from sandcastle import SandcastleCommandFailed, SandcastleTimeoutReached
-from packit.local_project import LocalProject
 from packit.config import PackageConfig, JobType, JobConfig
+from packit.exceptions import FailedCreateSRPM
+from packit.local_project import LocalProject
+from sandcastle import SandcastleCommandFailed, SandcastleTimeoutReached
 
-from packit_service.config import Config, Deployment
+from packit_service.config import ServiceConfig, Deployment
+from packit_service.service.events import PullRequestEvent, PullRequestCommentEvent
 from packit_service.service.models import CoprBuild
 from packit_service.worker.handler import (
     HandlerResults,
     BuildStatusReporter,
     PRCheckName,
 )
-from packit_service.service.events import PullRequestEvent, PullRequestCommentEvent
 
 logger = logging.getLogger(__name__)
 
@@ -45,12 +44,12 @@ logger = logging.getLogger(__name__)
 class CoprBuildHandler(object):
     def __init__(
         self,
-        config: Config,
+        config: ServiceConfig,
         package_config: PackageConfig,
         project: GitProject,
         event: Union[PullRequestEvent, PullRequestCommentEvent],
     ):
-        self.config: Config = config
+        self.config: ServiceConfig = config
         self.package_config: PackageConfig = package_config
         self.project: GitProject = project
         self.event: Union[PullRequestEvent, PullRequestCommentEvent] = event

--- a/packit_service/worker/handler.py
+++ b/packit_service/worker/handler.py
@@ -31,9 +31,8 @@ from typing import Dict, Any, Optional, Type, List
 from ogr.abstract import GitProject
 from packit.api import PackitAPI
 from packit.config import JobConfig, JobTriggerType, JobType
-from packit_service.config import Config, Deployment
 
-
+from packit_service.config import Deployment, ServiceConfig
 from packit_service.constants import (
     PACKIT_PROD_CHECK,
     PACKIT_STG_CHECK,
@@ -41,11 +40,9 @@ from packit_service.constants import (
     PACKIT_STG_TESTING_FARM_CHECK,
 )
 from packit_service.service.events import Event
-
 from packit_service.service.models import CoprBuild
 
 logger = logging.getLogger(__name__)
-
 
 JOB_NAME_HANDLER_MAPPING: Dict[JobType, Type["JobHandler"]] = {}
 
@@ -57,7 +54,7 @@ class PRCheckName:
 
     @staticmethod
     def get_build_check() -> str:
-        config = Config.get_service_config()
+        config = ServiceConfig.get_service_config()
         if config.deployment == Deployment.prod:
             return PACKIT_PROD_CHECK
 
@@ -65,7 +62,7 @@ class PRCheckName:
 
     @staticmethod
     def get_testing_farm_check() -> str:
-        config = Config.get_service_config()
+        config = ServiceConfig.get_service_config()
         if config.deployment == Deployment.prod:
             return PACKIT_PROD_TESTING_FARM_CHECK
 
@@ -139,8 +136,8 @@ class JobHandler:
     name: JobType
     triggers: List[JobTriggerType]
 
-    def __init__(self, config: Config, job: JobConfig, event: Event):
-        self.config: Config = config
+    def __init__(self, config: ServiceConfig, job: JobConfig, event: Event):
+        self.config: ServiceConfig = config
         self.job: JobConfig = job
         self.event = event
 

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -27,16 +27,21 @@ We love you, Steve Jobs.
 import logging
 from typing import Optional, Dict, Union, Type
 
-from packit.config import JobTriggerType, JobType
 from ogr.abstract import GitProject
 from ogr.services.github import GithubProject
+from packit.config import JobTriggerType, JobType
 
-from packit_service.config import Config
+from packit_service.config import ServiceConfig
 from packit_service.service.events import (
     PullRequestCommentEvent,
     IssueCommentEvent,
     Event,
     TestingFarmResultsEvent,
+)
+from packit_service.worker.comment_action_handler import (
+    COMMENT_ACTION_HANDLER_MAPPING,
+    CommentAction,
+    CommentActionHandler,
 )
 from packit_service.worker.github_handlers import GithubAppInstallationHandler
 from packit_service.worker.handler import (
@@ -45,11 +50,6 @@ from packit_service.worker.handler import (
     JobHandler,
 )
 from packit_service.worker.parser import Parser
-from packit_service.worker.comment_action_handler import (
-    COMMENT_ACTION_HANDLER_MAPPING,
-    CommentAction,
-    CommentActionHandler,
-)
 from packit_service.worker.testing_farm_handlers import TestingFarmResultsHandler
 from packit_service.worker.whitelist import Whitelist
 
@@ -69,7 +69,7 @@ class SteveJobs:
     @property
     def config(self):
         if self._config is None:
-            self._config = Config.get_service_config()
+            self._config = ServiceConfig.get_service_config()
         return self._config
 
     @staticmethod

--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -27,6 +27,7 @@ import logging
 from typing import Optional, Union, List
 
 from packit.utils import nested_get
+
 from packit_service.service.events import (
     PullRequestEvent,
     PullRequestCommentEvent,
@@ -335,7 +336,12 @@ class Parser:
             logger.info(f"msg_id = {msg_id}")
 
             branch = nested_get(event, "msg", "commit", "branch")
-            return DistGitEvent(topic, repo_namespace, repo_name, ref, branch, msg_id)
+
+            # TODO: get the right hostname without hardcoding
+            project_url = f"https://src.fedoraproject.org/{repo_namespace}/{repo_name}"
+            return DistGitEvent(
+                topic, repo_namespace, repo_name, ref, branch, msg_id, project_url
+            )
         return None
 
     @staticmethod

--- a/packit_service/worker/testing_farm_handlers.py
+++ b/packit_service/worker/testing_farm_handlers.py
@@ -34,7 +34,7 @@ from packit.config import (
 )
 from packit.local_project import LocalProject
 
-from packit_service.config import Config
+from packit_service.config import ServiceConfig
 from packit_service.service.events import TestingFarmResultsEvent, TestingFarmResult
 from packit_service.worker.github_handlers import AbstractGithubJobHandler
 from packit_service.worker.handler import (
@@ -53,16 +53,16 @@ class TestingFarmResultsHandler(AbstractGithubJobHandler):
 
     def __init__(
         self,
-        config: Config,
+        config: ServiceConfig,
         job: JobConfig,
         test_results_event: TestingFarmResultsEvent,
     ):
         super().__init__(config=config, job=job, event=test_results_event)
-        self.project: GitProject = self.config.get_project(url=self.event.https_url)
+        self.project: GitProject = test_results_event.get_project()
         self.package_config: PackageConfig = get_package_config_from_repo(
             self.project, test_results_event.ref
         )
-        self.package_config.upstream_project_url = test_results_event.https_url
+        self.package_config.upstream_project_url = test_results_event.project_url
 
     def run(self) -> HandlerResults:
         self.local_project = LocalProject(

--- a/packit_service/worker/testing_farm_handlers.py
+++ b/packit_service/worker/testing_farm_handlers.py
@@ -58,10 +58,7 @@ class TestingFarmResultsHandler(AbstractGithubJobHandler):
         test_results_event: TestingFarmResultsEvent,
     ):
         super().__init__(config=config, job=job, event=test_results_event)
-        self.project: GitProject = self.github_service.get_project(
-            repo=test_results_event.repo_name,
-            namespace=test_results_event.repo_namespace,
-        )
+        self.project: GitProject = self.config.get_project(url=self.event.https_url)
         self.package_config: PackageConfig = get_package_config_from_repo(
             self.project, test_results_event.ref
         )

--- a/packit_service/worker/whitelist.py
+++ b/packit_service/worker/whitelist.py
@@ -2,6 +2,8 @@
 #
 # Copyright (c) 2018-2019 Red Hat, Inc.
 
+import logging
+
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
@@ -22,11 +24,9 @@
 from typing import Optional, Any
 
 import requests
-import logging
-
-from persistentdict.dict_in_redis import PersistentDict
 from ogr.abstract import GitProject
 from packit.config import JobTriggerType
+from persistentdict.dict_in_redis import PersistentDict
 
 from packit_service.constants import FAQ_URL
 from packit_service.service.events import (

--- a/packit_service/worker/whitelist.py
+++ b/packit_service/worker/whitelist.py
@@ -1,9 +1,6 @@
 # MIT License
 #
 # Copyright (c) 2018-2019 Red Hat, Inc.
-
-import logging
-
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
@@ -21,6 +18,7 @@ import logging
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import logging
 from typing import Optional, Any
 
 import requests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,23 +20,20 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import os
-import pytest
-
 from pathlib import Path
+
+import pytest
+from copr.v3.client import Client as CoprClient
 from flexmock import flexmock
 from github import Github
-from copr.v3.client import Client as CoprClient
 from github.GitRelease import GitRelease as PyGithubRelease
-
-from packit.config import Config
-from packit.local_project import LocalProject
-from tests.spellbook import SAVED_HTTPD_REQS
-
 from ogr.services.github import GithubProject, GithubRelease, GitTag
+from packit.local_project import LocalProject
 
-from packit_service.config import Config as ServiceConfig
+from packit_service.config import ServiceConfig
 from packit_service.constants import SANDCASTLE_WORK_DIR
 from packit_service.worker.whitelist import Whitelist
+from tests.spellbook import SAVED_HTTPD_REQS
 
 
 @pytest.fixture()
@@ -48,7 +45,7 @@ def dump_http_com():
     Usage:
     1. add it to your test case and pass the test path
       def test_something(dump_http_com):
-        config = dump_http_com(f"{Path(__file__).name}/pr_handle.yaml")
+        service_config = dump_http_com(f"{Path(__file__).name}/pr_handle.yaml")
     2. Run your test
       GITHUB_TOKEN=asdqwe pytest-3 -k test_something
     3. Your http communication should now be stored in tests/data/http-requests/{path}
@@ -57,7 +54,7 @@ def dump_http_com():
 
     def f(path: str):
         """ path points to a file where the http communication will be saved """
-        conf = Config()
+        conf = ServiceConfig()
         # TODO: add pagure support
         # conf._pagure_user_token = os.environ.get("PAGURE_TOKEN", "test")
         # conf._pagure_fork_token = os.environ.get("PAGURE_FORK_TOKEN", "test")

--- a/tests/integration/test_handler.py
+++ b/tests/integration/test_handler.py
@@ -22,9 +22,9 @@
 from pathlib import Path
 
 from packit.config import JobConfig, JobType, JobTriggerType
-from packit_service.config import Config
-from packit_service.service.events import Event
 
+from packit_service.config import ServiceConfig
+from packit_service.service.events import Event
 from packit_service.worker.handler import JobHandler
 
 
@@ -39,7 +39,7 @@ def test_handler_cleanup(tmpdir):
     t.joinpath(".g").write_text("g")
     t.joinpath(".h").symlink_to(".g", target_is_directory=False)
 
-    c = Config()
+    c = ServiceConfig()
     c.command_handler_work_dir = t
     jc = JobConfig(JobType.copr_build, [], JobTriggerType.pull_request, {})
     j = JobHandler(c, jc, Event(JobTriggerType.pull_request))

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -3,18 +3,16 @@ import json
 import pytest
 from flexmock import flexmock
 from github import Github
-
 from ogr.services.github import GithubProject
-
 from packit.api import PackitAPI
 from packit.config import JobTriggerType
 from packit.local_project import LocalProject
 
-from packit_service.config import Config
+from packit_service.config import ServiceConfig
 from packit_service.constants import SANDCASTLE_WORK_DIR
-from tests.spellbook import DATA_DIR
 from packit_service.worker.jobs import SteveJobs
 from packit_service.worker.whitelist import Whitelist
+from tests.spellbook import DATA_DIR
 
 
 @pytest.fixture()
@@ -37,9 +35,9 @@ def test_dist_git_push_release_handle(release_event):
     flexmock(Whitelist, check_and_report=True)
     steve = SteveJobs()
     flexmock(SteveJobs, _is_private=False)
-    config = Config()
+    config = ServiceConfig()
     config.command_handler_work_dir = SANDCASTLE_WORK_DIR
-    flexmock(Config).should_receive("get_service_config").and_return(config)
+    flexmock(ServiceConfig).should_receive("get_service_config").and_return(config)
     # it would make sense to make LocalProject offline
     flexmock(PackitAPI).should_receive("sync_release").with_args(
         dist_git_branch="master", version="0.3.0", create_pr=False

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -22,20 +22,24 @@
 import pytest
 from packit.exceptions import PackitInvalidConfigException
 
-from packit_service.config import Config, Deployment
+from packit_service.config import ServiceConfig, Deployment
 
 
 def get_service_config_missing():
     # missing required fields
-    return {"deployment": "dev"}
+    return {}
 
 
 def get_service_config_invalid():
     # wrong option
     return {
-        "deployment": "prod",
-        "github_app_id": False,
-        "github_app_cert_path": "/path/lib",
+        "deployment": False,
+        "authentication": {
+            "github.com": {
+                "github_app_id": "11111",
+                "github_app_cert_path": "/path/lib",
+            }
+        },
         "webhook_secret": "secret",
         "command_handler_work_dir": "/sandcastle",
         "command_handler_image_reference": "docker.io/usercont/sandcastle",
@@ -46,8 +50,12 @@ def get_service_config_invalid():
 def get_service_config_valid():
     return {
         "deployment": "prod",
-        "github_app_id": "11111",
-        "github_app_cert_path": "/path/lib",
+        "authentication": {
+            "github.com": {
+                "github_app_id": "11111",
+                "github_app_cert_path": "/path/lib",
+            }
+        },
         "webhook_secret": "secret",
         "command_handler": "sandcastle",
         "command_handler_work_dir": "/sandcastle",
@@ -72,15 +80,15 @@ def service_config_invalid():
 
 
 def test_parse_valid(service_config_valid):
-    config = Config.get_from_dict(service_config_valid)
+    config = ServiceConfig.get_from_dict(service_config_valid)
     assert config.deployment == Deployment("prod")
 
 
 def test_parse_invalid(service_config_invalid):
     with pytest.raises(PackitInvalidConfigException):
-        Config.get_from_dict(service_config_invalid)
+        ServiceConfig.get_from_dict(service_config_invalid)
 
 
 def test_parse_missing(service_config_missing):
     with pytest.raises(PackitInvalidConfigException):
-        Config.get_from_dict(service_config_missing)
+        ServiceConfig.get_from_dict(service_config_missing)

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -126,7 +126,7 @@ class TestEvents:
         assert event_object.repo_namespace == "Codertocat"
         assert event_object.repo_name == "Hello-World"
         assert event_object.tag_name == "0.0.1"
-        assert event_object.https_url == "https://github.com/Codertocat/Hello-World"
+        assert event_object.project_url == "https://github.com/Codertocat/Hello-World"
 
     def test_parse_pr(self, pull_request):
         event_object = Parser.parse_event(pull_request)
@@ -139,7 +139,7 @@ class TestEvents:
         assert event_object.base_repo_name == "packit"
         assert event_object.base_ref == "528b803be6f93e19ca4130bf4976f2800a3004c4"
         assert event_object.target_repo == "packit-service/packit"
-        assert event_object.https_url == "https://github.com/packit-service/packit"
+        assert event_object.project_url == "https://github.com/packit-service/packit"
         assert event_object.commit_sha == "528b803be6f93e19ca4130bf4976f2800a3004c4"
 
         def _get_f_c(*args, **kwargs):
@@ -162,7 +162,9 @@ class TestEvents:
             event_object.target_repo
             == f"{event_object.base_repo_namespace}/{event_object.base_repo_name}"
         )
-        assert event_object.https_url == "https://github.com/packit-service/hello-world"
+        assert (
+            event_object.project_url == "https://github.com/packit-service/hello-world"
+        )
         assert event_object.github_login == "phracek"
         assert event_object.comment == "/packit copr-build"
 
@@ -179,7 +181,9 @@ class TestEvents:
             event_object.target_repo
             == f"{event_object.base_repo_namespace}/{event_object.base_repo_name}"
         )
-        assert event_object.https_url == "https://github.com/packit-service/hello-world"
+        assert (
+            event_object.project_url == "https://github.com/packit-service/hello-world"
+        )
         assert event_object.github_login == "phracek"
         assert event_object.comment == ""
 
@@ -197,7 +201,7 @@ class TestEvents:
             == f"{event_object.base_repo_namespace}/{event_object.base_repo_name}"
         )
         assert event_object.base_ref == "master"
-        assert event_object.https_url == "https://github.com/packit-service/packit"
+        assert event_object.project_url == "https://github.com/packit-service/packit"
         assert event_object.github_login == "phracek"
         assert event_object.comment == "/packit propose-update"
 
@@ -211,7 +215,9 @@ class TestEvents:
         assert event_object.repo_namespace == "packit-service"
         assert event_object.repo_name == "hello-world"
         assert event_object.ref == "pull/10/head"
-        assert event_object.https_url == "https://github.com/packit-service/hello-world"
+        assert (
+            event_object.project_url == "https://github.com/packit-service/hello-world"
+        )
         assert event_object.commit_sha == "46597d9b66a1927b50376f73bdb1ec1a5757c330"
         assert event_object.message == "Error or info message to display"
         assert event_object.environment == "Fedora-Cloud-Base-29-1.2.x86_64.qcow2"

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -31,7 +31,7 @@ from flexmock import flexmock
 from ogr.services.github import GithubProject, GithubService
 from packit.config import JobTriggerType
 
-from packit_service.config import Config
+from packit_service.config import ServiceConfig
 from packit_service.service.events import (
     WhitelistStatus,
     InstallationEvent,
@@ -93,13 +93,15 @@ class TestEvents:
 
     @pytest.fixture()
     def mock_config(self):
-        config = flexmock(Config)
-        config.github_app_id = 123123
-        config.github_app_cert_path = None
-        config.github_token = "token"
-        config.dry_run = False
-        config.github_requests_log_path = "/path"
-        config.should_receive("get_service_config").and_return(flexmock(Config))
+        service_config = flexmock(ServiceConfig)
+        service_config.github_app_id = 123123
+        service_config.github_app_cert_path = None
+        service_config.github_token = "token"
+        service_config.dry_run = False
+        service_config.github_requests_log_path = "/path"
+        service_config.should_receive("get_service_config").and_return(
+            flexmock(ServiceConfig)
+        )
 
     def test_parse_installation(self, installation):
         event_object = Parser.parse_event(installation)
@@ -144,7 +146,7 @@ class TestEvents:
             raise FileNotFoundError()
 
         flexmock(GithubProject, get_file_content=_get_f_c)
-        flexmock(Config, get_service_config=Config())
+        flexmock(ServiceConfig, get_service_config=ServiceConfig())
         assert event_object.get_package_config() is None
 
     def test_parse_pr_comment_created(self, pr_comment_created_request):
@@ -221,8 +223,8 @@ class TestEvents:
 
         assert isinstance(event_object, PullRequestEvent)
 
-        flexmock(Config).should_receive("get_service_config").and_return(
-            flexmock(Config)
+        flexmock(ServiceConfig).should_receive("get_service_config").and_return(
+            flexmock(ServiceConfig)
         )
         project = event_object.get_project()
 

--- a/tests/unit/test_steve.py
+++ b/tests/unit/test_steve.py
@@ -33,7 +33,7 @@ from packit.api import PackitAPI
 from packit.config import JobTriggerType
 from packit.local_project import LocalProject
 
-from packit_service.config import Config
+from packit_service.config import ServiceConfig
 from packit_service.constants import SANDCASTLE_WORK_DIR
 from packit_service.worker.jobs import SteveJobs
 from packit_service.worker.whitelist import Whitelist
@@ -68,9 +68,9 @@ def test_process_message(event):
         full_repo_name="foo/bar",
     )
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
-    config = Config()
+    config = ServiceConfig()
     config.command_handler_work_dir = SANDCASTLE_WORK_DIR
-    flexmock(Config).should_receive("get_service_config").and_return(config)
+    flexmock(ServiceConfig).should_receive("get_service_config").and_return(config)
 
     flexmock(PackitAPI).should_receive("sync_release").with_args(
         dist_git_branch="master", version="1.2.3", create_pr=False

--- a/tests/unit/test_web_hook.py
+++ b/tests/unit/test_web_hook.py
@@ -2,6 +2,9 @@
 #
 # Copyright (c) 2018-2019 Red Hat, Inc.
 
+import pytest
+from flask import Flask, request
+
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
@@ -20,15 +23,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 from flexmock import flexmock
-from flask import Flask, request
-import pytest
 
-from packit_service.config import Config
+from packit_service.config import ServiceConfig
 
 
 @pytest.fixture()
 def mock_config():
-    config = flexmock(Config)
+    config = flexmock(ServiceConfig)
     config.webhook_secret = "testing-secret"
     return config
 
@@ -46,7 +47,9 @@ def test_validate_signature(mock_config, digest, is_good):
     headers = {"X-Hub-Signature": f"sha1={digest}"}
 
     # flexmock config before import as it fails on looking for config
-    flexmock(Config).should_receive("get_service_config").and_return(flexmock(Config))
+    flexmock(ServiceConfig).should_receive("get_service_config").and_return(
+        flexmock(ServiceConfig)
+    )
     from packit_service.service import web_hook
 
     web_hook.config = mock_config


### PR DESCRIPTION
- [x] Change Config to be a subclass of Config from packit.
- [x] Use the new authentication method.
- [x] Get the project objects via `config.get_project(url)`.
~- [ ] backward-compatibility (new authentication)~