### PR TITLE
Fix report in whitelist

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -6,12 +6,8 @@ SANDCASTLE_PVC = "SANDCASTLE_PVC"
 
 CONFIG_FILE_NAME = "packit-service.yaml"
 
-PACKIT_PROD_ACCOUNT_CHECK = "packit/authorized-to-build"
-PACKIT_STG_ACCOUNT_CHECK = "packit-stg/authorized-to-build"
 PACKIT_PROD_CHECK = "packit/rpm-build"
 PACKIT_STG_CHECK = "packit-stg/rpm-build"
-PACKIT_PROD_SRPM_CHECK = "packit/srpm-build"
-PACKIT_STG_SRPM_CHECK = "packit-stg/srpm-build"
 PACKIT_PROD_TESTING_FARM_CHECK = "packit/testing-farm"
 PACKIT_STG_TESTING_FARM_CHECK = "packit-stg/testing-farm"
 

--- a/packit_service/worker/github_handlers.py
+++ b/packit_service/worker/github_handlers.py
@@ -141,7 +141,7 @@ class GithubAppInstallationHandler(AbstractGithubJobHandler):
         )
         # try to add user to whitelist
         whitelist = Whitelist(
-            fas_user=self.config.fas_user, fas_password=self.config.fas_password
+            fas_user=self.config.fas_user, fas_password=self.config.fas_password,
         )
         account_login = self.installation_event.account_login
         account_type = self.installation_event.account_type

--- a/packit_service/worker/handler.py
+++ b/packit_service/worker/handler.py
@@ -37,10 +37,6 @@ from packit_service.config import Deployment, ServiceConfig
 from packit_service.constants import (
     PACKIT_PROD_CHECK,
     PACKIT_STG_CHECK,
-    PACKIT_PROD_ACCOUNT_CHECK,
-    PACKIT_STG_ACCOUNT_CHECK,
-    PACKIT_PROD_SRPM_CHECK,
-    PACKIT_STG_SRPM_CHECK,
     PACKIT_PROD_TESTING_FARM_CHECK,
     PACKIT_STG_TESTING_FARM_CHECK,
 )
@@ -56,20 +52,6 @@ class PRCheckName:
     """
     This is class providing static methods for getting check names according to deployment
     """
-
-    @staticmethod
-    def get_account_check() -> str:
-        config = ServiceConfig.get_service_config()
-        if config.deployment == Deployment.prod:
-            return PACKIT_PROD_ACCOUNT_CHECK
-        return PACKIT_STG_ACCOUNT_CHECK
-
-    @staticmethod
-    def get_srpm_build_check() -> str:
-        config = ServiceConfig.get_service_config()
-        if config.deployment == Deployment.prod:
-            return PACKIT_PROD_SRPM_CHECK
-        return PACKIT_STG_SRPM_CHECK
 
     @staticmethod
     def get_build_check(chroot: str = None) -> str:

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -30,6 +30,7 @@ from typing import Optional, Dict, Union, Type
 from ogr.abstract import GitProject
 from ogr.services.github import GithubProject
 from packit.config import JobTriggerType, JobType
+
 from packit_service.config import ServiceConfig
 from packit_service.service.events import (
     PullRequestCommentEvent,
@@ -116,7 +117,9 @@ class SteveJobs:
                 github_login = getattr(event, "github_login", None)
                 if github_login and github_login in self.config.admins:
                     logger.info(f"{github_login} is admin, you shall pass")
-                elif not whitelist.check_and_report(event, event.get_project()):
+                elif not whitelist.check_and_report(
+                    event, event.get_project(), config=self.config
+                ):
                     handlers_results[job.job.value] = HandlerResults(
                         success=False, details={"msg": "Account is not whitelisted!"}
                     )
@@ -175,7 +178,9 @@ class SteveJobs:
         github_login = getattr(event, "github_login", None)
         if github_login and github_login in self.config.admins:
             logger.info(f"{github_login} is admin, you shall pass")
-        elif not whitelist.check_and_report(event, event.get_project()):
+        elif not whitelist.check_and_report(
+            event, event.get_project(), config=self.config
+        ):
             return HandlerResults(
                 success=True, details={"msg": "Account is not whitelisted!"}
             )


### PR DESCRIPTION
- Remove code related to static checks.
- Use JobHelper in whitelist to correctly report failure.

Fixes https://github.com/packit-service/packit-service/issues/382