### PR TITLE
Set ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@
 FROM fedora:31
 
 ENV LANG=en_US.UTF-8 \
+    ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3 \
     ANSIBLE_STDOUT_CALLBACK=debug \
     USER=packit \
     HOME=/home/packit

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -2,6 +2,9 @@
 
 FROM docker.io/usercont/packit-service-worker:dev
 
+ENV ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3 \
+    ANSIBLE_STDOUT_CALLBACK=debug
+
 # Since we use worker base image, we need to install service deps manually
 COPY files/install-deps.yaml /src/files/
 RUN cd /src/ \

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -3,6 +3,7 @@
 FROM docker.io/usercont/packit
 
 ENV LANG=en_US.UTF-8 \
+    ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3 \
     ANSIBLE_STDOUT_CALLBACK=debug \
     USER=packit \
     HOME=/home/packit \

--- a/Dockerfile.worker.prod
+++ b/Dockerfile.worker.prod
@@ -4,6 +4,7 @@
 FROM docker.io/usercont/packit:prod
 
 ENV LANG=en_US.UTF-8 \
+    ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3 \
     ANSIBLE_STDOUT_CALLBACK=debug \
     USER=packit \
     HOME=/home/packit \

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -81,6 +81,7 @@ def test_pr_comment_copr_build_handler(
     flexmock(GithubProject).should_receive("get_all_pr_commits").with_args(
         9
     ).and_return(["528b803be6f93e19ca4130bf4976f2800a3004c4"]).once()
+    flexmock(GithubProject, get_files="foo.spec")
     flexmock(SteveJobs, _is_private=False)
     results = SteveJobs().process_message(pr_copr_build_comment_event)
     assert results["jobs"]["pull_request_action"]["success"]
@@ -98,6 +99,7 @@ def test_pr_comment_build_handler(
     flexmock(GithubProject).should_receive("get_all_pr_commits").with_args(
         9
     ).and_return(["528b803be6f93e19ca4130bf4976f2800a3004c4"]).once()
+    flexmock(GithubProject, get_files="foo.spec")
     flexmock(SteveJobs, _is_private=False)
     results = SteveJobs().process_message(pr_build_comment_event)
     assert results["jobs"]["pull_request_action"]["success"]

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -22,7 +22,7 @@ def release_event():
 
 def test_dist_git_push_release_handle(release_event):
     packit_yaml = (
-        "{'specfile_path': '', 'synced_files': []"
+        "{'specfile_path': 'hello-world.spec', 'synced_files': []"
         ", jobs: [{trigger: release, job: propose_downstream, metadata: {targets:[]}}]}"
     )
     flexmock(Github, get_repo=lambda full_name_or_id: None)
@@ -49,7 +49,7 @@ def test_dist_git_push_release_handle(release_event):
 
 def test_dist_git_push_release_handle_multiple_branches(release_event):
     packit_yaml = (
-        "{'specfile_path': '', 'synced_files': []"
+        "{'specfile_path': 'hello-world.spec', 'synced_files': []"
         ", jobs: [{trigger: release, job: propose_downstream, "
         "metadata: {targets:[], dist-git-branch: fedora-all}}]}"
     )
@@ -85,7 +85,7 @@ def test_dist_git_push_release_handle_multiple_branches(release_event):
 
 def test_dist_git_push_release_handle_one_failed(release_event):
     packit_yaml = (
-        "{'specfile_path': '', 'synced_files': []"
+        "{'specfile_path': 'hello-world.spec', 'synced_files': []"
         ", jobs: [{trigger: release, job: propose_downstream, "
         "metadata: {targets:[], dist-git-branch: fedora-all}}]}"
     )
@@ -123,7 +123,7 @@ def test_dist_git_push_release_handle_one_failed(release_event):
 
 def test_dist_git_push_release_handle_all_failed(release_event):
     packit_yaml = (
-        "{'specfile_path': '', 'synced_files': []"
+        "{'specfile_path': 'hello-world.spec', 'synced_files': []"
         ", jobs: [{trigger: release, job: propose_downstream, "
         "metadata: {targets:[], dist-git-branch: fedora-all}}]}"
     )

--- a/tests/unit/test_steve.py
+++ b/tests/unit/test_steve.py
@@ -56,7 +56,7 @@ from packit_service.worker.whitelist import Whitelist
 )
 def test_process_message(event):
     packit_yaml = {
-        "specfile_path": "",
+        "specfile_path": "bar.spec",
         "synced_files": [],
         "jobs": [{"trigger": "release", "job": "propose_downstream"}],
     }


### PR DESCRIPTION
Recently, ansible started to warn:
```
[DEPRECATION WARNING]: Distribution fedora 31 on host localhost should use
/usr/bin/python3, but is using /usr/bin/python for backward compatibility with
prior Ansible releases. A future Ansible release will default to using the
discovered platform python for this host. See https://docs.ansible.com/ansible/
2.9/reference_appendices/interpreter_discovery.html for more information. This
feature will be removed in version 2.12. Deprecation warnings can be disabled
by setting deprecation_warnings=False in ansible.cfg.
```

Fixes #385 