### PR TITLE
[fedmsg] install copr json schemas

### DIFF
--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -17,4 +17,5 @@
       # web service needs packit just for few bits (see #109), so hopefully we don't need it from master and RPM is enough
       - python3-packit
       - fedora-messaging
+      - python3-copr-messaging  # json schemas
       state: present


### PR DESCRIPTION
Fixes
```
[WARNING fedora_messaging.message] The schema 'copr.build.end' is not in the schema registry! Either install the package with its schema definition or define a schema. Falling back to the default schema...
```