### PR TITLE
don't apply migrations since we don't have any, yet

### DIFF
--- a/files/run_httpd.sh
+++ b/files/run_httpd.sh
@@ -9,8 +9,9 @@ export LD_PRELOAD=libnss_wrapper.so
 export NSS_WRAPPER_PASSWD=${HOME}/passwd
 export NSS_WRAPPER_GROUP=/etc/group
 
-pushd /src
-alembic upgrade head
-popd
+# uncomment this after we have some migrations
+# pushd /src
+# alembic upgrade head
+# popd
 
 httpd -DFOREGROUND


### PR DESCRIPTION
should fix `FileNotFoundError: [Errno 2] No such file or directory: '/src/alembic/versions'`