### PR TITLE
Revert getting job per trigger

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -14,3 +14,8 @@ MSG_RETRIGGER = (
     "You can re-trigger build by adding a comment (`/packit {build}`) "
     "into this pull request."
 )
+
+PERMISSIONS_ERROR_WRITE_OR_ADMIN = (
+    "Only users with write or admin permissions to the repository "
+    "can trigger Packit-as-a-Service"
+)

--- a/packit_service/worker/build/build_helper.py
+++ b/packit_service/worker/build/build_helper.py
@@ -164,7 +164,7 @@ class BaseBuildJobHelper:
 
         if not self._job_build:
             for job in self.package_config.jobs:
-                if job.job == self.job_type_build and job.trigger == self.event.trigger:
+                if job.job == self.job_type_build:
                     self._job_build = job
                     break
         return self._job_build
@@ -180,7 +180,7 @@ class BaseBuildJobHelper:
 
         if not self._job_tests:
             for job in self.package_config.jobs:
-                if job.job == self.job_type_test and job.trigger == self.event.trigger:
+                if job.job == self.job_type_test:
                     self._job_tests = job
                     break
         return self._job_tests


### PR DESCRIPTION
- Do not filter job-configs per trigger. (To make the stg working.)
  - Then `comments` and other events are not matched.
  - Fixes: https://sentry.io/organizations/red-hat-0p/issues/1546065384/?environment=stg&project=1767823&query=is%3Aunresolved

I'll make a propper fix but need some time for that.