### PR TITLE
logs: set copr build logs url when a build start

### DIFF
--- a/packit_service/worker/copr_build.py
+++ b/packit_service/worker/copr_build.py
@@ -39,12 +39,12 @@ from sandcastle import SandcastleCommandFailed, SandcastleTimeoutReached
 
 from packit_service.config import ServiceConfig, Deployment
 from packit_service.constants import MSG_RETRIGGER
+from packit_service.models import CoprBuild, SRPMBuild
 from packit_service.service.events import (
     PullRequestEvent,
     PullRequestCommentEvent,
     CoprBuildEvent,
 )
-from packit_service.models import CoprBuild, SRPMBuild
 from packit_service.service.models import CoprBuild as RedisCoprBuild
 from packit_service.service.urls import get_log_url
 from packit_service.worker import sentry_integration

--- a/packit_service/worker/fedmsg_handlers.py
+++ b/packit_service/worker/fedmsg_handlers.py
@@ -260,6 +260,8 @@ class CoprBuildEndHandler(FedmsgHandler):
                 url=url,
                 chroot=self.event.chroot,
             )
+            if build_pg:
+                build_pg.set_status(gh_state)
 
             if (
                 self.build_job_helper.job_tests
@@ -282,7 +284,6 @@ class CoprBuildEndHandler(FedmsgHandler):
             state=gh_state, description=failed_msg, url=url, chroot=self.event.chroot,
         )
         if build_pg:
-            build_pg.set_build_logs_url(get_copr_build_logs_url(self.event))
             build_pg.set_status(gh_state)
         return HandlerResults(success=False, details={"msg": failed_msg})
 
@@ -333,6 +334,8 @@ class CoprBuildStartHandler(FedmsgHandler):
         if build_pg:
             url = get_log_url(build_pg.id)
             build_pg.set_status(status)
+            copr_build_logs = get_copr_build_logs_url(self.event)
+            build_pg.set_build_logs_url(copr_build_logs)
         else:
             url = copr_url_from_event(self.event)
 

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -107,6 +107,7 @@ def test_copr_build_end(copr_build_end, pc_build, copr_build):
     flexmock(GithubProject).should_receive("pr_comment")
 
     flexmock(CoprBuild).should_receive("get_by_build_id").and_return(copr_build)
+    flexmock(CoprBuild).should_receive("set_status").with_args("success")
     flexmock(CoprBuildDB).should_receive("get_build").and_return(
         {
             "commit_sha": "XXXXX",
@@ -176,6 +177,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build):
     flexmock(LocalProject).should_receive("refresh_the_arguments").and_return(None)
 
     flexmock(CoprBuild).should_receive("get_by_build_id").and_return(copr_build)
+    flexmock(CoprBuild).should_receive("set_status").with_args("success")
     flexmock(CoprBuildDB).should_receive("get_build").and_return(
         {
             "commit_sha": "XXXXX",
@@ -272,6 +274,7 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build):
     flexmock(LocalProject).should_receive("refresh_the_arguments").and_return(None)
 
     flexmock(CoprBuild).should_receive("get_by_build_id").and_return(copr_build)
+    flexmock(CoprBuild).should_receive("set_status").with_args("success")
     flexmock(CoprBuildDB).should_receive("get_build").and_return(
         {
             "commit_sha": "XXXXX",
@@ -366,6 +369,7 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build):
     flexmock(LocalProject).should_receive("refresh_the_arguments").and_return(None)
 
     flexmock(CoprBuild).should_receive("get_by_build_id").and_return(copr_build)
+    flexmock(CoprBuild).should_receive("set_status").with_args("success")
     flexmock(CoprBuildDB).should_receive("get_build").and_return(
         {
             "commit_sha": "XXXXX",
@@ -455,7 +459,8 @@ def test_copr_build_start(copr_build_start, pc_build, copr_build):
     flexmock(requests).should_receive("get").and_return(requests.Response())
     flexmock(requests.Response).should_receive("raise_for_status").and_return(None)
 
-    flexmock(CoprBuild).should_receive("set_status").with_args("pending")
+    flexmock(CoprBuild).should_receive("set_status").with_args("pending").once()
+    flexmock(CoprBuild).should_receive("set_build_logs_url")
     # check if packit-service set correct PR status
     flexmock(BuildStatusReporter).should_receive("report").with_args(
         state="pending",
@@ -504,6 +509,7 @@ def test_copr_build_just_tests_defined(copr_build_start, pc_tests, copr_build):
     flexmock(requests.Response).should_receive("raise_for_status").and_return(None)
 
     flexmock(CoprBuild).should_receive("set_status").with_args("pending")
+    flexmock(CoprBuild).should_receive("set_build_logs_url")
     # check if packit-service sets the correct PR status
     flexmock(BuildStatusReporter).should_receive("report").with_args(
         state="pending",
@@ -545,6 +551,7 @@ def test_copr_build_not_comment_on_success(copr_build_end, pc_build, copr_build)
     flexmock(GithubProject).should_receive("pr_comment").never()
 
     flexmock(CoprBuild).should_receive("get_by_build_id").and_return(copr_build)
+    flexmock(CoprBuild).should_receive("set_status").with_args("success")
     flexmock(CoprBuildDB).should_receive("get_build").and_return(
         {
             "commit_sha": "XXXXX",


### PR DESCRIPTION
with this change, the logs url is set when a build starts, not when it ends

also realised that coprbuildend event worked differently than I thought: so now the status is set correctly in the DB all the time