### PR TITLE
Test with Docker CE

### DIFF
--- a/files/install-openshift.yaml
+++ b/files/install-openshift.yaml
@@ -9,7 +9,6 @@
           - git
           - rpmdevtools
           - docker
-          - podman
         state: present
       become: true
     - name: Put SELinux in permissive mode, logging actions that would be blocked.

--- a/files/install-openshift.yaml
+++ b/files/install-openshift.yaml
@@ -8,7 +8,21 @@
         name:
           - git
           - rpmdevtools
-          - docker
+        state: present
+      become: true
+    # Docs: https://docs.docker.com/install/linux/docker-ce/fedora/
+    - name: Setup Docker CE repo
+      get_url:
+        url: https://download.docker.com/linux/fedora/docker-ce.repo
+        dest: /etc/yum.repos.d/docker-ce.repo
+        mode: 0644
+      become: true
+    - name: Install Docker CE
+      dnf:
+        name:
+          - docker-ce
+          - docker-ce-cli
+          - containerd.io
         state: present
       become: true
     - name: Put SELinux in permissive mode, logging actions that would be blocked.


### PR DESCRIPTION
We started to have this issue with `oc cluster up` yesterday, where the
OpenShift pods would fail to start, so all the tests turned red.

After much time spent and failing to find out the root cause, I've
decided to go with the solution I know it works, that is using Docker
CE, instead of docker from Fedora 30.

See #395 for the history.