### PR TITLE
add a way to run integration tests inside openshift

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,13 +80,55 @@ When you are contributing to changelog, please follow these suggestions:
   trying to convince the person to use the project and that the changelog
   should help with that.
 
-### Testing
+# Testing
 
 Tests are stored in [tests](/tests) directory.
-Running tests locally:
+
+
+## Test categories
+
+We have multiple test categories within packit-service:
+
+1. Unit tests — stored in `tests/unit/` directory:
+  * These tests don't require external resources.
+  * They are meant to exercise independent functions (usually in utils) or
+    abstractions, such as classes.
+  * The tests should be able to be run locally easily.
+
+2. Integration tests — stored in `tests/integration/`:
+  * If a test is executing a command or talking to a service, it's an
+    integration test.
+
+3. Integration tests which run within an OpenShift pod — stored in
+   `tests/openshift_integration/`:
+  * A checkout of packit-service is built as a container image and deployed to
+    openshift as a job while the root process is pytest.
+  * With these, we are making sure that tools we use run well inside [the non-standard OpenShift environment](.https://developers.redhat.com/blog/2016/10/21/understanding-openshift-security-context-constraints/)
+  * [requre](https://github.com/packit-service/requre) and/or
+    [flexmock](https://flexmock.readthedocs.io/en/latest/) is suppose to be
+    used to handle remote interactions and secrets so we don't touch production
+    systems while running tests in CI
+
+4. End To End tests (so far we have none of these):
+  * These tests run against a real deployment of packit-service.
+  * It's expected to send real inputs inside the service and get actual results
+    (observable in GitHub, COPR, Fedora infra etc.)
+  * [requre](https://github.com/packit-service/requre) is used to record the
+    remote interactions which are then replayed in CI.
+
+
+## Running tests locally
+
+You can run unit and integration tests locally in a container:
 ```
 make check_in_container
 ```
+
+For the tests which need an OpenShift cluster, you should provision one using `oc cluster up` or minishift and then run:
+```
+make check-inside-openshift
+```
+
 
 ## Running tests in CI
 

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,11 +1,11 @@
 # For running tests locally, see check_in_container target in Makefile
 
-FROM docker.io/usercont/packit
+FROM docker.io/usercont/packit-service-worker
 
-COPY files/install-deps.yaml ./
-RUN ansible-playbook -vv -c local -i localhost, ./install-deps.yaml
+RUN set -ex; mkdir -p /home/packit/.config \
+    && ln -s $PS_PATH/files/packit-service.yaml /home/packit/.config/packit-service.yaml \
+    && ansible-playbook -vv -c local -i localhost, ./files/recipe-tests.yaml
 
-COPY files/recipe-tests.yaml ./
-RUN ansible-playbook -vv -c local -i localhost, ./recipe-tests.yaml
-
-WORKDIR /src
+# we are doing the same here as in worker Df so that we don't need to rerun the
+# playbook above for every code change: iterating fast <3
+COPY . $PS_PATH

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,6 +1,6 @@
 # For running tests locally, see check_in_container target in Makefile
 
-FROM docker.io/usercont/packit-service-worker
+FROM docker.io/usercont/packit-service-worker:dev
 
 RUN set -ex; mkdir -p /home/packit/.config \
     && ln -s $PS_PATH/files/packit-service.yaml /home/packit/.config/packit-service.yaml \

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -23,5 +23,6 @@ RUN cd $PS_PATH && \
     ansible-playbook -vv -c local -i localhost, recipe-worker.yaml
 
 COPY . $PS_PATH
+WORKDIR $PS_PATH
 
 CMD ["/usr/bin/run_worker.sh"]

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,8 @@ test_image: files/install-deps.yaml files/recipe-tests.yaml
 	$(CONTAINER_ENGINE) build --rm -t $(TEST_IMAGE) -f Dockerfile.tests .
 
 check_in_container: test_image
-	$(CONTAINER_ENGINE) run --rm -ti \
+	@# don't use -ti here in CI, TTY is not allocated in zuul
+	$(CONTAINER_ENGINE) run --rm \
 		-v $(CURDIR):/src-packit-service \
 		-w /src-packit-service \
 		--security-opt label=disable \

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,6 @@ check_in_container: test_image
 # deploy a pod with tests and run them
 check-inside-openshift: CONTAINER_ENGINE=docker
 check-inside-openshift: test_image
-	@# make sure we are running against a local cluster
-	oc whoami --show-server | grep localhost
 	oc delete job packit-tests || :
 	@# http://timmurphy.org/2015/09/27/how-to-get-a-makefile-directory-path/
 	@# sadly the hostPath volume doesn't work:

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,15 @@ SERVICE_IMAGE := docker.io/usercont/packit-service
 WORKER_IMAGE := docker.io/usercont/packit-service-worker
 WORKER_PROD_IMAGE := docker.io/usercont/packit-service-worker:prod
 TEST_IMAGE := packit-service-tests
-TEST_TARGET := ./tests/
+TEST_TARGET := ./tests/unit ./tests/integration/
+CONTAINER_ENGINE := podman
 
 build: files/install-deps.yaml files/recipe.yaml
 	docker build --rm -t $(SERVICE_IMAGE) .
 
+worker: CONTAINER_ENGINE ?= docker
 worker: files/install-deps-worker.yaml files/recipe-worker.yaml
-	docker build --rm -t $(WORKER_IMAGE) -f Dockerfile.worker .
+	$(CONTAINER_ENGINE) build --rm -t $(WORKER_IMAGE) -f Dockerfile.worker .
 
 # this is for cases when you want to deploy into production and don't want to wait for dockerhub
 worker-prod: files/install-deps-worker.yaml files/recipe-worker.yaml
@@ -41,13 +43,31 @@ check:
 	find . -name "*.pyc" -exec rm {} \;
 	PYTHONPATH=$(CURDIR) PYTHONDONTWRITEBYTECODE=1 python3 -m pytest --color=yes --verbose --showlocals --cov=packit_service --cov-report=term-missing $(TEST_TARGET)
 
-test_image: files/install-deps.yaml files/recipe-tests.yaml
-	podman build --rm -t $(TEST_IMAGE) -f Dockerfile.tests .
+test_image: CONTAINER_ENGINE=podman
+test_image: worker files/install-deps.yaml files/recipe-tests.yaml
+	$(CONTAINER_ENGINE) build --rm -t $(TEST_IMAGE) -f Dockerfile.tests .
 
 check_in_container: test_image
-	podman run --rm -ti \
-		-v $(CURDIR):/src \
-		-w /src \
+	$(CONTAINER_ENGINE) run --rm -ti \
+		-v $(CURDIR):/src-packit-service \
+		-w /src-packit-service \
 		--security-opt label=disable \
 		-v $(CURDIR)/files/packit-service.yaml:/root/.config/packit-service.yaml \
 		$(TEST_IMAGE) make check
+
+# deploy a pod with tests and run them
+check-inside-openshift: CONTAINER_ENGINE=docker
+check-inside-openshift: test_image
+	@# make sure we are running against a local cluster
+	oc whoami --show-server | grep localhost
+	oc delete job packit-tests || :
+	oc apply -f files/test-in-openshift.yaml
+	oc wait job/packit-tests --for condition=complete --timeout=60s
+	oc logs job/packit-tests
+	# this garbage tells us if the tests passed or not
+	oc get job packit-tests -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' | grep True
+
+# this target is expected to run within an openshift pod
+check-within-openshift:
+	/src-packit-service/files/setup_env_in_openshift.sh
+	pytest-3 -k test_update

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ WORKER_IMAGE := docker.io/usercont/packit-service-worker
 WORKER_PROD_IMAGE := docker.io/usercont/packit-service-worker:prod
 TEST_IMAGE := packit-service-tests
 TEST_TARGET := ./tests/unit ./tests/integration/
-CONTAINER_ENGINE := podman
+CONTAINER_ENGINE := docker
 
 build: files/install-deps.yaml files/recipe.yaml
 	docker build --rm -t $(SERVICE_IMAGE) .
@@ -43,7 +43,7 @@ check:
 	find . -name "*.pyc" -exec rm {} \;
 	PYTHONPATH=$(CURDIR) PYTHONDONTWRITEBYTECODE=1 python3 -m pytest --color=yes --verbose --showlocals --cov=packit_service --cov-report=term-missing $(TEST_TARGET)
 
-test_image: CONTAINER_ENGINE ?= podman
+test_image: CONTAINER_ENGINE ?= docker
 test_image: files/install-deps.yaml files/recipe-tests.yaml
 	$(CONTAINER_ENGINE) build --rm -t $(TEST_IMAGE) -f Dockerfile.tests .
 

--- a/files/recipe-tests.yaml
+++ b/files/recipe-tests.yaml
@@ -9,19 +9,3 @@
       - python3-pytest
       - python3-pytest-cov
       state: present
-  - name: Install sandcastle
-    pip:
-      name: git+https://github.com/packit-service/sandcastle.git
-  - name: Install ogr from git master
-    pip:
-      name: git+https://github.com/packit-service/ogr.git
-  # we don't install packit-service, so install deps manually
-  - name: Pip install dependencies
-    pip:
-      name:
-      - persistentdict
-      - celery[redis]
-  - name: Clean all the cache files (especially pip)
-    file:
-      state: absent
-      path: ~/.cache/

--- a/files/run_tests.sh
+++ b/files/run_tests.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/bash
+
+set -x
+
+source /src-packit-service/files/setup_env_in_openshift.sh
+
+id
+
+cat $HOME/.config/packit-service.yaml
+
+pytest-3 -vv tests/openshift_integration/

--- a/files/run_worker.sh
+++ b/files/run_worker.sh
@@ -6,14 +6,7 @@ if [[ -z ${APP} ]]; then
     exit 1
 fi
 
-export PACKIT_HOME=/home/packit
-
-# Generate passwd file based on current uid, needed for fedpkg
-grep -v ^packit /etc/passwd > ${PACKIT_HOME}/passwd
-printf "packit:x:$(id -u):0:Packit Service:/home/packit:/bin/bash\n" >> ${PACKIT_HOME}/passwd
-export LD_PRELOAD=libnss_wrapper.so
-export NSS_WRAPPER_PASSWD=${HOME}/passwd
-export NSS_WRAPPER_GROUP=/etc/group
+source /src-packit-service/files/setup_env_in_openshift.sh
 
 mkdir --mode=0700 -p ${PACKIT_HOME}/.ssh
 install -m 0400 /packit-ssh/id_rsa ${PACKIT_HOME}/.ssh/

--- a/files/setup_env_in_openshift.sh
+++ b/files/setup_env_in_openshift.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/bash
+
+set -x
+
+export PACKIT_HOME=/home/packit
+# Generate passwd file based on current uid, needed for fedpkg
+grep -v ^packit /etc/passwd > ${PACKIT_HOME}/passwd
+printf "packit:x:$(id -u):0:Packit Service:/home/packit:/bin/bash\n" >> ${PACKIT_HOME}/passwd
+export LD_PRELOAD=libnss_wrapper.so
+export NSS_WRAPPER_PASSWD=${HOME}/passwd
+export NSS_WRAPPER_GROUP=/etc/group

--- a/files/test-in-openshift.yaml
+++ b/files/test-in-openshift.yaml
@@ -1,25 +1,35 @@
 ---
-apiVersion: batch/v1
-kind: Job
+kind: Template
+apiVersion: v1
 metadata:
-  name: packit-tests
-spec:
-  template:
-    spec:
-      restartPolicy: Never
-      containers:
-      - name: packit-tests
-        image: packit-service-tests
-        imagePullPolicy: Never  # IfNotPresent
-        workingDir: /src-packit-service
-        # volumeMounts:
-        # - name: packit-ssh
-        #   mountPath: /packit-ssh
-        # - name: packit-secrets
-        #   mountPath: /secrets
-        # - name: packit-config
-        #   mountPath: /home/packit/.config
-        # - name: packit-worker-vol
-        #   mountPath: /sandcastle
-        command: ["bash", "/src-packit-service/files/run_tests.sh"]
-  backoffLimit: 1
+  name: packit-service-tests-template
+# parameters:
+# - name: PACKIT_SERVICE_SRC_LOCAL_PATH
+#   displayName: Packit Service Sources Path
+#   description: Local path to packit-service sources
+#   required: true
+objects:
+- apiVersion: batch/v1
+  kind: Job
+  metadata:
+    name: packit-tests
+  spec:
+    template:
+      spec:
+        restartPolicy: Never
+        containers:
+        - name: packit-tests
+          image: packit-service-tests
+          imagePullPolicy: Never  # IfNotPresent
+          workingDir: /src-packit-service
+          # volumeMounts:
+          # - name: packit-service-sources
+          #   mountPath: /src-packit-service
+          command: ["bash", "/src-packit-service/files/run_tests.sh"]
+        # TODO: try in a few months with OKD 4 and CRC
+        # volumes:
+        # - name: packit-service-sources
+        #   hostPath:
+        #     path: "${PACKIT_SERVICE_SRC_LOCAL_PATH}"
+        #     type: Directory
+    backoffLimit: 1

--- a/files/test-in-openshift.yaml
+++ b/files/test-in-openshift.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: packit-tests
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: packit-tests
+        image: packit-service-tests
+        imagePullPolicy: Never  # IfNotPresent
+        workingDir: /src-packit-service
+        # volumeMounts:
+        # - name: packit-ssh
+        #   mountPath: /packit-ssh
+        # - name: packit-secrets
+        #   mountPath: /secrets
+        # - name: packit-config
+        #   mountPath: /home/packit/.config
+        # - name: packit-worker-vol
+        #   mountPath: /sandcastle
+        command: ["bash", "/src-packit-service/files/run_tests.sh"]
+  backoffLimit: 1

--- a/files/zuul-tests.yaml
+++ b/files/zuul-tests.yaml
@@ -1,10 +1,15 @@
 ---
-- name: This is a recipe for how to run packit tests
+- name: Run packit-service tests
   hosts: all
   tasks:
   - include_tasks: tasks/zuul-project-setup.yaml
-  - name: Build packit-service worker image from current src dir
+  - name: Run tests within a container
     command: "make check_in_container"
+    args:
+      chdir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
+    become: true
+  - name: Run tests which are executed within openshift
+    command: make check-inside-openshift
     args:
       chdir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
     become: true

--- a/tests/openshift_integration/__init__.py
+++ b/tests/openshift_integration/__init__.py
@@ -1,0 +1,21 @@
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.

--- a/tests/openshift_integration/test_fedpkg.py
+++ b/tests/openshift_integration/test_fedpkg.py
@@ -1,0 +1,32 @@
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+from pathlib import Path
+
+from packit.fedpkg import FedPKG
+
+
+def test_fedpkg_clone(tmpdir):
+    """ test `fedpkg clone -a` within an openshift pod """
+    t = Path(tmpdir)
+    f = FedPKG()
+    f.clone("units", str(t), anonymous=True)
+    assert t.joinpath("units.spec").is_file()


### PR DESCRIPTION
TODO:
* [x] document this
* [x] describe what types of tests should be done like this
* ~~add stg secrets inside the job~~ doesn't make any sense
* [x] ~~bind code inside the pod~~ nope :/
* [x] fix `check_in_cont`

I also added a sample test:
* test fedpkg clone -a within openshift