### PR TITLE
use proper github failure status

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -14,3 +14,5 @@ MSG_RETRIGGER = (
     "You can re-trigger build by adding a comment (`/packit {build}`) "
     "into this pull request."
 )
+
+GITHUB_FAILURE_STATUS = "failure"

--- a/packit_service/worker/build/copr_build.py
+++ b/packit_service/worker/build/copr_build.py
@@ -30,7 +30,7 @@ from packit.utils import PackitFormatter
 from sandcastle import SandcastleTimeoutReached
 
 from packit_service.config import ServiceConfig, Deployment
-from packit_service.constants import MSG_RETRIGGER
+from packit_service.constants import MSG_RETRIGGER, GITHUB_FAILURE_STATUS
 from packit_service.models import CoprBuild, SRPMBuild
 from packit_service.service.events import (
     PullRequestEvent,
@@ -139,7 +139,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
         if build_metadata.srpm_failed:
             msg = "SRPM build failed, check the logs for details."
             self.report_status_to_all(
-                state="failed",
+                state=GITHUB_FAILURE_STATUS,
                 description=msg,
                 url=get_srpm_log_url(srpm_build_model.id),
             )

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -2,6 +2,7 @@ import json
 
 from flexmock import flexmock
 from ogr.abstract import GitProject, GitService
+from ogr.services.github.flag import GithubCommitFlag
 from packit.api import PackitAPI
 from packit.config import PackageConfig, JobConfig, JobType, JobTriggerType
 from packit.exceptions import FailedCreateSRPM
@@ -133,10 +134,14 @@ def test_copr_build_fails_in_packit():
             templ.format(ver=v),
             trim=True,
         ).and_return().once()
+    status = "failure"
+    assert GithubCommitFlag._states[
+        status
+    ]  # making sure we set the correct string here
     for v in ["29", "30", "31", "rawhide"]:
         flexmock(GitProject).should_receive("set_commit_status").with_args(
             "528b803be6f93e19ca4130bf4976f2800a3004c4",
-            "failed",
+            status,
             "https://localhost:5000/srpm-build/2/logs",
             "SRPM build failed, check the logs for details.",
             templ.format(ver=v),


### PR DESCRIPTION
stg traceback:
```
  File "/src-packit-service/packit_service/worker/build/build_helper.py", line 234, in _report
    description=description, state=state, url=url, check_names=check_names,
  File "/src-packit-service/packit_service/worker/reporting.py", line 62, in report
    state=state, description=description, check_name=check, url=url
  File "/src-packit-service/packit_service/worker/reporting.py", line 68, in set_status
    self.commit_sha, state, url, description, check_name, trim=True
  File "/usr/lib/python3.7/site-packages/ogr/read_only.py", line 70, in readonly_func
    return func(self, *args, **kwargs)
  File "/usr/lib/python3.7/site-packages/ogr/services/github/project.py", line 346, in set_commit_status
    trim=trim,
  File "/usr/lib/python3.7/site-packages/ogr/services/github/flag.py", line 75, in set
    state = GithubCommitFlag._states[state]
KeyError: 'failed'

```