### PR TITLE
Allow empty tests in testing farm result

### DIFF
--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -400,7 +400,7 @@ class Parser:
                 result=TestingFarmResult(raw_test["result"]),
                 log_url=raw_test.get("log"),
             )
-            for raw_test in event.get("tests")
+            for raw_test in event.get("tests", [])
         ]
 
         logger.info(f"Results from Testing farm event. Pipeline ID: {pipeline_id}")


### PR DESCRIPTION
The use should stay fine even with empty list: https://github.com/packit-service/packit-service/blob/master/packit_service/worker/testing_farm_handlers.py#L80

The log message will be:
```
Received testing-farm test results:
[]
```

Let me know if you want to change that.