### PR TITLE
New CoprBuildEvent.from_build_id() to return None if build_id not in DB

### DIFF
--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -239,7 +239,9 @@ class TestEvents:
         assert event_object.copr_chroot == "fedora-29-x86_64"
 
     def test_parse_copr_build_event_start(self, copr_build_results_start):
-        flexmock(CoprBuildDB).should_receive("get_build")
+        flexmock(CoprBuildDB).should_receive("get_build").and_return(
+            {"repo_name": "foo"}
+        )
 
         event_object = Parser.parse_event(copr_build_results_start)
 
@@ -250,9 +252,12 @@ class TestEvents:
         assert event_object.status == 3
         assert event_object.owner == "packit"
         assert event_object.project_name == "packit-service-hello-world-24-stg"
+        assert event_object.base_repo_name == "foo"
 
     def test_parse_copr_build_event_end(self, copr_build_results_end):
-        flexmock(CoprBuildDB).should_receive("get_build")
+        flexmock(CoprBuildDB).should_receive("get_build").and_return(
+            {"repo_name": "foo"}
+        )
 
         event_object = Parser.parse_event(copr_build_results_end)
 
@@ -263,6 +268,7 @@ class TestEvents:
         assert event_object.status == 1
         assert event_object.owner == "packit"
         assert event_object.project_name == "packit-service-hello-world-24-stg"
+        assert event_object.base_repo_name == "foo"
 
     def test_get_project_pr(self, pull_request, mock_config):
         event_object = Parser.parse_event(pull_request)


### PR DESCRIPTION
I'm seeing lots of empty task results in redis:
```
"{\"status\": \"SUCCESS\", \"result\": null, \"traceback\": null, \"children\": [], \"task_id\": \"1e6888d5-c73c-4023-bbca-f308c56c9b41\"}"
```

This change should make `Parser.parse_copr_event()` return `None` instead of empty `CoprBuildEvent`.
That prevents `SteveJobs.process_message()` from running handler and sending empty task results to Celery backend.