### PR TITLE
Return task result when copr build started

### DIFF
--- a/packit_service/worker/fedmsg_handlers.py
+++ b/packit_service/worker/fedmsg_handlers.py
@@ -302,3 +302,5 @@ class CoprBuildStartHandler(FedmsgHandler):
             url=copr_url_from_event(self.event),
             check_names=PRCheckName.get_build_check(self.event.chroot),
         )
+        msg = f"Build on {self.event.chroot} in copr has started..."
+        return HandlerResults(success=True, details={"msg": msg})


### PR DESCRIPTION
For this task it has been None many times:

https://sentry.io/organizations/red-hat-0p/issues/?project=1767823&query=is%3Aunresolved+copr_build_started&statsPeriod=90d