### PR TITLE
Update Sentry to 0.14.1

### DIFF
--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -22,6 +22,5 @@
         name:
           - git+https://github.com/packit-service/sandcastle.git
           - persistentdict
-          # "We recommend you update your SDK from version 0.12.3 to version 0.14.0"
-          - sentry-sdk==0.14.0
+          - sentry-sdk==0.14.1
         executable: pip3


### PR DESCRIPTION
https://github.com/getsentry/sentry-python/releases/tag/0.14.1

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>