### PR TITLE
Use released ogr version, not from git master

### DIFF
--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -19,7 +19,8 @@
     pip:
       name:
       - git+https://github.com/packit-service/sandcastle.git
-      - git+https://github.com/packit-service/ogr.git
+      # ogr (released version) is installed in packit image
+      # - git+https://github.com/packit-service/ogr.git
       - persistentdict
       # "We recommend you update your SDK from version 0.12.2 to version 0.12.3"
       - sentry-sdk==0.12.3


### PR DESCRIPTION
@lachmanfrantisek @TomasTomecek WDYT

Do we really need to have latest `ogr` from `git master` in `packit-service-worker`?
Isn't latest released version ([in base packit image](https://github.com/packit-service/packit/blob/master/setup.cfg#L45)) enough?

The thing is that we don't have any `stable` branch in `ogr`, so everytime we rebuild `worker:prod`, it pulls in `ogr` from `master`.