### PR TITLE
[Model.serialize()] don't save identifier

### DIFF
--- a/packit_service/service/models.py
+++ b/packit_service/service/models.py
@@ -47,9 +47,9 @@ class Model:
         """ convert from python data structure into a json serializable dict for PersistentDict """
         data = self.__dict__
         cp = copy.deepcopy(data)
-        # we don't need to store table_name inside
-        if "table_name" in cp:
-            del cp["table_name"]
+        # we don't need to store table_name & identifier (key)
+        cp.pop("table_name", None)
+        cp.pop("identifier", None)
         return cp
 
     def deserialize(self, inp: Dict):

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -8,12 +8,11 @@ def test_serialize_task():
     t = Task.create("123", {1: 2, "a": "b"}, save=False)
     s = t.serialize()
     assert s["metadata"] == {1: 2, "a": "b"}
-    assert s["identifier"] == "123"
     assert isinstance(s["date_created"], str)
     t.date_created = None
     nt = Task()
     nt.deserialize(s)
-    assert nt.identifier == "123"
+    assert nt.identifier is None
     assert nt.metadata == {1: 2, "a": "b"}
     assert isinstance(nt.date_created, datetime)
 
@@ -24,7 +23,6 @@ def test_serialize_installs():
     )
     i = Installation.create(1, ev, save=False)
     s = i.serialize()
-    assert s["identifier"] == 1
     assert s["event_data"]
 
     i2 = Installation()


### PR DESCRIPTION
We don't need it as we use it as a key (hash key field in Redis terms).
Example:
`github_installation` (table/hash) uses `installation_id` as `identifier` and as the key/field so we have it stored 3 times in one entry!
```python
1219102: 
{"identifier": 1219102,
 "event_data": {"trigger": "JobTriggerType.installation",
                         "installation_id": 1219102,
                         ...}
}
```