### PR TITLE
Fix `None` url

### DIFF
--- a/packit_service/worker/copr_build.py
+++ b/packit_service/worker/copr_build.py
@@ -231,13 +231,11 @@ class JobHelper:
             )
         return self.default_project_name
 
-    def report_status_to_all(
-        self, description: str, state: str, url: str = None
-    ) -> None:
+    def report_status_to_all(self, description: str, state: str, url: str = "") -> None:
         self.report_status_to_build(description, state, url)
         self.report_status_to_tests(description, state, url)
 
-    def report_status_to_build(self, description, state, url: str = None):
+    def report_status_to_build(self, description, state, url: str = ""):
         if self.job_copr_build:
             self.status_reporter.report(
                 description=description,
@@ -246,7 +244,7 @@ class JobHelper:
                 check_names=self.build_check_names,
             )
 
-    def report_status_to_tests(self, description, state, url: str = None):
+    def report_status_to_tests(self, description, state, url: str = ""):
         if self.job_tests:
             self.status_reporter.report(
                 description=description,

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -69,7 +69,7 @@ def test_copr_build_check_names():
         state="pending",
         description="Building SRPM ...",
         check_name="packit-stg/rpm-build-bright-future-x86_64",
-        url=None,
+        url="",
     ).and_return()
     flexmock(BuildStatusReporter).should_receive("set_status").with_args(
         state="pending",


### PR DESCRIPTION
- Url on status defaults to empty string.
- fixes:
  - https://sentry.io/organizations/red-hat-0p/issues/1450159324/?project=1767823&query=is%3Aunresolved
  - https://sentry.io/organizations/red-hat-0p/issues/1456032269/?project=1767823&query=is%3Aunresolved

-----

- 1:0 Recure x flexmock ...;-)