### PR TITLE
No need to configure build for tests

### DIFF
--- a/packit_service/worker/copr_build.py
+++ b/packit_service/worker/copr_build.py
@@ -128,12 +128,19 @@ class CoprBuildHandler(object):
         1. If the job is not defined, use the test_chroots.
         2. If the job is defined, but not the targets, use "fedora-stable" alias otherwise.
         """
-        if not self.job_copr_build:
+        if (
+            (not self.job_copr_build or "targets" not in self.job_copr_build.metadata)
+            and self.job_tests
+            and "targets" in self.job_tests.metadata
+        ):
             return self.tests_chroots
-        configured_targets = self.job_copr_build.metadata.get(
-            "targets", ["fedora-stable"]
-        )
-        return list(get_build_targets(*configured_targets))
+
+        if not self.job_copr_build:
+            raw_targets = ["fedora-stable"]
+        else:
+            raw_targets = self.job_copr_build.metadata.get("targets", ["fedora-stable"])
+
+        return list(get_build_targets(*raw_targets))
 
     @property
     def tests_chroots(self) -> List[str]:

--- a/packit_service/worker/github_handlers.py
+++ b/packit_service/worker/github_handlers.py
@@ -405,9 +405,12 @@ class GithubTestingFarmHandler(AbstractGithubJobHandler):
 
         r = BuildStatusReporter(self.project, self.event.commit_sha)
 
-        chroots = self.job.metadata.get("targets")
-        logger.debug(f"Testing farm chroots: {chroots}")
-        for chroot in chroots:
+        copr_build_handler = CoprBuildHandler(
+            self.config, self.package_config, self.project, self.event
+        )
+        tests_chroots = copr_build_handler.tests_chroots
+        logger.debug(f"Testing farm chroots: {tests_chroots}")
+        for chroot in tests_chroots:
             pipeline_id = str(uuid.uuid4())
             logger.debug(f"Pipeline id: {pipeline_id}")
             payload: dict = {

--- a/packit_service/worker/handler.py
+++ b/packit_service/worker/handler.py
@@ -101,6 +101,14 @@ def add_to_mapping(kls: Type["JobHandler"]):
     return kls
 
 
+def add_to_mapping_for_job(job_type: JobType):
+    def _add_to_mapping(kls: Type["JobHandler"]):
+        JOB_NAME_HANDLER_MAPPING[job_type] = kls
+        return kls
+
+    return _add_to_mapping
+
+
 class BuildStatusReporter:
     def __init__(
         self,

--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -1,0 +1,189 @@
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+import json
+import logging
+import uuid
+from typing import Union
+
+import requests
+from ogr.abstract import GitProject
+from ogr.utils import RequestResponse
+from packit.config import PackageConfig
+
+from packit_service.config import Deployment, ServiceConfig
+from packit_service.constants import TESTING_FARM_TRIGGER_URL
+from packit_service.service.events import (
+    PullRequestEvent,
+    PullRequestCommentEvent,
+    CoprBuildEvent,
+)
+from packit_service.worker.copr_build import JobHelper
+from packit_service.worker.handler import (
+    HandlerResults,
+    PRCheckName,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TestingFarmJobHelper(JobHelper):
+    def __init__(
+        self,
+        config: ServiceConfig,
+        package_config: PackageConfig,
+        project: GitProject,
+        event: Union[
+            PullRequestEvent,
+            PullRequestCommentEvent,
+            CoprBuildEvent,
+            PullRequestCommentEvent,
+        ],
+    ):
+        super().__init__(config, package_config, project, event)
+        self.session = requests.session()
+        adapter = requests.adapters.HTTPAdapter(max_retries=5)
+        self.insecure = False
+        self.session.mount("https://", adapter)
+        self.header: dict = {"Content-Type": "application/json"}
+
+    def run_testing_farm(self):
+        for chroot in self.tests_chroots:
+            pipeline_id = str(uuid.uuid4())
+            logger.debug(f"Pipeline id: {pipeline_id}")
+            payload: dict = {
+                "pipeline": {"id": pipeline_id},
+                "api": {"token": self.config.testing_farm_secret},
+            }
+
+            logger.debug(f"Payload: {payload}")
+
+            stg = "-stg" if self.config.deployment == Deployment.stg else ""
+            copr_repo_name = (
+                f"packit/{self.project.namespace}-{self.project.repo}-"
+                f"{self.event.pr_id}{stg}"
+            )
+
+            payload["artifact"] = {
+                "repo-name": self.event.base_repo_name,
+                "repo-namespace": self.event.base_repo_namespace,
+                "copr-repo-name": copr_repo_name,
+                "copr-chroot": chroot,
+                "commit-sha": self.event.commit_sha,
+                "git-url": self.event.project_url,
+                "git-ref": self.base_ref,
+            }
+
+            logger.debug("Sending testing farm request...")
+            logger.debug(payload)
+
+            req = self.send_testing_farm_request(
+                TESTING_FARM_TRIGGER_URL, "POST", {}, json.dumps(payload)
+            )
+            logger.debug(f"Request sent: {req}")
+            if not req:
+                msg = "Failed to post request to testing farm API."
+                logger.debug("Failed to post request to testing farm API.")
+                self.status_reporter.report(
+                    "failure",
+                    msg,
+                    None,
+                    "",
+                    check_names=PRCheckName.get_testing_farm_check(chroot),
+                )
+                return HandlerResults(success=False, details={"msg": msg})
+            else:
+                logger.debug(
+                    f"Submitted to testing farm with return code: {req.status_code}"
+                )
+
+                """
+                Response:
+                {
+                    "id": "9fa3cbd1-83f2-4326-a118-aad59f5",
+                    "success": true,
+                    "url": "https://console-testing-farm.apps.ci.centos.org/pipeline/<id>"
+                }
+                """
+
+                # success set check on pending
+                if req.status_code != 200:
+                    # something went wrong
+                    msg = req.json()["message"]
+                    self.status_reporter.report(
+                        "failure",
+                        msg,
+                        None,
+                        check_names=PRCheckName.get_testing_farm_check(chroot),
+                    )
+                    return HandlerResults(success=False, details={"msg": msg})
+
+                self.status_reporter.report(
+                    "pending",
+                    "Tests are running ...",
+                    None,
+                    req.json()["url"],
+                    check_names=PRCheckName.get_testing_farm_check(chroot),
+                )
+
+        return HandlerResults(success=True, details={})
+
+    def send_testing_farm_request(
+        self, url: str, method: str = None, params: dict = None, data=None
+    ):
+        method = method or "GET"
+        try:
+            response = self.get_raw_request(
+                method=method, url=url, params=params, data=data
+            )
+        except requests.exceptions.ConnectionError as er:
+            logger.error(er)
+            raise Exception(f"Cannot connect to url: `{url}`.", er)
+        return response
+
+    def get_raw_request(
+        self, url, method="GET", params=None, data=None, header=None
+    ) -> RequestResponse:
+
+        response = self.session.request(
+            method=method,
+            url=url,
+            params=params,
+            headers=header or self.header,
+            data=data,
+            verify=not self.insecure,
+        )
+
+        json_output = None
+        try:
+            json_output = response.json()
+        except ValueError:
+            logger.debug(response.text)
+
+        return RequestResponse(
+            status_code=response.status_code,
+            ok=response.ok,
+            content=response.content,
+            json=json_output,
+            reason=response.reason,
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,12 +108,7 @@ def mock_pr_comment_functionality(request):
         full_repo_name="packit-service/hello-world",
     )
     flexmock(Github, get_repo=lambda full_name_or_id: None)
-    flexmock(GithubProject).should_receive("who_can_merge_pr").and_return(
-        {"phracek"}
-    ).once()
-    flexmock(GithubProject).should_receive("get_all_pr_commits").with_args(
-        9
-    ).and_return(["528b803be6f93e19ca4130bf4976f2800a3004c4"]).once()
+
     config = ServiceConfig()
     config.command_handler_work_dir = SANDCASTLE_WORK_DIR
     flexmock(ServiceConfig).should_receive("get_service_config").and_return(config)

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -24,8 +24,9 @@ import json
 
 import pytest
 from flexmock import flexmock
+from ogr.services.github import GithubProject
 
-from packit_service.worker.copr_build import CoprBuildHandler
+from packit_service.worker.copr_build import CoprBuildJobHelper
 from packit_service.worker.handler import HandlerResults
 from packit_service.worker.jobs import SteveJobs
 from tests.spellbook import DATA_DIR
@@ -71,9 +72,15 @@ def pr_wrong_packit_comment_event():
 def test_pr_comment_copr_build_handler(
     mock_pr_comment_functionality, pr_copr_build_comment_event
 ):
-    flexmock(CoprBuildHandler).should_receive("run_copr_build").and_return(
+    flexmock(CoprBuildJobHelper).should_receive("run_copr_build").and_return(
         HandlerResults(success=True, details={})
     ).once()
+    flexmock(GithubProject).should_receive("who_can_merge_pr").and_return(
+        {"phracek"}
+    ).once()
+    flexmock(GithubProject).should_receive("get_all_pr_commits").with_args(
+        9
+    ).and_return(["528b803be6f93e19ca4130bf4976f2800a3004c4"]).once()
     flexmock(SteveJobs, _is_private=False)
     results = SteveJobs().process_message(pr_copr_build_comment_event)
     assert results["jobs"]["pull_request_action"]["success"]
@@ -82,9 +89,15 @@ def test_pr_comment_copr_build_handler(
 def test_pr_comment_build_handler(
     mock_pr_comment_functionality, pr_build_comment_event
 ):
-    flexmock(CoprBuildHandler).should_receive("run_copr_build").and_return(
+    flexmock(CoprBuildJobHelper).should_receive("run_copr_build").and_return(
         HandlerResults(success=True, details={})
     )
+    flexmock(GithubProject).should_receive("who_can_merge_pr").and_return(
+        {"phracek"}
+    ).once()
+    flexmock(GithubProject).should_receive("get_all_pr_commits").with_args(
+        9
+    ).and_return(["528b803be6f93e19ca4130bf4976f2800a3004c4"]).once()
     flexmock(SteveJobs, _is_private=False)
     results = SteveJobs().process_message(pr_build_comment_event)
     assert results["jobs"]["pull_request_action"]["success"]

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -73,7 +73,7 @@ def test_pr_comment_copr_build_handler(
 ):
     flexmock(CoprBuildHandler).should_receive("run_copr_build").and_return(
         HandlerResults(success=True, details={})
-    )
+    ).once()
     flexmock(SteveJobs, _is_private=False)
     results = SteveJobs().process_message(pr_copr_build_comment_event)
     assert results["jobs"]["pull_request_action"]["success"]

--- a/tests/unit/test_copr_build_handler.py
+++ b/tests/unit/test_copr_build_handler.py
@@ -2,7 +2,7 @@ import pytest
 from flexmock import flexmock
 from packit.config import PackageConfig, JobConfig, JobType, JobTriggerType
 
-from packit_service.worker.copr_build import CoprBuildHandler
+from packit_service.worker.copr_build import CoprBuildJobHelper
 
 
 @pytest.mark.parametrize(
@@ -104,7 +104,7 @@ from packit_service.worker.copr_build import CoprBuildHandler
     ],
 )
 def test_targets(jobs, build_targets, test_targets):
-    copr_build_handler = CoprBuildHandler(
+    copr_build_handler = CoprBuildJobHelper(
         config=flexmock(),
         package_config=PackageConfig(jobs=jobs),
         project=flexmock(),

--- a/tests/unit/test_copr_build_handler.py
+++ b/tests/unit/test_copr_build_handler.py
@@ -1,0 +1,115 @@
+import pytest
+from flexmock import flexmock
+from packit.config import PackageConfig, JobConfig, JobType, JobTriggerType
+
+from packit_service.worker.copr_build import CoprBuildHandler
+
+
+@pytest.mark.parametrize(
+    "jobs,build_targets,test_targets",
+    [
+        pytest.param(
+            [
+                JobConfig(
+                    job=JobType.copr_build,
+                    trigger=JobTriggerType.pull_request,
+                    metadata={"targets": ["fedora-29", "fedora-31"]},
+                )
+            ],
+            {"fedora-29-x86_64", "fedora-31-x86_64"},
+            set(),
+            id="build_with_targets",
+        ),
+        pytest.param(
+            [
+                JobConfig(
+                    job=JobType.copr_build,
+                    trigger=JobTriggerType.pull_request,
+                    metadata={},
+                )
+            ],
+            {"fedora-30-x86_64", "fedora-31-x86_64"},
+            set(),
+            id="build_without_targets",
+        ),
+        pytest.param(
+            [
+                JobConfig(
+                    job=JobType.tests, trigger=JobTriggerType.pull_request, metadata={},
+                )
+            ],
+            {"fedora-30-x86_64", "fedora-31-x86_64"},
+            {"fedora-30-x86_64", "fedora-31-x86_64"},
+            id="test_without_targets",
+        ),
+        pytest.param(
+            [
+                JobConfig(
+                    job=JobType.tests,
+                    trigger=JobTriggerType.pull_request,
+                    metadata={"targets": ["fedora-29", "fedora-31"]},
+                )
+            ],
+            {"fedora-29-x86_64", "fedora-31-x86_64"},
+            {"fedora-29-x86_64", "fedora-31-x86_64"},
+            id="test_with_targets",
+        ),
+        pytest.param(
+            [
+                JobConfig(
+                    job=JobType.copr_build,
+                    trigger=JobTriggerType.pull_request,
+                    metadata={},
+                ),
+                JobConfig(
+                    job=JobType.tests, trigger=JobTriggerType.pull_request, metadata={},
+                ),
+            ],
+            {"fedora-30-x86_64", "fedora-31-x86_64"},
+            {"fedora-30-x86_64", "fedora-31-x86_64"},
+            id="build_without_target&test_without_targets",
+        ),
+        pytest.param(
+            [
+                JobConfig(
+                    job=JobType.copr_build,
+                    trigger=JobTriggerType.pull_request,
+                    metadata={"targets": ["fedora-29", "fedora-31"]},
+                ),
+                JobConfig(
+                    job=JobType.tests, trigger=JobTriggerType.pull_request, metadata={},
+                ),
+            ],
+            {"fedora-29-x86_64", "fedora-31-x86_64"},
+            {"fedora-29-x86_64", "fedora-31-x86_64"},
+            id="build_with_target&test_without_targets",
+        ),
+        pytest.param(
+            [
+                JobConfig(
+                    job=JobType.copr_build,
+                    trigger=JobTriggerType.pull_request,
+                    metadata={},
+                ),
+                JobConfig(
+                    job=JobType.tests,
+                    trigger=JobTriggerType.pull_request,
+                    metadata={"targets": ["fedora-29", "fedora-31"]},
+                ),
+            ],
+            {"fedora-29-x86_64", "fedora-31-x86_64"},
+            {"fedora-29-x86_64", "fedora-31-x86_64"},
+            id="build_without_target&test_with_targets",
+        ),
+    ],
+)
+def test_targets(jobs, build_targets, test_targets):
+    copr_build_handler = CoprBuildHandler(
+        config=flexmock(),
+        package_config=PackageConfig(jobs=jobs),
+        project=flexmock(),
+        event=flexmock(),
+    )
+
+    assert set(copr_build_handler.build_chroots) == build_targets
+    assert set(copr_build_handler.tests_chroots) == test_targets


### PR DESCRIPTION
- Run the build for the test job as well.
- Restructure the handler/helper classes code for build/test
    - Rename `CoprBuildHandler` to `CoprBuildJobHelper` because it's not related to the `Handler` classes in the code.
    - Create `TestingFarmJobHelper` and share the code with the common superclass of the `CoprBuildJobHelper`.
    - Improve `CoprBuildJobHelper` to not need the copr_build job and calculate the right chroots.
        - Fix the aliases for the testing farm.