### PR TITLE
[Worker] Install celery from PyPI

### DIFF
--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -7,8 +7,6 @@
       name:
       - python3-ipdb  # for easy debugging
       - nss_wrapper  # openshift anyuid passwd madness
-      - python3-celery # (#107)
-      - python3-redis
       - redis  # redis-cli for debugging
       - origin-clients # for sandcastle
       - python3-kubernetes # for sandcastle
@@ -19,8 +17,6 @@
     pip:
       name:
       - git+https://github.com/packit-service/sandcastle.git
-      # ogr RPM is installed in base packit image
-      # - git+https://github.com/packit-service/ogr.git
       - persistentdict
       # "We recommend you update your SDK from version 0.12.2 to version 0.12.3"
       - sentry-sdk==0.12.3

--- a/files/run_worker.sh
+++ b/files/run_worker.sh
@@ -22,4 +22,4 @@ install -m 0400 /packit-ssh/config .
 grep -q pkgs.fedoraproject.org known_hosts || ssh-keyscan pkgs.fedoraproject.org >>known_hosts
 popd
 
-exec celery-3 worker --app="${APP}" --loglevel=${LOGLEVEL} --concurrency=1
+exec celery worker --app="${APP}" --loglevel=${LOGLEVEL} --concurrency=1

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -1,12 +1,11 @@
 import json
 
-import pytest
 from flexmock import flexmock
+
 from ogr.abstract import GitProject, GitService
 from packit.api import PackitAPI
 from packit.config import PackageConfig, JobConfig, JobType, JobTriggerType
 from packit.exceptions import FailedCreateSRPM
-
 from packit_service.config import ServiceConfig
 from packit_service.service.models import CoprBuild
 from packit_service.worker import sentry_integration
@@ -17,7 +16,6 @@ from packit_service.worker.parser import Parser
 from tests.spellbook import DATA_DIR
 
 
-@pytest.fixture()
 def pull_request():
     with open(DATA_DIR / "webhooks" / "github_pr_event.json", "r") as outfile:
         return json.load(outfile)


### PR DESCRIPTION
since 'celery status/inspect' (needed in Health checks) don't work from RPM