### PR TITLE
Simplify statuses

### DIFF
--- a/packit_service/worker/copr_build.py
+++ b/packit_service/worker/copr_build.py
@@ -382,7 +382,7 @@ class CoprBuildJobHelper(JobHelper):
     def _process_failed_srpm_build(self, ex):
         sentry_integration.send_to_sentry(ex)
         msg = (
-            f"There was an error while creating the SRPM. {MSG_RETRIGGER}\n"
+            f"There was an error while creating SRPM. {MSG_RETRIGGER}\n"
             "\nOutput:"
             "\n```\n"
             f"{ex}"
@@ -400,7 +400,7 @@ class CoprBuildJobHelper(JobHelper):
         else:
             output = ex.output
         msg = (
-            f"There was an error while creating the SRPM. {MSG_RETRIGGER}\n"
+            f"There was an error while creating SRPM. {MSG_RETRIGGER}\n"
             "\nOutput:"
             "\n```\n"
             f"{output}"
@@ -416,7 +416,7 @@ class CoprBuildJobHelper(JobHelper):
         return HandlerResults(success=False, details={"msg": msg})
 
     def _process_timeout(self):
-        msg = f"You have reached 10-minute timeout while creating the SRPM. {MSG_RETRIGGER}"
+        msg = f"You have reached 10-minute timeout while creating SRPM. {MSG_RETRIGGER}"
         self.project.pr_comment(self.event.pr_id, msg)
         msg = "Timeout reached while creating a SRPM."
         self.report_status_to_all(

--- a/packit_service/worker/copr_build.py
+++ b/packit_service/worker/copr_build.py
@@ -231,6 +231,30 @@ class JobHelper:
             )
         return self.default_project_name
 
+    def report_status_to_all(
+        self, description: str, state: str, url: str = None
+    ) -> None:
+        self.report_status_to_build(description, state, url)
+        self.report_status_to_tests(description, state, url)
+
+    def report_status_to_build(self, description, state, url: str = None):
+        if self.job_copr_build:
+            self.status_reporter.report(
+                description=description,
+                state=state,
+                url=url,
+                check_names=self.build_check_names,
+            )
+
+    def report_status_to_tests(self, description, state, url: str = None):
+        if self.job_tests:
+            self.status_reporter.report(
+                description=description,
+                state=state,
+                url=url,
+                check_names=self.test_check_names,
+            )
+
 
 class CoprBuildJobHelper(JobHelper):
     @property
@@ -270,26 +294,20 @@ class CoprBuildJobHelper(JobHelper):
             # we can't report it to end-user at this stage
             return HandlerResults(success=False, details={"msg": msg})
 
-        if self.job_tests:
-            self.status_reporter.report_tests_waiting_for_build(
-                test_check_names=self.test_check_names
-            )
-
         try:
-            self.status_reporter.report_srpm_build_start(
-                build_check_names=self.build_check_names
-            )
+            self.report_status_to_all(description="Building SRPM ...", state="pending")
             build_id, _ = self.api.run_copr_build(
                 project=self.job_project,
                 chroots=self.build_chroots,
                 owner=self.job_owner,
             )
-            self.status_reporter.report_srpm_build_finish()
-            self.status_reporter.report_rpm_build_start(
-                build_check_names=self.build_check_names,
+            self.report_status_to_all(
+                description="Building RPM ...",
+                state="pending",
                 url="https://copr.fedorainfracloud.org/coprs/"
                 f"{self.job_owner}/{self.job_project}/build/{build_id}/",
             )
+
             # Save copr build with commit information to be able to report status back
             # after fedmsg copr.build.end arrives
             copr_build_db = CoprBuildDB()
@@ -340,13 +358,9 @@ class CoprBuildJobHelper(JobHelper):
         )
         logger.error(msg)
         self.project.pr_comment(self.event.pr_id, f"{msg}\n{MSG_RETRIGGER}")
-        self.status_reporter.report(
-            state="failure",
-            description="Submit of the build failed, check latest comment for details.",
-            check_names=self.build_check_names,
-        )
-        self.status_reporter.report_tests_failed_because_of_the_build_submit(
-            test_check_names=self.test_check_names
+        self.report_status_to_all(
+            state="error",
+            description="Submit of the build failed, check comments for details.",
         )
         return HandlerResults(success=False, details={"msg": msg})
 
@@ -355,13 +369,13 @@ class CoprBuildJobHelper(JobHelper):
         msg = f"There was an error while running a copr build:\n```\n{ex}\n```\n"
         logger.error(msg)
         self.project.pr_comment(self.event.pr_id, f"{msg}\n{MSG_RETRIGGER}")
-        self.status_reporter.report(
+        self.report_status_to_build(
             state="failure",
             description="Build failed, check latest comment for details.",
-            check_names=self.build_check_names,
         )
-        self.status_reporter.report_tests_failed_because_of_the_build(
-            test_check_names=self.test_check_names
+        self.report_status_to_tests(
+            state="error",
+            description="Build failed, check latest comment for details.",
         )
         return HandlerResults(success=False, details={"msg": msg})
 
@@ -375,18 +389,8 @@ class CoprBuildJobHelper(JobHelper):
             "\n```"
         )
         self.project.pr_comment(self.event.pr_id, msg)
-        short_msg = "Failed to create the SRPM."
-        self.status_reporter.report(
-            state="failure",
-            description=short_msg,
-            check_names=PRCheckName.get_srpm_build_check(),
-        )
-        self.status_reporter.report_rpm_build_failed_because_of_the_srpm_fail(
-            build_check_names=self.build_check_names
-        )
-        self.status_reporter.report_tests_failed_because_of_the_build(
-            test_check_names=self.test_check_names
-        )
+        short_msg = "Failed to create SRPM."
+        self.report_status_to_all(description=short_msg, state="error")
         return HandlerResults(success=False, details={"msg": short_msg})
 
     def _process_failed_command(self, ex):
@@ -396,7 +400,7 @@ class CoprBuildJobHelper(JobHelper):
         else:
             output = ex.output
         msg = (
-            f"There was an error while creating a SRPM. {MSG_RETRIGGER}\n"
+            f"There was an error while creating the SRPM. {MSG_RETRIGGER}\n"
             "\nOutput:"
             "\n```\n"
             f"{output}"
@@ -405,11 +409,9 @@ class CoprBuildJobHelper(JobHelper):
         )
         self.project.pr_comment(self.event.pr_id, msg)
         sentry_integration.send_to_sentry(output)
-        msg = "Failed to create a SRPM."
-        self.status_reporter.report(
-            state="failure",
-            description=msg,
-            check_names=PRCheckName.get_srpm_build_check(),
+        msg = "Failed to create SRPM."
+        self.report_status_to_all(
+            state="error", description=msg,
         )
         return HandlerResults(success=False, details={"msg": msg})
 
@@ -417,11 +419,8 @@ class CoprBuildJobHelper(JobHelper):
         msg = f"You have reached 10-minute timeout while creating the SRPM. {MSG_RETRIGGER}"
         self.project.pr_comment(self.event.pr_id, msg)
         msg = "Timeout reached while creating a SRPM."
-        self.status_reporter.report(
-            state="failure", description=msg, check_names=self.build_check_names
-        )
-        self.status_reporter.report_tests_failed_because_of_the_build(
-            test_check_names=self.test_check_names
+        self.report_status_to_all(
+            state="error", description=msg,
         )
         return HandlerResults(success=False, details={"msg": msg})
 
@@ -457,12 +456,7 @@ class CoprBuildJobHelper(JobHelper):
         )
         self.project.pr_comment(self.event.pr_id, comment_msg)
 
-        self.status_reporter.report(
-            state="failure",
-            description="Build failed, check latest comment for details.",
-            check_names=self.build_check_names,
-        )
-        self.status_reporter.report_tests_failed_because_of_the_build(
-            test_check_names=self.test_check_names
+        self.report_status_to_all(
+            state="error", description="Build failed, check the comments for details.",
         )
         return HandlerResults(success=False, details={"msg": msg})

--- a/packit_service/worker/fedmsg_handlers.py
+++ b/packit_service/worker/fedmsg_handlers.py
@@ -295,7 +295,7 @@ class CoprBuildStartHandler(FedmsgHandler):
             logger.debug(msg)
             return HandlerResults(success=True, details={"msg": msg})
 
-        self.build_job_helper.status_reporter(
+        self.build_job_helper.status_reporter.report(
             state="pending",
             description="RPM build has started...",
             url=copr_url_from_event(self.event),

--- a/packit_service/worker/handler.py
+++ b/packit_service/worker/handler.py
@@ -143,7 +143,9 @@ class BuildStatusReporter:
             check_names = [check_names]
 
         for check in check_names:
-            self.set_status(state, description, check, url)
+            self.set_status(
+                state=state, description=description, check_name=check, url=url
+            )
 
     def set_status(self, state: str, description: str, check_name: str, url: str = ""):
         logger.debug(f"Setting status for check '{check_name}': {description}")
@@ -153,65 +155,6 @@ class BuildStatusReporter:
 
     def get_statuses(self):
         self.project.get_commit_statuses(commit=self.commit_sha)
-
-    def report_srpm_build_start(self, build_check_names):
-        self.report(
-            state="pending",
-            description="SRPM build has just started...",
-            check_names=PRCheckName.get_srpm_build_check(),
-        )
-        self.report(
-            state="pending",
-            description="RPM build is waiting for successful SPRM build",
-            check_names=build_check_names,
-        )
-
-    def report_srpm_build_finish(self):
-        self.report(
-            state="success",
-            description="SRPM was built successfully.",
-            check_names=PRCheckName.get_srpm_build_check(),
-        )
-
-    def report_rpm_build_start(self, url, build_check_names):
-        self.report(
-            state="pending",
-            description="RPM build has just started...",
-            check_names=build_check_names,
-            url=url,
-        )
-
-    def report_tests_waiting_for_build(self, test_check_names):
-        self.report(
-            state="pending",
-            url="",
-            description="Waiting for a successful RPM build",
-            check_names=test_check_names,
-        )
-
-    def report_rpm_build_failed_because_of_the_srpm_fail(self, build_check_names):
-        self.report(
-            state="failure",
-            url="",
-            description="Failed to create the SRPM. No RPM build will be run.",
-            check_names=build_check_names,
-        )
-
-    def report_tests_failed_because_of_the_build(self, test_check_names):
-        self.report(
-            state="failure",
-            url="",
-            description="RPM build failed. No tests will be run.",
-            check_names=test_check_names,
-        )
-
-    def report_tests_failed_because_of_the_build_submit(self, test_check_names):
-        self.report(
-            state="failure",
-            url="",
-            description="Submitting of the build failed. Cannot get the build results.",
-            check_names=test_check_names,
-        )
 
 
 class HandlerResults(dict):

--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -120,8 +120,6 @@ class TestingFarmJobHelper(JobHelper):
             "api": {"token": self.config.testing_farm_secret},
         }
 
-        logger.debug(f"Payload: {payload}")
-
         stg = "-stg" if self.config.deployment == Deployment.stg else ""
         copr_repo_name = (
             f"packit/{self.project.namespace}-{self.project.repo}-"

--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -95,7 +95,8 @@ class TestingFarmJobHelper(JobHelper):
 
     def run_testing_farm(self, chroot: str) -> HandlerResults:
         if chroot not in self.tests_chroots:
-            # Who triggered that?
+            # Leaving here just to be sure that we will discover this situation if it occurs.
+            # Currently not possible to trigger this situation.
             msg = f"Target '{chroot}' not defined for tests but triggered."
             logger.error(msg)
             send_to_sentry(PackitConfigException(msg))

--- a/packit_service/worker/testing_farm_handlers.py
+++ b/packit_service/worker/testing_farm_handlers.py
@@ -78,10 +78,9 @@ class TestingFarmResultsHandler(AbstractGithubJobHandler):
             status = "failure"
 
         r.report(
-            status,
-            self.event.message,
-            None,
-            self.event.log_url,
+            state=status,
+            description=self.event.message,
+            url=self.event.log_url,
             check_names=PRCheckName.get_testing_farm_check(self.event.copr_chroot),
         )
 


### PR DESCRIPTION
- Do not create aditional statuses.
- Run testing farm for one target after copr build-end.


----

Fixes: #330 