### PR TITLE
whitelist: treat admins as whitelisted

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,6 @@ services:
       KRB5CCNAME: FILE:/tmp/krb5cc_packit
     volumes:
       - ./packit_service:/src-packit-service/packit_service:ro,z
-      - ./secrets/dev/.packit.yaml:/home/packit/.config/.packit.yaml:ro,z
       # worker should not require packit-service.yaml
       - ./secrets/dev/packit-service.yaml:/home/packit/.config/packit-service.yaml:ro,z
       - ./secrets/dev/copr:/home/packit/.config/copr:ro,z
@@ -79,9 +78,9 @@ services:
     volumes:
       - ./packit_service:/usr/local/lib/python3.7/site-packages/packit_service:ro,z
       # There's no secrets/ by default. You have to create (or symlink to other dir) it yourself.
+      # Make sure that httpd-packit.conf is present, otherwise you'll be getting 404
       - ./secrets/dev/httpd-packit.conf:/etc/httpd/conf.d/httpd-packit.conf:ro,Z
       - ./secrets/dev/packit-service.yaml:/home/packit/.config/packit-service.yaml:ro,z
-      - ./secrets/dev/packit.yaml:/home/packit/.config/.packit.yaml:ro,z
       - ./secrets/dev/fedora.keytab:/secrets/fedora.keytab:ro,z
       - ./secrets/dev/private-key.pem:/secrets/private-key.pem:ro,z
       - ./secrets/dev/fullchain.pem:/secrets/fullchain.pem:ro,z

--- a/files/recipe-worker.yaml
+++ b/files/recipe-worker.yaml
@@ -19,6 +19,7 @@
     file:
       state: directory
       path: /sandcastle
+      mode: 0777
   - name: Copy gitconfig
     copy:
       src: gitconfig

--- a/files/scripts/whitelist.py
+++ b/files/scripts/whitelist.py
@@ -16,6 +16,7 @@ def cli():
 def approve(account_name):
     """
     Approve user who is waiting on whitelist.
+
     :param account_name: github namespace
     :return:
     """
@@ -31,6 +32,7 @@ def approve(account_name):
 def remove(account_name):
     """
     Remove account from whitelist
+
     :param account_name: github namespace
     :return:
     """
@@ -46,7 +48,6 @@ def remove(account_name):
 def waiting():
     """
     Show accounts waiting for approval.
-    :return:
     """
     whitelist = Whitelist()
 

--- a/packit_service/worker/fedmsg_handlers.py
+++ b/packit_service/worker/fedmsg_handlers.py
@@ -84,7 +84,7 @@ def copr_url_from_event(event: CoprBuildEvent):
         logger.debug(f"Reaching url {url}")
         r = requests.get(url)
         r.raise_for_status()
-    except Exception:
+    except requests.RequestException:
         # we might want sentry to know but don't want to start handling things?
         logger.error(f"Failed to reach url with copr chroot build result.")
         url = (

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -113,7 +113,10 @@ class SteveJobs:
                 # check whitelist approval for every job to be able to track down which jobs
                 # failed because of missing whitelist approval
                 whitelist = Whitelist()
-                if not whitelist.check_and_report(event, event.get_project()):
+                github_login = getattr(event, "github_login", None)
+                if github_login and github_login in self.config.admins:
+                    logger.info(f"{github_login} is admin, you shall pass")
+                elif not whitelist.check_and_report(event, event.get_project()):
                     handlers_results[job.job.value] = HandlerResults(
                         success=False, details={"msg": "Account is not whitelisted!"}
                     )
@@ -169,7 +172,10 @@ class SteveJobs:
         # check whitelist approval for every job to be able to track down which jobs
         # failed because of missing whitelist approval
         whitelist = Whitelist()
-        if not whitelist.check_and_report(event, event.get_project()):
+        github_login = getattr(event, "github_login", None)
+        if github_login and github_login in self.config.admins:
+            logger.info(f"{github_login} is admin, you shall pass")
+        elif not whitelist.check_and_report(event, event.get_project()):
             return HandlerResults(
                 success=True, details={"msg": "Account is not whitelisted!"}
             )


### PR DESCRIPTION
\+ random fixes:
* rec-worker: create sandcastle as 0777 (for sake of docker-compose)
* d-c: we no longer have packit.yaml, and docs
* whitelist: polish docstrings
* copr_url_from_event: catch only exceptions from requests