### PR TITLE
Refactor: move handlers to submodule

### DIFF
--- a/packit_service/worker/build/copr_build.py
+++ b/packit_service/worker/build/copr_build.py
@@ -46,7 +46,7 @@ from packit_service.service.models import CoprBuild as RedisCoprBuild
 from packit_service.service.urls import get_log_url
 from packit_service.worker import sentry_integration
 from packit_service.worker.build.build_helper import BaseBuildJobHelper
-from packit_service.worker.handler import HandlerResults
+from packit_service.worker.result import HandlerResults
 from packit_service.worker.utils import get_copr_build_url_for_values
 
 try:

--- a/packit_service/worker/build/koji_build.py
+++ b/packit_service/worker/build/koji_build.py
@@ -24,7 +24,7 @@ import logging
 from packit.config import JobType
 
 from packit_service.worker.build.copr_build import BaseBuildJobHelper
-from packit_service.worker.handler import HandlerResults
+from packit_service.worker.result import HandlerResults
 
 logger = logging.getLogger(__name__)
 

--- a/packit_service/worker/handlers/__init__.py
+++ b/packit_service/worker/handlers/__init__.py
@@ -1,0 +1,73 @@
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# If you have some problems with the imports between files in this directory,
+# try using absolute import.
+# Example:
+# from packit_service.worker.handlers.fedmsg_handlers import something
+# instead of
+# from packit_service.worker.handlers import something
+
+
+from packit_service.worker.handlers.abstract import Handler, JobHandler
+from packit_service.worker.handlers.comment_action_handler import CommentActionHandler
+from packit_service.worker.handlers.fedmsg_handlers import (
+    CoprBuildEndHandler,
+    CoprBuildStartHandler,
+    FedmsgHandler,
+    NewDistGitCommitHandler,
+)
+from packit_service.worker.handlers.github_handlers import (
+    AbstractGithubJobHandler,
+    GithubAppInstallationHandler,
+    GithubCoprBuildHandler,
+    GitHubIssueCommentProposeUpdateHandler,
+    GitHubPullRequestCommentCoprBuildHandler,
+    GitHubPullRequestCommentTestingFarmHandler,
+    GithubPullRequestHandler,
+    GithubReleaseHandler,
+    GithubTestingFarmHandler,
+)
+
+from packit_service.worker.handlers.testing_farm_handlers import (
+    TestingFarmResultsHandler,
+)
+
+__all__ = [
+    AbstractGithubJobHandler.__name__,
+    CommentActionHandler.__name__,
+    CoprBuildEndHandler.__name__,
+    CoprBuildStartHandler.__name__,
+    FedmsgHandler.__name__,
+    GithubAppInstallationHandler.__name__,
+    GithubCoprBuildHandler.__name__,
+    GitHubIssueCommentProposeUpdateHandler.__name__,
+    GitHubPullRequestCommentCoprBuildHandler.__name__,
+    GitHubPullRequestCommentTestingFarmHandler.__name__,
+    GithubPullRequestHandler.__name__,
+    GithubReleaseHandler.__name__,
+    GithubTestingFarmHandler.__name__,
+    Handler.__name__,
+    JobHandler.__name__,
+    NewDistGitCommitHandler.__name__,
+    TestingFarmResultsHandler.__name__,
+]

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -27,7 +27,7 @@ import logging
 import shutil
 from os import getenv
 from pathlib import Path
-from typing import Dict, Any, Optional, Type, List
+from typing import Dict, Optional, Type, List
 
 from packit.api import PackitAPI
 from packit.config import JobConfig, JobTriggerType, JobType
@@ -35,6 +35,7 @@ from packit.local_project import LocalProject
 
 from packit_service.config import ServiceConfig
 from packit_service.service.events import Event
+from packit_service.worker.result import HandlerResults
 from packit_service.worker.sentry_integration import push_scope_to_sentry
 
 logger = logging.getLogger(__name__)
@@ -53,26 +54,6 @@ def add_to_mapping_for_job(job_type: JobType):
         return kls
 
     return _add_to_mapping
-
-
-class HandlerResults(dict):
-    """
-    Job handler results.
-    Inherit from dict to be JSON serializable.
-    """
-
-    def __init__(self, success: bool, details: Dict[str, Any] = None):
-        """
-
-        :param success: has the job handler succeeded:
-                          True - we processed the event
-                          False - there was an error while processing it -
-                                  usually an exception
-        :param details: more info from job handler
-                        (optional) 'msg' key contains a message
-                        more keys to be defined
-        """
-        super().__init__(self, success=success, details=details or {})
 
 
 class Handler:

--- a/packit_service/worker/handlers/comment_action_handler.py
+++ b/packit_service/worker/handlers/comment_action_handler.py
@@ -30,7 +30,8 @@ from typing import Dict, Type, Union
 
 from packit_service.config import ServiceConfig
 from packit_service.service.events import PullRequestCommentEvent, IssueCommentEvent
-from packit_service.worker.handler import HandlerResults, Handler
+from packit_service.worker.handlers import Handler
+from packit_service.worker.result import HandlerResults
 
 logger = logging.getLogger(__name__)
 

--- a/packit_service/worker/handlers/fedmsg_handlers.py
+++ b/packit_service/worker/handlers/fedmsg_handlers.py
@@ -50,12 +50,10 @@ from packit_service.service.events import (
 from packit_service.service.urls import get_log_url
 from packit_service.worker.build.copr_build import CoprBuildJobHelper
 from packit_service.worker.copr_db import CoprBuildDB
-from packit_service.worker.github_handlers import GithubTestingFarmHandler
-from packit_service.worker.handler import (
-    JobHandler,
-    HandlerResults,
-    add_to_mapping,
-)
+from packit_service.worker.handlers.abstract import JobHandler
+from packit_service.worker.handlers.abstract import add_to_mapping
+from packit_service.worker.handlers.github_handlers import GithubTestingFarmHandler
+from packit_service.worker.result import HandlerResults
 
 logger = logging.getLogger(__name__)
 
@@ -124,7 +122,7 @@ class FedmsgHandler(JobHandler):
 
 @add_topic
 @add_to_mapping
-class NewDistGitCommit(FedmsgHandler):
+class NewDistGitCommitHandler(FedmsgHandler):
     """ A new flag was added to a dist-git pull request """
 
     topic = "org.fedoraproject.prod.git.receive"

--- a/packit_service/worker/handlers/github_handlers.py
+++ b/packit_service/worker/handlers/github_handlers.py
@@ -51,17 +51,19 @@ from packit_service.service.events import (
 from packit_service.service.models import Installation
 from packit_service.worker import sentry_integration
 from packit_service.worker.build import CoprBuildJobHelper
-from packit_service.worker.comment_action_handler import (
-    CommentAction,
-    add_to_comment_action_mapping,
+from packit_service.worker.handlers import (
     CommentActionHandler,
-    add_to_comment_action_mapping_with_name,
-)
-from packit_service.worker.handler import (
     JobHandler,
-    HandlerResults,
+)
+from packit_service.worker.result import HandlerResults
+from packit_service.worker.handlers.abstract import (
     add_to_mapping,
     add_to_mapping_for_job,
+)
+from packit_service.worker.handlers.comment_action_handler import (
+    add_to_comment_action_mapping,
+    add_to_comment_action_mapping_with_name,
+    CommentAction,
 )
 from packit_service.worker.testing_farm import TestingFarmJobHelper
 from packit_service.worker.whitelist import Whitelist

--- a/packit_service/worker/handlers/testing_farm_handlers.py
+++ b/packit_service/worker/handlers/testing_farm_handlers.py
@@ -35,12 +35,10 @@ from packit.config import (
 
 from packit_service.config import ServiceConfig
 from packit_service.service.events import TestingFarmResultsEvent, TestingFarmResult
+from packit_service.worker.handlers import AbstractGithubJobHandler
+from packit_service.worker.result import HandlerResults
+from packit_service.worker.handlers.abstract import add_to_mapping
 from packit_service.worker.reporting import StatusReporter
-from packit_service.worker.github_handlers import AbstractGithubJobHandler
-from packit_service.worker.handler import (
-    add_to_mapping,
-    HandlerResults,
-)
 from packit_service.worker.testing_farm import TestingFarmJobHelper
 
 logger = logging.getLogger(__name__)

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -40,23 +40,21 @@ from packit_service.service.events import (
     CoprBuildEvent,
     FedmsgTopic,
 )
-from packit_service.worker.comment_action_handler import (
-    COMMENT_ACTION_HANDLER_MAPPING,
-    CommentAction,
-    CommentActionHandler,
-)
-from packit_service.worker.fedmsg_handlers import (
+from packit_service.worker.handlers import (
     CoprBuildEndHandler,
     CoprBuildStartHandler,
-)
-from packit_service.worker.github_handlers import GithubAppInstallationHandler
-from packit_service.worker.handler import (
-    HandlerResults,
-    JOB_NAME_HANDLER_MAPPING,
+    GithubAppInstallationHandler,
+    CommentActionHandler,
+    TestingFarmResultsHandler,
     JobHandler,
 )
+from packit_service.worker.result import HandlerResults
+from packit_service.worker.handlers.abstract import JOB_NAME_HANDLER_MAPPING
+from packit_service.worker.handlers.comment_action_handler import (
+    COMMENT_ACTION_HANDLER_MAPPING,
+    CommentAction,
+)
 from packit_service.worker.parser import Parser
-from packit_service.worker.testing_farm_handlers import TestingFarmResultsHandler
 from packit_service.worker.whitelist import Whitelist
 
 REQUESTED_PULL_REQUEST_COMMENT = "/packit"

--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -43,7 +43,7 @@ from packit_service.service.events import (
     IssueCommentAction,
     CoprBuildEvent,
 )
-from packit_service.worker.fedmsg_handlers import NewDistGitCommit
+from packit_service.worker.handlers import NewDistGitCommitHandler
 
 logger = logging.getLogger(__name__)
 
@@ -340,7 +340,7 @@ class Parser:
     def parse_distgit_event(event) -> Optional[DistGitEvent]:
         """ this corresponds to dist-git event when someone pushes new commits """
         topic = event.get("topic")
-        if topic != NewDistGitCommit.topic:
+        if topic != NewDistGitCommitHandler.topic:
             return None
 
         logger.info(f"Dist-git commit event, topic: {topic}")

--- a/packit_service/worker/result.py
+++ b/packit_service/worker/result.py
@@ -1,0 +1,21 @@
+from typing import Dict, Any
+
+
+class HandlerResults(dict):
+    """
+    Job handler results.
+    Inherit from dict to be JSON serializable.
+    """
+
+    def __init__(self, success: bool, details: Dict[str, Any] = None):
+        """
+
+        :param success: has the job handler succeeded:
+                          True - we processed the event
+                          False - there was an error while processing it -
+                                  usually an exception
+        :param details: more info from job handler
+                        (optional) 'msg' key contains a message
+                        more keys to be defined
+        """
+        super().__init__(self, success=success, details=details or {})

--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -40,7 +40,7 @@ from packit_service.service.events import (
     CoprBuildEvent,
 )
 from packit_service.worker.build import CoprBuildJobHelper
-from packit_service.worker.handler import HandlerResults
+from packit_service.worker.result import HandlerResults
 from packit_service.worker.sentry_integration import send_to_sentry
 
 logger = logging.getLogger(__name__)

--- a/tests/integration/test_handler.py
+++ b/tests/integration/test_handler.py
@@ -27,7 +27,7 @@ from packit.config import JobConfig, JobType, JobTriggerType
 
 from packit_service.config import ServiceConfig
 from packit_service.service.events import Event
-from packit_service.worker.handler import JobHandler
+from packit_service.worker.handlers import JobHandler
 
 
 @pytest.fixture()

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -24,9 +24,9 @@ import json
 
 import pytest
 from flexmock import flexmock
-
 from packit.api import PackitAPI
-from packit_service.worker.handler import HandlerResults
+
+from packit_service.worker.result import HandlerResults
 from packit_service.worker.jobs import SteveJobs
 from tests.spellbook import DATA_DIR
 

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -35,12 +35,11 @@ from packit.local_project import LocalProject
 from packit_service.models import CoprBuild
 from packit_service.service.events import CoprBuildEvent
 from packit_service.service.urls import get_log_url
-from packit_service.worker.reporting import StatusReporter
 from packit_service.worker.build.copr_build import CoprBuildJobHelper
 from packit_service.worker.copr_db import CoprBuildDB
-from packit_service.worker.fedmsg_handlers import CoprBuildEndHandler
-from packit_service.worker.github_handlers import GithubTestingFarmHandler
+from packit_service.worker.handlers import CoprBuildEndHandler, GithubTestingFarmHandler
 from packit_service.worker.jobs import SteveJobs
+from packit_service.worker.reporting import StatusReporter
 from packit_service.worker.testing_farm import TestingFarmJobHelper
 from tests.spellbook import DATA_DIR
 

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -27,7 +27,7 @@ from flexmock import flexmock
 from ogr.services.github import GithubProject
 
 from packit_service.worker.build.copr_build import CoprBuildJobHelper
-from packit_service.worker.handler import HandlerResults
+from packit_service.worker.result import HandlerResults
 from packit_service.worker.jobs import SteveJobs
 from tests.spellbook import DATA_DIR
 

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -30,7 +30,7 @@ from packit_service.service.events import (
     TestResult,
 )
 from packit_service.worker.reporting import StatusReporter
-from packit_service.worker.testing_farm_handlers import TestingFarmResultsHandler
+from packit_service.worker.handlers import TestingFarmResultsHandler
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Move handlers to the `packit_service.worker.handlers` module.