### PR TITLE
Refactor of the build-helper classes

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -6,11 +6,6 @@ SANDCASTLE_PVC = "SANDCASTLE_PVC"
 
 CONFIG_FILE_NAME = "packit-service.yaml"
 
-PACKIT_PROD_CHECK = "packit/rpm-build"
-PACKIT_STG_CHECK = "packit-stg/rpm-build"
-PACKIT_PROD_TESTING_FARM_CHECK = "packit/testing-farm"
-PACKIT_STG_TESTING_FARM_CHECK = "packit-stg/testing-farm"
-
 TESTING_FARM_TRIGGER_URL = (
     "https://scheduler-testing-farm.apps.ci.centos.org/v0/trigger"
 )

--- a/packit_service/worker/build/__init__.py
+++ b/packit_service/worker/build/__init__.py
@@ -20,15 +20,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-
-from .build_helper import (
-    BaseBuildJobHelper,
-    BuildStatusReporter,
-)
-from .copr_build import CoprBuildJobHelper
+from packit_service.worker.build.build_helper import BaseBuildJobHelper
+from packit_service.worker.build.copr_build import CoprBuildJobHelper
 
 __all__ = [
     CoprBuildJobHelper.__name__,
     BaseBuildJobHelper.__name__,
-    BuildStatusReporter.__name__,
 ]

--- a/packit_service/worker/build/__init__.py
+++ b/packit_service/worker/build/__init__.py
@@ -19,30 +19,16 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from contextlib import contextmanager
 
 
-def send_to_sentry(ex):
-    # so that we don't have to have sentry sdk installed locally
-    import sentry_sdk
+from .build_helper import (
+    BaseBuildJobHelper,
+    BuildStatusReporter,
+)
+from .copr_build import CoprBuildJobHelper
 
-    sentry_sdk.capture_exception(ex)
-
-
-@contextmanager
-def push_scope_to_sentry():
-    try:
-        # so that we don't have to have sentry sdk installed locally
-        import sentry_sdk
-
-    except ImportError:
-
-        class SentryMocker:
-            def set_tag(self, k, v):
-                pass
-
-        yield SentryMocker()
-    else:
-
-        with sentry_sdk.push_scope() as scope:
-            yield scope
+__all__ = [
+    CoprBuildJobHelper.__name__,
+    BaseBuildJobHelper.__name__,
+    BuildStatusReporter.__name__,
+]

--- a/packit_service/worker/build/build_helper.py
+++ b/packit_service/worker/build/build_helper.py
@@ -50,12 +50,7 @@ class BaseBuildJobHelper:
         config: ServiceConfig,
         package_config: PackageConfig,
         project: GitProject,
-        event: Union[
-            PullRequestEvent,
-            PullRequestCommentEvent,
-            CoprBuildEvent,
-            PullRequestCommentEvent,
-        ],
+        event: Union[PullRequestEvent, PullRequestCommentEvent, CoprBuildEvent],
     ):
         self.config: ServiceConfig = config
         self.package_config: PackageConfig = package_config
@@ -165,6 +160,7 @@ class BaseBuildJobHelper:
             for job in self.package_config.jobs:
                 if job.job == self.job_type_build:
                     self._job_build = job
+                    break
         return self._job_build
 
     @property
@@ -180,6 +176,7 @@ class BaseBuildJobHelper:
             for job in self.package_config.jobs:
                 if job.job == self.job_type_test:
                     self._job_tests = job
+                    break
         return self._job_tests
 
     @property

--- a/packit_service/worker/build/build_helper.py
+++ b/packit_service/worker/build/build_helper.py
@@ -1,0 +1,336 @@
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import logging
+from typing import Union, List, Optional
+
+from ogr.abstract import GitProject
+from packit.api import PackitAPI
+from packit.config import PackageConfig, JobType, JobConfig
+from packit.config.aliases import get_build_targets
+from packit.local_project import LocalProject
+
+from packit_service.config import ServiceConfig, Deployment
+from packit_service.constants import MSG_RETRIGGER
+from packit_service.service.events import (
+    PullRequestEvent,
+    PullRequestCommentEvent,
+    CoprBuildEvent,
+)
+from packit_service.service.models import CoprBuild
+
+logger = logging.getLogger(__name__)
+
+
+class BaseBuildJobHelper:
+    job_type_build: Optional[JobType] = None
+    job_type_test: Optional[JobType] = None
+    status_name_build: str = "base-build-status"
+    status_name_test: str = "base-test-status"
+
+    def __init__(
+        self,
+        config: ServiceConfig,
+        package_config: PackageConfig,
+        project: GitProject,
+        event: Union[
+            PullRequestEvent,
+            PullRequestCommentEvent,
+            CoprBuildEvent,
+            PullRequestCommentEvent,
+        ],
+    ):
+        self.config: ServiceConfig = config
+        self.package_config: PackageConfig = package_config
+        self.project: GitProject = project
+        self.event: Union[
+            PullRequestEvent, PullRequestCommentEvent, CoprBuildEvent,
+        ] = event
+
+        # lazy properties
+        self._api = None
+        self._job_build = None
+        self._job_tests = None
+        self._local_project = None
+        self._status_reporter = None
+        self._test_check_names: Optional[List[str]] = None
+        self._build_check_names: Optional[List[str]] = None
+
+        self.msg_retrigger: str = MSG_RETRIGGER.format(
+            build="copr-build" if self.job_build else "build"
+        )
+
+    @property
+    def local_project(self) -> LocalProject:
+        if self._local_project is None:
+            self._local_project = LocalProject(
+                git_project=self.project,
+                working_dir=self.config.command_handler_work_dir,
+                ref=self.base_ref,
+                pr_id=self.event.pr_id,
+            )
+        return self._local_project
+
+    @property
+    def api(self) -> PackitAPI:
+        if not self._api:
+            self._api = PackitAPI(self.config, self.package_config, self.local_project)
+        return self._api
+
+    @property
+    def base_ref(self) -> str:
+        if isinstance(self.event, PullRequestEvent):
+            return self.event.base_ref
+
+        if isinstance(self.event, CoprBuildEvent):
+            if self.event.ref:
+                # FIXME: return commit sha always once on PG
+                return self.event.ref
+            return self.event.commit_sha
+
+        if isinstance(self.event, PullRequestCommentEvent):
+            return self.event.commit_sha
+
+    @property
+    def build_chroots(self) -> List[str]:
+        """
+        Return the chroots to build.
+
+        1. If the job is not defined, use the test_chroots.
+        2. If the job is defined, but not the targets, use "fedora-stable" alias otherwise.
+        """
+        if (
+            (not self.job_build or "targets" not in self.job_build.metadata)
+            and self.job_tests
+            and "targets" in self.job_tests.metadata
+        ):
+            return self.tests_chroots
+
+        if not self.job_build:
+            raw_targets = ["fedora-stable"]
+        else:
+            raw_targets = self.job_build.metadata.get("targets", ["fedora-stable"])
+            if isinstance(raw_targets, str):
+                raw_targets = [raw_targets]
+
+        return list(get_build_targets(*raw_targets))
+
+    @property
+    def tests_chroots(self) -> List[str]:
+        """
+        Return the list of chroots used in the testing farm.
+        Has to be a sub-set of the `build_chroots`.
+
+        Return an empty list if there is no job configured.
+
+        If not defined:
+        1. use the build_chroots if the job si configured
+        2. use "fedora-stable" alias otherwise
+        """
+        if not self.job_tests:
+            return []
+
+        if "targets" not in self.job_tests.metadata and self.job_build:
+            return self.build_chroots
+
+        configured_targets = self.job_tests.metadata.get("targets", ["fedora-stable"])
+        if isinstance(configured_targets, str):
+            configured_targets = [configured_targets]
+
+        return list(get_build_targets(*configured_targets))
+
+    @property
+    def job_build(self) -> Optional[JobConfig]:
+        """
+        Check if there is JobConfig for builds defined
+        :return: JobConfig or None
+        """
+        if not self.job_type_build:
+            return None
+
+        if not self._job_build:
+            for job in self.package_config.jobs:
+                if job.job == self.job_type_build:
+                    self._job_build = job
+        return self._job_build
+
+    @property
+    def job_tests(self) -> Optional[JobConfig]:
+        """
+        Check if there is JobConfig for tests defined
+        :return: JobConfig or None
+        """
+        if not self.job_type_test:
+            return None
+
+        if not self._job_tests:
+            for job in self.package_config.jobs:
+                if job.job == self.job_type_test:
+                    self._job_tests = job
+        return self._job_tests
+
+    @property
+    def status_reporter(self):
+        if not self._status_reporter:
+            self._status_reporter = BuildStatusReporter(
+                self.project, self.event.commit_sha, copr_build_model=None
+            )
+        return self._status_reporter
+
+    @property
+    def test_check_names(self) -> List[str]:
+        if not self._test_check_names:
+            self._test_check_names = [
+                self.get_test_check(chroot) for chroot in self.tests_chroots
+            ]
+        return self._test_check_names
+
+    @property
+    def build_check_names(self) -> List[str]:
+        if not self._build_check_names:
+            self._build_check_names = [
+                self.get_build_check(chroot) for chroot in self.build_chroots
+            ]
+        return self._build_check_names
+
+    @classmethod
+    def get_build_check(cls, chroot: str = None) -> str:
+        config = ServiceConfig.get_service_config()
+        deployment_str = (
+            "packit" if config.deployment == Deployment.prod else "packit-stg"
+        )
+        chroot_str = f"-{chroot}" if chroot else ""
+        return f"{deployment_str}/{cls.status_name_build}{chroot_str}"
+
+    @classmethod
+    def get_test_check(cls, chroot: str = None) -> str:
+        config = ServiceConfig.get_service_config()
+        deployment_str = (
+            "packit" if config.deployment == Deployment.prod else "packit-stg"
+        )
+        chroot_str = f"-{chroot}" if chroot else ""
+        return f"{deployment_str}/{cls.status_name_test}{chroot_str}"
+
+    def report_status_to_all(self, description: str, state: str, url: str = "") -> None:
+        self.report_status_to_build(description, state, url)
+        self.report_status_to_tests(description, state, url)
+
+    def report_status_to_build(self, description, state, url: str = "") -> None:
+        if self.job_build:
+            self.status_reporter.report(
+                description=description,
+                state=state,
+                url=url,
+                check_names=self.build_check_names,
+            )
+
+    def report_status_to_tests(self, description, state, url: str = "") -> None:
+        if self.job_tests:
+            self.status_reporter.report(
+                description=description,
+                state=state,
+                url=url,
+                check_names=self.test_check_names,
+            )
+
+    def report_status_to_build_for_chroot(
+        self, description, state, url: str = "", chroot: str = ""
+    ) -> None:
+        if self.job_build and chroot in self.build_chroots:
+            cs = self.get_build_check(chroot)
+            self.status_reporter.report(
+                description=description, state=state, url=url, check_names=cs,
+            )
+
+    def report_status_to_test_for_chroot(
+        self, description, state, url: str = "", chroot: str = ""
+    ) -> None:
+        if self.job_tests and chroot in self.tests_chroots:
+            self.status_reporter.report(
+                description=description,
+                state=state,
+                url=url,
+                check_names=self.get_test_check(chroot),
+            )
+
+    def report_status_to_all_for_chroot(
+        self, description, state, url: str = "", chroot: str = ""
+    ):
+        self.report_status_to_build_for_chroot(description, state, url, chroot)
+        self.report_status_to_test_for_chroot(description, state, url, chroot)
+
+
+class BuildStatusReporter:
+    def __init__(
+        self,
+        project: GitProject,
+        commit_sha: str,
+        copr_build_model: Optional[CoprBuild] = None,
+    ):
+        self.project = project
+        self.commit_sha = commit_sha
+        self.copr_build_model = copr_build_model
+
+    def report(
+        self,
+        state: str,
+        description: str,
+        build_id: Optional[str] = None,
+        url: str = "",
+        check_names: Union[str, list, None] = None,
+    ) -> None:
+        """
+        set commit check status
+
+        :param state: state accepted by github
+        :param description: the long text
+        :param build_id: copr build id
+        :param url: url to point to (logs usually)
+        :param check_names: those in bold
+        """
+
+        logger.debug(
+            f"Reporting state of copr build ID={build_id}"
+            f" state={state}, commit={self.commit_sha}"
+        )
+        if self.copr_build_model:
+            self.copr_build_model.status = state
+            self.copr_build_model.save()
+
+        if not check_names:
+            # TODO: We don't want to use this behaviour.
+            check_names = [BaseBuildJobHelper.get_build_check()]
+        elif isinstance(check_names, str):
+            check_names = [check_names]
+
+        for check in check_names:
+            self.set_status(
+                state=state, description=description, check_name=check, url=url
+            )
+
+    def set_status(self, state: str, description: str, check_name: str, url: str = ""):
+        logger.debug(f"Setting status for check '{check_name}': {description}")
+        self.project.set_commit_status(
+            self.commit_sha, state, url, description, check_name, trim=True
+        )
+
+    def get_statuses(self):
+        self.project.get_commit_statuses(commit=self.commit_sha)

--- a/packit_service/worker/build/koji_build.py
+++ b/packit_service/worker/build/koji_build.py
@@ -1,7 +1,7 @@
 # MIT License
 #
 # Copyright (c) 2018-2019 Red Hat, Inc.
-
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
@@ -19,30 +19,15 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from contextlib import contextmanager
+from packit.config import JobType
+
+from packit_service.worker.build.copr_build import BaseBuildJobHelper
+from packit_service.worker.handler import HandlerResults
 
 
-def send_to_sentry(ex):
-    # so that we don't have to have sentry sdk installed locally
-    import sentry_sdk
+class KojiBuildJobHelper(BaseBuildJobHelper):
+    job_type_build = JobType.production_build
+    job_type_test = None
 
-    sentry_sdk.capture_exception(ex)
-
-
-@contextmanager
-def push_scope_to_sentry():
-    try:
-        # so that we don't have to have sentry sdk installed locally
-        import sentry_sdk
-
-    except ImportError:
-
-        class SentryMocker:
-            def set_tag(self, k, v):
-                pass
-
-        yield SentryMocker()
-    else:
-
-        with sentry_sdk.push_scope() as scope:
-            yield scope
+    def run_koji_build(self, scratch: bool = False) -> HandlerResults:
+        raise NotImplementedError()

--- a/packit_service/worker/build/koji_build.py
+++ b/packit_service/worker/build/koji_build.py
@@ -19,10 +19,14 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+import logging
+
 from packit.config import JobType
 
 from packit_service.worker.build.copr_build import BaseBuildJobHelper
 from packit_service.worker.handler import HandlerResults
+
+logger = logging.getLogger(__name__)
 
 
 class KojiBuildJobHelper(BaseBuildJobHelper):

--- a/packit_service/worker/github_handlers.py
+++ b/packit_service/worker/github_handlers.py
@@ -380,16 +380,6 @@ class GitHubPullRequestCommentCoprBuildHandler(
         )
         self.package_config.upstream_project_url = event.project_url
 
-    def get_tests_for_build(self) -> Optional[JobConfig]:
-        """
-        Check if there are tests defined
-        :return: JobConfig or None
-        """
-        for job in self.package_config.jobs:
-            if job.job == JobType.tests:
-                return job
-        return None
-
     def run(self) -> HandlerResults:
         collaborators = self.project.who_can_merge_pr()
         if self.event.github_login not in collaborators | self.config.admins:

--- a/packit_service/worker/handler.py
+++ b/packit_service/worker/handler.py
@@ -31,6 +31,7 @@ from typing import Dict, Any, Optional, Type, List
 
 from packit.api import PackitAPI
 from packit.config import JobConfig, JobTriggerType, JobType
+from packit.local_project import LocalProject
 
 from packit_service.config import ServiceConfig
 from packit_service.service.events import Event
@@ -78,7 +79,7 @@ class Handler:
     def __init__(self, config: ServiceConfig):
         self.config: ServiceConfig = config
         self.api: Optional[PackitAPI] = None
-        self.local_project: Optional[PackitAPI] = None
+        self.local_project: Optional[LocalProject] = None
 
     def run(self) -> HandlerResults:
         raise NotImplementedError("This should have been implemented.")

--- a/packit_service/worker/handler.py
+++ b/packit_service/worker/handler.py
@@ -27,56 +27,18 @@ import logging
 import shutil
 from os import getenv
 from pathlib import Path
-from typing import Dict, Any, Optional, Type, List, Union
+from typing import Dict, Any, Optional, Type, List
 
-from ogr.abstract import GitProject
 from packit.api import PackitAPI
 from packit.config import JobConfig, JobTriggerType, JobType
 
-from packit_service.config import Deployment, ServiceConfig
-from packit_service.constants import (
-    PACKIT_PROD_CHECK,
-    PACKIT_STG_CHECK,
-    PACKIT_PROD_TESTING_FARM_CHECK,
-    PACKIT_STG_TESTING_FARM_CHECK,
-)
+from packit_service.config import ServiceConfig
 from packit_service.service.events import Event
-from packit_service.service.models import CoprBuild
 from packit_service.worker.sentry_integration import push_scope_to_sentry
 
 logger = logging.getLogger(__name__)
 
 JOB_NAME_HANDLER_MAPPING: Dict[JobType, Type["JobHandler"]] = {}
-
-
-class PRCheckName:
-    """
-    This is class providing static methods for getting check names according to deployment
-    """
-
-    @staticmethod
-    def get_build_check(chroot: str = None) -> str:
-        config = ServiceConfig.get_service_config()
-        if config.deployment == Deployment.prod:
-            if chroot:
-                return f"{PACKIT_PROD_CHECK}-{chroot}"
-            return PACKIT_PROD_CHECK
-
-        if chroot:
-            return f"{PACKIT_STG_CHECK}-{chroot}"
-        return PACKIT_STG_CHECK
-
-    @staticmethod
-    def get_testing_farm_check(chroot: str = None) -> str:
-        config = ServiceConfig.get_service_config()
-        if config.deployment == Deployment.prod:
-            if chroot:
-                return f"{PACKIT_PROD_TESTING_FARM_CHECK}-{chroot}"
-            return PACKIT_PROD_TESTING_FARM_CHECK
-
-        if chroot:
-            return f"{PACKIT_STG_TESTING_FARM_CHECK}-{chroot}"
-        return PACKIT_STG_TESTING_FARM_CHECK
 
 
 def add_to_mapping(kls: Type["JobHandler"]):
@@ -90,64 +52,6 @@ def add_to_mapping_for_job(job_type: JobType):
         return kls
 
     return _add_to_mapping
-
-
-class BuildStatusReporter:
-    def __init__(
-        self,
-        project: GitProject,
-        commit_sha: str,
-        copr_build_model: Optional[CoprBuild] = None,
-    ):
-        self.project = project
-        self.commit_sha = commit_sha
-        self.copr_build_model = copr_build_model
-
-    def report(
-        self,
-        state: str,
-        description: str,
-        build_id: Optional[str] = None,
-        url: str = "",
-        check_names: Union[str, list, None] = None,
-    ):
-        """
-        set commit check status
-
-        :param state: state accepted by github
-        :param description: the long text
-        :param build_id: copr build id
-        :param url: url to point to (logs usually)
-        :param check_names: those in bold
-        :return: nuthin'
-        """
-
-        logger.debug(
-            f"Reporting state of copr build ID={build_id}"
-            f" state={state}, commit={self.commit_sha}"
-        )
-        if self.copr_build_model:
-            self.copr_build_model.status = state
-            self.copr_build_model.save()
-
-        if not check_names:
-            check_names = [PRCheckName.get_build_check()]
-        elif isinstance(check_names, str):
-            check_names = [check_names]
-
-        for check in check_names:
-            self.set_status(
-                state=state, description=description, check_name=check, url=url
-            )
-
-    def set_status(self, state: str, description: str, check_name: str, url: str = ""):
-        logger.debug(f"Setting status for check '{check_name}': {description}")
-        self.project.set_commit_status(
-            self.commit_sha, state, url, description, check_name, trim=True
-        )
-
-    def get_statuses(self):
-        self.project.get_commit_statuses(commit=self.commit_sha)
 
 
 class HandlerResults(dict):

--- a/packit_service/worker/handler.py
+++ b/packit_service/worker/handler.py
@@ -27,7 +27,6 @@ import logging
 import shutil
 from os import getenv
 from pathlib import Path
-from sentry_sdk import push_scope
 from typing import Dict, Any, Optional, Type, List, Union
 
 from ogr.abstract import GitProject
@@ -43,6 +42,7 @@ from packit_service.constants import (
 )
 from packit_service.service.events import Event
 from packit_service.service.models import CoprBuild
+from packit_service.worker.sentry_integration import push_scope_to_sentry
 
 logger = logging.getLogger(__name__)
 
@@ -193,7 +193,7 @@ class Handler:
 
     def run_n_clean(self) -> HandlerResults:
         try:
-            with push_scope() as scope:
+            with push_scope_to_sentry() as scope:
                 for k, v in self.get_tag_info().items():
                     scope.set_tag(k, v)
                 return self.run()

--- a/packit_service/worker/reporting.py
+++ b/packit_service/worker/reporting.py
@@ -1,0 +1,72 @@
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import logging
+from typing import Union
+
+from ogr.abstract import GitProject
+
+logger = logging.getLogger(__name__)
+
+
+class StatusReporter:
+    def __init__(
+        self, project: GitProject, commit_sha: str,
+    ):
+        self.project = project
+        self.commit_sha = commit_sha
+
+    def report(
+        self,
+        state: str,
+        description: str,
+        url: str = "",
+        check_names: Union[str, list, None] = None,
+    ) -> None:
+        """
+        set commit check status
+
+        :param state: state accepted by github
+        :param description: the long text
+        :param url: url to point to (logs usually)
+        :param check_names: those in bold
+        """
+
+        if not check_names:
+            logger.warning("No checks to set status for.")
+            return
+
+        elif isinstance(check_names, str):
+            check_names = [check_names]
+
+        for check in check_names:
+            self.set_status(
+                state=state, description=description, check_name=check, url=url
+            )
+
+    def set_status(self, state: str, description: str, check_name: str, url: str = ""):
+        logger.debug(f"Setting status for check '{check_name}': {description}")
+        self.project.set_commit_status(
+            self.commit_sha, state, url, description, check_name, trim=True
+        )
+
+    def get_statuses(self):
+        self.project.get_commit_statuses(commit=self.commit_sha)

--- a/packit_service/worker/sentry_integration.py
+++ b/packit_service/worker/sentry_integration.py
@@ -19,6 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+from contextlib import contextmanager
 
 
 def send_to_sentry(ex):
@@ -26,3 +27,22 @@ def send_to_sentry(ex):
     import sentry_sdk
 
     sentry_sdk.capture_exception(ex)
+
+
+@contextmanager
+def push_scope_to_sentry():
+    try:
+        # so that we don't have to have sentry sdk installed locally
+        import sentry_sdk
+
+    except ImportError:
+
+        class SentryMocker:
+            def set_tag(self, k, v):
+                pass
+
+        yield SentryMocker()
+    else:
+
+        with sentry_sdk.push_scope as scope:
+            yield scope

--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -29,7 +29,7 @@ from typing import Union
 import requests
 from ogr.abstract import GitProject
 from ogr.utils import RequestResponse
-from packit.config import PackageConfig, JobType
+from packit.config import PackageConfig
 from packit.exceptions import PackitConfigException
 
 from packit_service.config import Deployment, ServiceConfig
@@ -39,19 +39,14 @@ from packit_service.service.events import (
     PullRequestCommentEvent,
     CoprBuildEvent,
 )
-from packit_service.worker.build import BaseBuildJobHelper
+from packit_service.worker.build import CoprBuildJobHelper
 from packit_service.worker.handler import HandlerResults
 from packit_service.worker.sentry_integration import send_to_sentry
 
 logger = logging.getLogger(__name__)
 
 
-class TestingFarmJobHelper(BaseBuildJobHelper):
-    job_type_build = JobType.copr_build
-    job_type_test = JobType.tests
-    status_name_build: str = "rpm-build"
-    status_name_test: str = "testing-farm"
-
+class TestingFarmJobHelper(CoprBuildJobHelper):
     def __init__(
         self,
         config: ServiceConfig,

--- a/packit_service/worker/testing_farm_handlers.py
+++ b/packit_service/worker/testing_farm_handlers.py
@@ -39,9 +39,9 @@ from packit_service.worker.github_handlers import AbstractGithubJobHandler
 from packit_service.worker.handler import (
     add_to_mapping,
     HandlerResults,
-    BuildStatusReporter,
-    PRCheckName,
 )
+from packit_service.worker.build.build_helper import BuildStatusReporter
+from packit_service.worker.testing_farm import TestingFarmJobHelper
 
 logger = logging.getLogger(__name__)
 
@@ -103,7 +103,7 @@ class TestingFarmResultsHandler(AbstractGithubJobHandler):
             state=status,
             description=short_msg,
             url=self.event.log_url,
-            check_names=PRCheckName.get_testing_farm_check(self.event.copr_chroot),
+            check_names=TestingFarmJobHelper.get_test_check(self.event.copr_chroot),
         )
 
         return HandlerResults(success=True, details={})

--- a/packit_service/worker/testing_farm_handlers.py
+++ b/packit_service/worker/testing_farm_handlers.py
@@ -35,12 +35,12 @@ from packit.config import (
 
 from packit_service.config import ServiceConfig
 from packit_service.service.events import TestingFarmResultsEvent, TestingFarmResult
+from packit_service.worker.reporting import StatusReporter
 from packit_service.worker.github_handlers import AbstractGithubJobHandler
 from packit_service.worker.handler import (
     add_to_mapping,
     HandlerResults,
 )
-from packit_service.worker.build.build_helper import BuildStatusReporter
 from packit_service.worker.testing_farm import TestingFarmJobHelper
 
 logger = logging.getLogger(__name__)
@@ -98,8 +98,8 @@ class TestingFarmResultsHandler(AbstractGithubJobHandler):
         else:
             short_msg = self.event.message
 
-        r = BuildStatusReporter(self.project, self.event.commit_sha)
-        r.report(
+        status_reporter = StatusReporter(self.project, self.event.commit_sha)
+        status_reporter.report(
             state=status,
             description=short_msg,
             url=self.event.log_url,

--- a/packit_service/worker/whitelist.py
+++ b/packit_service/worker/whitelist.py
@@ -41,7 +41,7 @@ from packit_service.service.events import (
     TestingFarmResultsEvent,
     DistGitEvent,
 )
-from packit_service.worker.copr_build import JobHelper
+from packit_service.worker.build import CoprBuildJobHelper
 
 logger = logging.getLogger(__name__)
 
@@ -221,7 +221,7 @@ class Whitelist:
                 if event.trigger == JobTriggerType.comment:
                     project.pr_comment(event.pr_id, msg)
                 else:
-                    job_helper = JobHelper(
+                    job_helper = CoprBuildJobHelper(
                         config=config,
                         package_config=event.get_package_config(),
                         project=project,

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -32,22 +32,21 @@ from packit.config.package_config import PackageConfig
 from packit.copr_helper import CoprHelper
 from packit.local_project import LocalProject
 
-from packit_service.constants import PACKIT_STG_CHECK, PACKIT_STG_TESTING_FARM_CHECK
 from packit_service.models import CoprBuild
 from packit_service.service.events import CoprBuildEvent
 from packit_service.service.urls import get_log_url
-from packit_service.worker.copr_build import CoprBuildJobHelper
+from packit_service.worker.build.build_helper import BuildStatusReporter
+from packit_service.worker.build.copr_build import CoprBuildJobHelper
 from packit_service.worker.copr_db import CoprBuildDB
 from packit_service.worker.fedmsg_handlers import CoprBuildEndHandler
 from packit_service.worker.github_handlers import GithubTestingFarmHandler
-from packit_service.worker.handler import BuildStatusReporter
-from packit_service.worker.handler import PRCheckName
 from packit_service.worker.jobs import SteveJobs
 from packit_service.worker.testing_farm import TestingFarmJobHelper
 from tests.spellbook import DATA_DIR
 
 CHROOT = "fedora-rawhide-x86_64"
-EXPECTED_CHECK_NAME = f"{PACKIT_STG_CHECK}-{CHROOT}"
+EXPECTED_BUILD_CHECK_NAME = f"packit-stg/rpm-build-{CHROOT}"
+EXPECTED_TESTING_FARM_CHECK_NAME = f"packit-stg/testing-farm-{CHROOT}"
 
 
 @pytest.fixture()
@@ -127,7 +126,7 @@ def test_copr_build_end(copr_build_end, pc_build, copr_build):
         state="success",
         description="RPMs were built successfully.",
         url=url,
-        check_names=PRCheckName.get_build_check(copr_build_end["chroot"]),
+        check_names=CoprBuildJobHelper.get_build_check(copr_build_end["chroot"]),
     ).once()
 
     # skip testing farm
@@ -197,14 +196,14 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build):
         state="success",
         description="RPMs were built successfully.",
         url=url,
-        check_names=EXPECTED_CHECK_NAME,
+        check_names=EXPECTED_BUILD_CHECK_NAME,
     ).once()
 
     flexmock(BuildStatusReporter).should_receive("report").with_args(
-        state="success",
+        state="pending",
         description="RPMs were built successfully.",
         url=url,
-        check_names=f"{PACKIT_STG_TESTING_FARM_CHECK}-{CHROOT}",
+        check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
     ).once()
 
     flexmock(TestingFarmJobHelper).should_receive(
@@ -221,13 +220,14 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build):
     flexmock(BuildStatusReporter).should_receive("report").with_args(
         state="pending",
         description="Build succeeded. Submitting the tests ...",
-        check_names=f"{PACKIT_STG_TESTING_FARM_CHECK}-{CHROOT}",
+        check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
+        url="",
     ).once()
     flexmock(BuildStatusReporter).should_receive("report").with_args(
         state="pending",
         description="Tests are running ...",
         url="some-url",
-        check_names=f"{PACKIT_STG_TESTING_FARM_CHECK}-{CHROOT}",
+        check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
     ).once()
 
     steve.process_message(copr_build_end)
@@ -293,14 +293,14 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build):
         state="success",
         description="RPMs were built successfully.",
         url="https://localhost:5000/copr-build/1/logs",
-        check_names=EXPECTED_CHECK_NAME,
+        check_names=EXPECTED_BUILD_CHECK_NAME,
     ).once()
 
     flexmock(BuildStatusReporter).should_receive("report").with_args(
-        state="success",
+        state="pending",
         description="RPMs were built successfully.",
         url="https://localhost:5000/copr-build/1/logs",
-        check_names=f"{PACKIT_STG_TESTING_FARM_CHECK}-fedora-rawhide-x86_64",
+        check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
     ).once()
 
     flexmock(TestingFarmJobHelper).should_receive(
@@ -317,12 +317,14 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build):
     flexmock(BuildStatusReporter).should_receive("report").with_args(
         state="pending",
         description="Build succeeded. Submitting the tests ...",
-        check_names=f"{PACKIT_STG_TESTING_FARM_CHECK}-fedora-rawhide-x86_64",
+        check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
+        url="",
     ).once()
     flexmock(BuildStatusReporter).should_receive("report").with_args(
         state="failure",
         description="some error",
-        check_names=f"{PACKIT_STG_TESTING_FARM_CHECK}-fedora-rawhide-x86_64",
+        check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
+        url="",
     ).once()
 
     steve.process_message(copr_build_end)
@@ -389,14 +391,14 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build):
         state="success",
         description="RPMs were built successfully.",
         url=url,
-        check_names=EXPECTED_CHECK_NAME,
+        check_names=EXPECTED_BUILD_CHECK_NAME,
     ).once()
 
     flexmock(BuildStatusReporter).should_receive("report").with_args(
-        state="success",
+        state="pending",
         description="RPMs were built successfully.",
         url=url,
-        check_names=f"{PACKIT_STG_TESTING_FARM_CHECK}-fedora-rawhide-x86_64",
+        check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
     ).once()
 
     flexmock(TestingFarmJobHelper).should_receive(
@@ -415,12 +417,14 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build):
     flexmock(BuildStatusReporter).should_receive("report").with_args(
         state="pending",
         description="Build succeeded. Submitting the tests ...",
-        check_names=f"{PACKIT_STG_TESTING_FARM_CHECK}-fedora-rawhide-x86_64",
+        check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
+        url="",
     ).once()
     flexmock(BuildStatusReporter).should_receive("report").with_args(
         state="failure",
         description="Failed to submit tests: some text error",
-        check_names=f"{PACKIT_STG_TESTING_FARM_CHECK}-fedora-rawhide-x86_64",
+        check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
+        url="",
     ).once()
 
     steve.process_message(copr_build_end)
@@ -441,7 +445,9 @@ def test_copr_build_start(copr_build_start, pc_build, copr_build):
         flexmock()
     )
     flexmock(CoprBuildEvent).should_receive("get_package_config").and_return(pc_build)
-    flexmock(PRCheckName).should_receive("get_build_check").and_return(PACKIT_STG_CHECK)
+    flexmock(CoprBuildJobHelper).should_receive("get_build_check").and_return(
+        EXPECTED_BUILD_CHECK_NAME
+    )
 
     flexmock(CoprBuild).should_receive("get_by_build_id").and_return(copr_build)
     flexmock(CoprBuildDB).should_receive("get_build").and_return(
@@ -466,7 +472,7 @@ def test_copr_build_start(copr_build_start, pc_build, copr_build):
         state="pending",
         description="RPM build has started...",
         url=url,
-        check_names=PACKIT_STG_CHECK,
+        check_names=EXPECTED_BUILD_CHECK_NAME,
     ).once()
 
     steve.process_message(copr_build_start)
@@ -487,9 +493,11 @@ def test_copr_build_just_tests_defined(copr_build_start, pc_tests, copr_build):
         flexmock()
     )
     flexmock(CoprBuildEvent).should_receive("get_package_config").and_return(pc_tests)
-    flexmock(PRCheckName).should_receive("get_build_check").and_return(PACKIT_STG_CHECK)
-    flexmock(PRCheckName).should_receive("get_testing_farm_check").and_return(
-        PACKIT_STG_TESTING_FARM_CHECK
+    flexmock(TestingFarmJobHelper).should_receive("get_build_check").and_return(
+        EXPECTED_BUILD_CHECK_NAME
+    )
+    flexmock(TestingFarmJobHelper).should_receive("get_test_check").and_return(
+        EXPECTED_TESTING_FARM_CHECK_NAME
     )
 
     flexmock(CoprBuild).should_receive("get_by_build_id").and_return(copr_build)
@@ -515,14 +523,14 @@ def test_copr_build_just_tests_defined(copr_build_start, pc_tests, copr_build):
         state="pending",
         description="RPM build has started...",
         url=url,
-        check_names=PACKIT_STG_CHECK,
+        check_names=EXPECTED_BUILD_CHECK_NAME,
     ).never()
 
     flexmock(BuildStatusReporter).should_receive("report").with_args(
         state="pending",
         description="RPM build has started...",
         url=url,
-        check_names=PRCheckName.get_testing_farm_check(copr_build_start["chroot"]),
+        check_names=TestingFarmJobHelper.get_test_check(copr_build_start["chroot"]),
     ).once()
 
     steve.process_message(copr_build_start)
@@ -543,7 +551,9 @@ def test_copr_build_not_comment_on_success(copr_build_end, pc_build, copr_build)
         flexmock()
     )
     flexmock(CoprBuildEvent).should_receive("get_package_config").and_return(pc_build)
-    flexmock(PRCheckName).should_receive("get_build_check").and_return(PACKIT_STG_CHECK)
+    flexmock(CoprBuildJobHelper).should_receive("get_build_check").and_return(
+        EXPECTED_BUILD_CHECK_NAME
+    )
 
     flexmock(CoprBuildEndHandler).should_receive(
         "was_last_build_successful"
@@ -572,7 +582,7 @@ def test_copr_build_not_comment_on_success(copr_build_end, pc_build, copr_build)
         state="success",
         description="RPMs were built successfully.",
         url=url,
-        check_names=PRCheckName.get_build_check(copr_build_end["chroot"]),
+        check_names=CoprBuildJobHelper.get_build_check(copr_build_end["chroot"]),
     ).once()
 
     # skip testing farm

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -35,7 +35,7 @@ from packit.local_project import LocalProject
 from packit_service.models import CoprBuild
 from packit_service.service.events import CoprBuildEvent
 from packit_service.service.urls import get_log_url
-from packit_service.worker.build.build_helper import BuildStatusReporter
+from packit_service.worker.reporting import StatusReporter
 from packit_service.worker.build.copr_build import CoprBuildJobHelper
 from packit_service.worker.copr_db import CoprBuildDB
 from packit_service.worker.fedmsg_handlers import CoprBuildEndHandler
@@ -122,7 +122,7 @@ def test_copr_build_end(copr_build_end, pc_build, copr_build):
     flexmock(requests).should_receive("get").and_return(requests.Response())
     flexmock(requests.Response).should_receive("raise_for_status").and_return(None)
     # check if packit-service set correct PR status
-    flexmock(BuildStatusReporter).should_receive("report").with_args(
+    flexmock(StatusReporter).should_receive("report").with_args(
         state="success",
         description="RPMs were built successfully.",
         url=url,
@@ -192,14 +192,14 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build):
     flexmock(requests).should_receive("get").and_return(requests.Response())
     flexmock(requests.Response).should_receive("raise_for_status").and_return(None)
     # check if packit-service set correct PR status
-    flexmock(BuildStatusReporter).should_receive("report").with_args(
+    flexmock(StatusReporter).should_receive("report").with_args(
         state="success",
         description="RPMs were built successfully.",
         url=url,
         check_names=EXPECTED_BUILD_CHECK_NAME,
     ).once()
 
-    flexmock(BuildStatusReporter).should_receive("report").with_args(
+    flexmock(StatusReporter).should_receive("report").with_args(
         state="pending",
         description="RPMs were built successfully.",
         url=url,
@@ -217,13 +217,13 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build):
         )
     )
 
-    flexmock(BuildStatusReporter).should_receive("report").with_args(
+    flexmock(StatusReporter).should_receive("report").with_args(
         state="pending",
         description="Build succeeded. Submitting the tests ...",
         check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
         url="",
     ).once()
-    flexmock(BuildStatusReporter).should_receive("report").with_args(
+    flexmock(StatusReporter).should_receive("report").with_args(
         state="pending",
         description="Tests are running ...",
         url="some-url",
@@ -289,14 +289,14 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build):
     flexmock(requests).should_receive("get").and_return(requests.Response())
     flexmock(requests.Response).should_receive("raise_for_status").and_return(None)
     # check if packit-service set correct PR status
-    flexmock(BuildStatusReporter).should_receive("report").with_args(
+    flexmock(StatusReporter).should_receive("report").with_args(
         state="success",
         description="RPMs were built successfully.",
         url="https://localhost:5000/copr-build/1/logs",
         check_names=EXPECTED_BUILD_CHECK_NAME,
     ).once()
 
-    flexmock(BuildStatusReporter).should_receive("report").with_args(
+    flexmock(StatusReporter).should_receive("report").with_args(
         state="pending",
         description="RPMs were built successfully.",
         url="https://localhost:5000/copr-build/1/logs",
@@ -314,13 +314,13 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build):
         )
     )
 
-    flexmock(BuildStatusReporter).should_receive("report").with_args(
+    flexmock(StatusReporter).should_receive("report").with_args(
         state="pending",
         description="Build succeeded. Submitting the tests ...",
         check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
         url="",
     ).once()
-    flexmock(BuildStatusReporter).should_receive("report").with_args(
+    flexmock(StatusReporter).should_receive("report").with_args(
         state="failure",
         description="some error",
         check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
@@ -387,14 +387,14 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build):
     flexmock(requests).should_receive("get").and_return(requests.Response())
     flexmock(requests.Response).should_receive("raise_for_status").and_return(None)
     # check if packit-service set correct PR status
-    flexmock(BuildStatusReporter).should_receive("report").with_args(
+    flexmock(StatusReporter).should_receive("report").with_args(
         state="success",
         description="RPMs were built successfully.",
         url=url,
         check_names=EXPECTED_BUILD_CHECK_NAME,
     ).once()
 
-    flexmock(BuildStatusReporter).should_receive("report").with_args(
+    flexmock(StatusReporter).should_receive("report").with_args(
         state="pending",
         description="RPMs were built successfully.",
         url=url,
@@ -414,13 +414,13 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build):
     )
 
     flexmock(CoprBuild).should_receive("set_status").with_args("failure")
-    flexmock(BuildStatusReporter).should_receive("report").with_args(
+    flexmock(StatusReporter).should_receive("report").with_args(
         state="pending",
         description="Build succeeded. Submitting the tests ...",
         check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
         url="",
     ).once()
-    flexmock(BuildStatusReporter).should_receive("report").with_args(
+    flexmock(StatusReporter).should_receive("report").with_args(
         state="failure",
         description="Failed to submit tests: some text error",
         check_names=EXPECTED_TESTING_FARM_CHECK_NAME,
@@ -468,7 +468,7 @@ def test_copr_build_start(copr_build_start, pc_build, copr_build):
     flexmock(CoprBuild).should_receive("set_status").with_args("pending").once()
     flexmock(CoprBuild).should_receive("set_build_logs_url")
     # check if packit-service set correct PR status
-    flexmock(BuildStatusReporter).should_receive("report").with_args(
+    flexmock(StatusReporter).should_receive("report").with_args(
         state="pending",
         description="RPM build has started...",
         url=url,
@@ -519,14 +519,14 @@ def test_copr_build_just_tests_defined(copr_build_start, pc_tests, copr_build):
     flexmock(CoprBuild).should_receive("set_status").with_args("pending")
     flexmock(CoprBuild).should_receive("set_build_logs_url")
     # check if packit-service sets the correct PR status
-    flexmock(BuildStatusReporter).should_receive("report").with_args(
+    flexmock(StatusReporter).should_receive("report").with_args(
         state="pending",
         description="RPM build has started...",
         url=url,
         check_names=EXPECTED_BUILD_CHECK_NAME,
     ).never()
 
-    flexmock(BuildStatusReporter).should_receive("report").with_args(
+    flexmock(StatusReporter).should_receive("report").with_args(
         state="pending",
         description="RPM build has started...",
         url=url,
@@ -578,7 +578,7 @@ def test_copr_build_not_comment_on_success(copr_build_end, pc_build, copr_build)
     flexmock(requests.Response).should_receive("raise_for_status").and_return(None)
 
     # check if packit-service set correct PR status
-    flexmock(BuildStatusReporter).should_receive("report").with_args(
+    flexmock(StatusReporter).should_receive("report").with_args(
         state="success",
         description="RPMs were built successfully.",
         url=url,

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -26,7 +26,7 @@ import pytest
 from flexmock import flexmock
 from ogr.services.github import GithubProject
 
-from packit_service.worker.copr_build import CoprBuildJobHelper
+from packit_service.worker.build.copr_build import CoprBuildJobHelper
 from packit_service.worker.handler import HandlerResults
 from packit_service.worker.jobs import SteveJobs
 from tests.spellbook import DATA_DIR

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -11,7 +11,7 @@ from packit_service.models import CoprBuild, SRPMBuild
 from packit_service.service.models import CoprBuild as RedisCoprBuild
 from packit_service.worker import sentry_integration
 from packit_service.worker.build.copr_build import CoprBuildJobHelper
-from packit_service.worker.build.build_helper import BuildStatusReporter
+from packit_service.worker.reporting import StatusReporter
 from packit_service.worker.parser import Parser
 from tests.spellbook import DATA_DIR
 
@@ -65,13 +65,13 @@ def build_handler(metadata=None, trigger=None, jobs=None):
 def test_copr_build_check_names():
     metadata = {"owner": "nobody", "targets": ["bright-future-x86_64"]}
     handler = build_handler(metadata)
-    flexmock(BuildStatusReporter).should_receive("set_status").with_args(
+    flexmock(StatusReporter).should_receive("set_status").with_args(
         state="pending",
         description="Building SRPM ...",
         check_name="packit-stg/rpm-build-bright-future-x86_64",
         url="",
     ).and_return()
-    flexmock(BuildStatusReporter).should_receive("set_status").with_args(
+    flexmock(StatusReporter).should_receive("set_status").with_args(
         state="pending",
         description="Building RPM ...",
         check_name="packit-stg/rpm-build-bright-future-x86_64",

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -10,8 +10,8 @@ from packit_service.config import ServiceConfig
 from packit_service.models import CoprBuild, SRPMBuild
 from packit_service.service.models import CoprBuild as RedisCoprBuild
 from packit_service.worker import sentry_integration
-from packit_service.worker.copr_build import CoprBuildJobHelper
-from packit_service.worker.handler import BuildStatusReporter
+from packit_service.worker.build.copr_build import CoprBuildJobHelper
+from packit_service.worker.build.build_helper import BuildStatusReporter
 from packit_service.worker.parser import Parser
 from tests.spellbook import DATA_DIR
 

--- a/tests/unit/test_copr_build_handler.py
+++ b/tests/unit/test_copr_build_handler.py
@@ -2,7 +2,7 @@ import pytest
 from flexmock import flexmock
 from packit.config import PackageConfig, JobConfig, JobType, JobTriggerType
 
-from packit_service.worker.copr_build import CoprBuildJobHelper
+from packit_service.worker.build.copr_build import CoprBuildJobHelper
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -29,7 +29,7 @@ from packit_service.service.events import (
     TestingFarmResult,
     TestResult,
 )
-from packit_service.worker.build import BuildStatusReporter
+from packit_service.worker.reporting import StatusReporter
 from packit_service.worker.testing_farm_handlers import TestingFarmResultsHandler
 
 
@@ -186,7 +186,7 @@ def test_testing_farm_response(
             commit_sha=flexmock(),
         ),
     )
-    flexmock(BuildStatusReporter).should_receive("report").with_args(
+    flexmock(StatusReporter).should_receive("report").with_args(
         state=status_status,
         description=status_message,
         url="some url",

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -29,7 +29,7 @@ from packit_service.service.events import (
     TestingFarmResult,
     TestResult,
 )
-from packit_service.worker.handler import BuildStatusReporter
+from packit_service.worker.build import BuildStatusReporter
 from packit_service.worker.testing_farm_handlers import TestingFarmResultsHandler
 
 

--- a/tests/unit/test_whitelist.py
+++ b/tests/unit/test_whitelist.py
@@ -46,7 +46,7 @@ from packit_service.service.events import (
 )
 from packit_service.service.events import WhitelistStatus
 from packit_service.service.models import Model
-from packit_service.worker.build import BuildStatusReporter
+from packit_service.worker.reporting import StatusReporter
 from packit_service.worker.whitelist import Whitelist
 
 EXPECTED_TESTING_FARM_CHECK_NAME = f"packit-stg/testing-farm-fedora-rawhide-x86_64"
@@ -285,7 +285,7 @@ def test_check_and_report(
             )
             flexmock(LocalProject).should_receive("checkout_pr").and_return(None)
             flexmock(Model).should_receive("save").and_return(None)
-            flexmock(BuildStatusReporter).should_receive("report").with_args(
+            flexmock(StatusReporter).should_receive("report").with_args(
                 description="Account is not whitelisted!",
                 state="error",
                 url=FAQ_URL,


### PR DESCRIPTION
- Preparation for the koji builds.
- The status reports were simplified.
- The status constant were removed.
- Hide sentry calls.
- The `CoprBuildJobHelper` class cleaned.
- Fixes the testing-farm state after successful copr build.
---

- I'll leave the other changes to the next PR, so this one does not get bigger.