### PR TITLE
Use intermediate log url for copr build in progress

### DIFF
--- a/packit_service/worker/fedmsg_handlers.py
+++ b/packit_service/worker/fedmsg_handlers.py
@@ -76,14 +76,15 @@ def get_copr_build_url(event: CoprBuildEvent) -> str:
 
 def copr_url_from_event(event: CoprBuildEvent):
     """
-    Get url to builder-live.log.gz bound to single event
+    Get url to builder-live.log bound to single event
+    After build is finished copr redirects it automatically to builder-live.log.gz
     :param event: fedora messaging event from topic copr.build.start or copr.build.end
     :return: reachable url
     """
     url = (
         f"https://copr-be.cloud.fedoraproject.org/results/{event.owner}/"
         f"{event.project_name}/{event.chroot}/"
-        f"{event.build_id:08d}-{event.pkg}/builder-live.log.gz"
+        f"{event.build_id:08d}-{event.pkg}/builder-live.log"
     )
     # make sure we provide valid url in status, let sentry handle if not
     try:

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -98,7 +98,7 @@ def test_copr_build_end(copr_build_end):
     url = (
         f"https://copr-be.cloud.fedoraproject.org/results/"
         f"packit/packit-service-hello-world-24-stg/fedora-rawhide-x86_64/"
-        f"01044215-hello/builder-live.log.gz"
+        f"01044215-hello/builder-live.log"
     )
     flexmock(requests).should_receive("get").and_return(requests.Response())
     flexmock(requests.Response).should_receive("raise_for_status").and_return(None)
@@ -171,7 +171,7 @@ def test_copr_build_end_testing_farm(copr_build_end):
     url = (
         f"https://copr-be.cloud.fedoraproject.org/results/"
         f"packit/packit-service-hello-world-24-stg/fedora-rawhide-x86_64/"
-        f"01044215-hello/builder-live.log.gz"
+        f"01044215-hello/builder-live.log"
     )
     flexmock(requests).should_receive("get").and_return(requests.Response())
     flexmock(requests.Response).should_receive("raise_for_status").and_return(None)
@@ -264,7 +264,7 @@ def test_copr_build_end_failed_testing_farm(copr_build_end):
     url = (
         f"https://copr-be.cloud.fedoraproject.org/results/"
         f"packit/packit-service-hello-world-24-stg/fedora-rawhide-x86_64/"
-        f"01044215-hello/builder-live.log.gz"
+        f"01044215-hello/builder-live.log"
     )
     flexmock(requests).should_receive("get").and_return(requests.Response())
     flexmock(requests.Response).should_receive("raise_for_status").and_return(None)
@@ -356,7 +356,7 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end):
     url = (
         f"https://copr-be.cloud.fedoraproject.org/results/"
         f"packit/packit-service-hello-world-24-stg/fedora-rawhide-x86_64/"
-        f"01044215-hello/builder-live.log.gz"
+        f"01044215-hello/builder-live.log"
     )
     flexmock(requests).should_receive("get").and_return(requests.Response())
     flexmock(requests.Response).should_receive("raise_for_status").and_return(None)
@@ -435,7 +435,7 @@ def test_copr_build_start(copr_build_start):
     url = (
         f"https://copr-be.cloud.fedoraproject.org/results/"
         f"packit/packit-service-hello-world-24-stg/fedora-rawhide-x86_64/"
-        f"01044215-hello/builder-live.log.gz"
+        f"01044215-hello/builder-live.log"
     )
     flexmock(requests).should_receive("get").and_return(requests.Response())
     flexmock(requests.Response).should_receive("raise_for_status").and_return(None)
@@ -497,7 +497,7 @@ def test_copr_build_not_comment_on_success(copr_build_end):
     url = (
         f"https://copr-be.cloud.fedoraproject.org/results/"
         f"packit/packit-service-hello-world-24-stg/fedora-rawhide-x86_64/"
-        f"01044215-hello/builder-live.log.gz"
+        f"01044215-hello/builder-live.log"
     )
     flexmock(requests).should_receive("get").and_return(requests.Response())
     flexmock(requests.Response).should_receive("raise_for_status").and_return(None)


### PR DESCRIPTION
The log is stored in `builder-live.log`. When the build is finished, the log file is compressed to `builder-live.log.gz` (Confirmed with @praiskup)


Fixes: https://sentry.io/organizations/red-hat-0p/issues/1450335609