### PR TITLE
moar random commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.py[co]
 .tox
-secrets/
+secrets
 
 .idea/
 .eggs/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,7 @@ services:
     command: /usr/bin/run_httpd.sh
     depends_on:
       - redis
+      - fedora-messaging
     ports:
       - 8443:8443
     environment:
@@ -80,9 +81,22 @@ services:
       # There's no secrets/ by default. You have to create (or symlink to other dir) it yourself.
       # Make sure that httpd-packit.conf is present, otherwise you'll be getting 404
       - ./secrets/dev/httpd-packit.conf:/etc/httpd/conf.d/httpd-packit.conf:ro,Z
+      # Make sure to set `command_handler: local` since there is no kube in d-c
       - ./secrets/dev/packit-service.yaml:/home/packit/.config/packit-service.yaml:ro,z
       - ./secrets/dev/fedora.keytab:/secrets/fedora.keytab:ro,z
       - ./secrets/dev/private-key.pem:/secrets/private-key.pem:ro,z
       - ./secrets/dev/fullchain.pem:/secrets/fullchain.pem:ro,z
       - ./secrets/dev/privkey.pem:/secrets/privkey.pem:ro,z
+    user: "123123"
+
+  fedora-messaging:
+    container_name: fedora-messaging
+    image: usercont/packit-service-fedmsg:latest
+    # command: listen-to-fedora-messaging
+    environment:
+      FEDORA_MESSAGING_CONF: /home/packit/.config/fedora.toml
+      REDIS_SERVICE_HOST: redis
+    volumes:
+      # get it from secrets
+      - ./secrets/dev/fedora.toml:/home/packit/.config/fedora.toml:ro,z
     user: "123123"

--- a/packit_service/worker/fedmsg_handlers.py
+++ b/packit_service/worker/fedmsg_handlers.py
@@ -25,9 +25,9 @@ This file defines classes for job handlers specific for Fedmsg events
 """
 
 import logging
-import requests
 from typing import Type, Optional
 
+import requests
 from packit.api import PackitAPI
 from packit.config import (
     JobType,
@@ -35,11 +35,11 @@ from packit.config import (
     JobConfig,
     get_package_config_from_repo,
 )
-from packit.exceptions import PackitException
 from packit.distgit import DistGit
 from packit.local_project import LocalProject
 from packit.utils import get_namespace_and_repo_name
 
+from packit_service.config import ServiceConfig
 from packit_service.service.events import Event, DistGitEvent, CoprBuildEvent
 from packit_service.worker.copr_db import CoprBuildDB
 from packit_service.worker.github_handlers import GithubTestingFarmHandler
@@ -50,7 +50,6 @@ from packit_service.worker.handler import (
     BuildStatusReporter,
     PRCheckName,
 )
-from packit_service.config import ServiceConfig
 
 logger = logging.getLogger(__name__)
 
@@ -89,7 +88,7 @@ def copr_url_from_event(event: CoprBuildEvent):
     # make sure we provide valid url in status, let sentry handle if not
     try:
         logger.debug(f"Reaching url {url}")
-        r = requests.get(url)
+        r = requests.head(url)
         r.raise_for_status()
     except requests.RequestException:
         # we might want sentry to know but don't want to start handling things?
@@ -98,13 +97,8 @@ def copr_url_from_event(event: CoprBuildEvent):
             "https://copr.fedorainfracloud.org/coprs/"
             f"{event.owner}/{event.project_name}/build/{event.build_id}/"
         )
-        try:
-            logger.debug(f"Reaching url {url}")
-            r = requests.get(url)
-            r.raise_for_status()
-        except Exception:
-            logger.error(f"Failed to reach url with copr build.")
-            raise PackitException("Error while getting copr build url")
+    # return the frontend URL no matter what
+    # we don't want to fail on this step; the error log is just enough
     return url
 
 

--- a/packit_service/worker/fedmsg_handlers.py
+++ b/packit_service/worker/fedmsg_handlers.py
@@ -68,6 +68,13 @@ def do_we_process_fedmsg_topic(topic: str) -> bool:
     return topic in PROCESSED_FEDMSG_TOPICS
 
 
+def get_copr_build_url(event: CoprBuildEvent) -> str:
+    return (
+        "https://copr.fedorainfracloud.org/coprs/"
+        f"{event.owner}/{event.project_name}/build/{event.build_id}/"
+    )
+
+
 def copr_url_from_event(event: CoprBuildEvent):
     """
     Get url to builder-live.log.gz bound to single event
@@ -202,6 +209,7 @@ class CoprBuildEndHandler(FedmsgHandler):
 
         r = BuildStatusReporter(self.event.get_project(), build["commit_sha"])
         url = copr_url_from_event(self.event)
+        build_url = get_copr_build_url(self.event)
 
         msg = "RPMs failed to be built."
         gh_state = "failure"
@@ -220,7 +228,7 @@ class CoprBuildEndHandler(FedmsgHandler):
 
             if not self.was_last_build_successful():
                 msg = (
-                    f"Congratulations! The build [has finished]({url})"
+                    f"Congratulations! The build [has finished]({build_url})"
                     " successfully. :champagne:\n\n"
                     "You can install the built RPMs by following these steps:\n\n"
                     "* `sudo yum install -y dnf-plugins-core` on RHEL 8\n"


### PR DESCRIPTION
```
copr url: use HEAD (performance), don't error out

copr frontend should really be up all the time - if it's not, we may
need to just wait a bit

Related https://github.com/packit-service/packit-service/issues/279
```

```
p-s PR copr build comment: link to copr frontend

...and not to some random log

Fixes #269
```

```
ignore secrets even if it's a symlink
```

```
add fedora-messaging to d-c
```