### PR TITLE
/packit build alias

### DIFF
--- a/packit_service/worker/comment_action_handler.py
+++ b/packit_service/worker/comment_action_handler.py
@@ -39,6 +39,7 @@ class CommentAction(enum.Enum):
     copr_build = "copr-build"
     propose_update = "propose-update"
     test = "test"
+    build = "build"
 
 
 COMMENT_ACTION_HANDLER_MAPPING: Dict[CommentAction, Type["CommentActionHandler"]] = {}
@@ -47,6 +48,16 @@ COMMENT_ACTION_HANDLER_MAPPING: Dict[CommentAction, Type["CommentActionHandler"]
 def add_to_comment_action_mapping(kls: Type["CommentActionHandler"]):
     COMMENT_ACTION_HANDLER_MAPPING[kls.name] = kls
     return kls
+
+
+def add_to_comment_action_mapping_with_name(name):
+    def add_to_comment_action_mapping_with_name_inner(
+        kls: Type["CommentActionHandler"],
+    ):
+        COMMENT_ACTION_HANDLER_MAPPING[name] = kls
+        return kls
+
+    return add_to_comment_action_mapping_with_name_inner
 
 
 class CommentActionHandler(Handler):

--- a/packit_service/worker/github_handlers.py
+++ b/packit_service/worker/github_handlers.py
@@ -59,6 +59,7 @@ from packit_service.worker.comment_action_handler import (
     CommentAction,
     add_to_comment_action_mapping,
     CommentActionHandler,
+    add_to_comment_action_mapping_with_name,
 )
 from packit_service.worker.copr_build import CoprBuildHandler
 from packit_service.worker.handler import (
@@ -455,6 +456,7 @@ class GithubTestingFarmHandler(AbstractGithubJobHandler):
 
 
 @add_to_comment_action_mapping
+@add_to_comment_action_mapping_with_name(name=CommentAction.build)
 class GitHubPullRequestCommentCoprBuildHandler(CommentActionHandler):
     """ Handler for PR comment `/packit copr-build` """
 

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -79,6 +79,17 @@ def test_pr_comment_copr_build_handler(
     assert results["jobs"]["pull_request_action"]["success"]
 
 
+def test_pr_comment_build_handler(
+    mock_pr_comment_functionality, pr_build_comment_event
+):
+    flexmock(CoprBuildHandler).should_receive("run_copr_build").and_return(
+        HandlerResults(success=True, details={})
+    )
+    flexmock(SteveJobs, _is_private=False)
+    results = SteveJobs().process_message(pr_build_comment_event)
+    assert results["jobs"]["pull_request_action"]["success"]
+
+
 def test_pr_comment_empty_handler(
     mock_pr_comment_functionality, pr_empty_comment_event
 ):


### PR DESCRIPTION
- Allow '/packit build' to trigger the copr-build as well.