### PR TITLE
Make error log less variable so sentry can group

### DIFF
--- a/packit_service/worker/github_handlers.py
+++ b/packit_service/worker/github_handlers.py
@@ -478,7 +478,9 @@ class GitHubIssueCommentProposeUpdateHandler(CommentActionHandler):
                 logger.error(f"error while running a build: {ex}")
                 sync_failed = True
         if sync_failed:
-            return HandlerResults(success=False, details={})
+            return HandlerResults(
+                success=False, details={"msg": "Propose update failed"}
+            )
 
         # Close issue if propose-update was successful in all branches
         self.project.issue_close(self.event.issue_id)

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -260,8 +260,8 @@ class SteveJobs:
 
         task_results = {"jobs": jobs_results, "event": event_object.get_dict()}
 
-        if any(not (v and v["success"]) for v in jobs_results.values()):
-            # Any job handler failed, mark task state as FAILURE
-            logger.error(task_results)
-        # Task state SUCCESS
+        for v in jobs_results.values():
+            if not (v and v["success"]):
+                logger.warning(task_results)
+                logger.error(v["details"]["msg"])
         return task_results


### PR DESCRIPTION
So we don't have: `{'jobs': {'copr_build_started': None}, 'event': {'trigger': 'commit', 'created_at': 157918113` and similar in event titles.

More info: https://docs.sentry.io/platforms/python/logging/