### PR TITLE
Filter builds not handled by packit as soon as possible

### DIFF
--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -94,6 +94,14 @@ class Event:
     def get_project(self) -> GitProject:
         raise NotImplementedError("Please implement me!")
 
+    def pre_check(self) -> bool:
+        """
+        Implement this method for those events, where you want to check if event properties are
+        correct. If this method returns false during runtime, execution of service code is skipped.
+        :return:
+        """
+        return True
+
 
 class AbstractGithubEvent(Event):
     def __init__(self, trigger: JobTriggerType, project_url=None):
@@ -419,6 +427,13 @@ class CoprBuildEvent(AbstractGithubEvent):
             self.commit_sha = self.build.get("commit_sha")
         else:
             logger.warning(f"Cannot get project for this build id: {self.build_id}")
+
+    def pre_check(self):
+        if not self.build:
+            logger.warning("Copr build is not handled by this deployment.")
+            return False
+
+        return True
 
     def get_dict(self) -> dict:
         result = super().get_dict()

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -40,7 +40,6 @@ from packit_service.service.events import (
     CoprBuildEvent,
     FedmsgTopic,
 )
-from packit_service.worker.copr_db import CoprBuildDB
 from packit_service.worker.fedmsg_handlers import (
     CoprBuildEndHandler,
     CoprBuildStartHandler,
@@ -212,16 +211,9 @@ class SteveJobs:
 
         jobs_results: Dict[str, HandlerResults] = {}
 
-        if isinstance(event_object, CoprBuildEvent):
-            db = CoprBuildDB()
-            build = db.get_build(event_object.build_id)
-            if not build:
-                logger.warning("Copr build is not handled by this deployment.")
-                return {
-                    "jobs": jobs_results,
-                    "event": event_object.get_dict(),
-                    "trigger": str(event_object.topic),
-                }
+        pre_check = event_object.pre_check()
+        if not pre_check:
+            return {"jobs": jobs_results, "event": event_object.get_dict()}
 
         is_private_repository = False
         try:


### PR DESCRIPTION
#159 was caused by fedora messages which come to packit, and they are not saved in Redis. Let's filter them as soon as possible. 

PS: Already deployed on stg.