### PR TITLE
Split job and jobconfig (service)

### DIFF
--- a/packit_service/config.py
+++ b/packit_service/config.py
@@ -25,8 +25,6 @@ from pathlib import Path
 from typing import Set, Optional
 
 from ogr.abstract import GitProject
-from yaml import safe_load
-
 from packit.config import (
     RunCommandType,
     Config,
@@ -34,6 +32,8 @@ from packit.config import (
     PackageConfig,
 )
 from packit.exceptions import PackitException, PackitConfigException
+from yaml import safe_load
+
 from packit_service.constants import (
     SANDCASTLE_WORK_DIR,
     SANDCASTLE_PVC,

--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -85,7 +85,8 @@ class TheJobTriggerType(str, enum.Enum):
     commit = "commit"
     installation = "installation"
     testing_farm_results = "testing_farm_results"
-    comment = "comment"
+    pr_comment = "pr_comment"
+    issue_comment = "issue_comment"
 
 
 class TestResult(dict):
@@ -295,7 +296,7 @@ class PullRequestCommentEvent(AbstractGithubEvent):
         comment: str,
         commit_sha: str = "",
     ):
-        super().__init__(trigger=TheJobTriggerType.comment, project_url=https_url)
+        super().__init__(trigger=TheJobTriggerType.pr_comment, project_url=https_url)
         self.action = action
         self.pr_id = pr_id
         self.base_repo_namespace = base_repo_namespace
@@ -344,7 +345,7 @@ class IssueCommentEvent(AbstractGithubEvent):
             str
         ] = "master",  # default is master when working with issues
     ):
-        super().__init__(trigger=TheJobTriggerType.comment, project_url=https_url)
+        super().__init__(trigger=TheJobTriggerType.issue_comment, project_url=https_url)
         self.action = action
         self.issue_id = issue_id
         self.base_repo_namespace = base_repo_namespace

--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -30,7 +30,10 @@ from datetime import datetime, timezone
 from typing import Optional, List, Union, Dict
 
 from ogr.abstract import GitProject
-from packit.config import JobTriggerType, get_package_config_from_repo, PackageConfig
+from packit.config import (
+    get_package_config_from_repo,
+    PackageConfig,
+)
 
 from packit_service.config import ServiceConfig, GithubPackageConfigGetter
 from packit_service.models import CoprBuild
@@ -75,6 +78,16 @@ class TestingFarmResult(str, enum.Enum):
     running = "running"
 
 
+class TheJobTriggerType(str, enum.Enum):
+    release = "release"
+    pull_request = "pull_request"
+    push = "push"
+    commit = "commit"
+    installation = "installation"
+    testing_farm_results = "testing_farm_results"
+    comment = "comment"
+
+
 class TestResult(dict):
     def __init__(self, name: str, result: TestingFarmResult, log_url: str):
         dict.__init__(self, name=name, result=result, log_url=log_url)
@@ -104,9 +117,9 @@ class TestResult(dict):
 
 class Event:
     def __init__(
-        self, trigger: JobTriggerType, created_at: Union[int, float, str] = None
+        self, trigger: TheJobTriggerType, created_at: Union[int, float, str] = None
     ):
-        self.trigger: JobTriggerType = trigger
+        self.trigger: TheJobTriggerType = trigger
         self.created_at: datetime
         if created_at:
             if isinstance(created_at, (int, float)):
@@ -163,7 +176,7 @@ class Event:
 
 
 class AbstractGithubEvent(Event, GithubPackageConfigGetter):
-    def __init__(self, trigger: JobTriggerType, project_url: str):
+    def __init__(self, trigger: TheJobTriggerType, project_url: str):
         super().__init__(trigger)
         self.project_url: str = project_url
         self.git_ref: Optional[str] = None  # git ref that can be 'git checkout'-ed
@@ -179,7 +192,7 @@ class ReleaseEvent(AbstractGithubEvent):
     def __init__(
         self, repo_namespace: str, repo_name: str, tag_name: str, https_url: str
     ):
-        super().__init__(trigger=JobTriggerType.release, project_url=https_url)
+        super().__init__(trigger=TheJobTriggerType.release, project_url=https_url)
         self.repo_namespace = repo_namespace
         self.repo_name = repo_name
         self.tag_name = tag_name
@@ -206,7 +219,7 @@ class PushGitHubEvent(AbstractGithubEvent):
         https_url: str,
         commit_sha: str,
     ):
-        super().__init__(trigger=JobTriggerType.commit, project_url=https_url)
+        super().__init__(trigger=TheJobTriggerType.push, project_url=https_url)
         self.repo_namespace = repo_namespace
         self.repo_name = repo_name
         self.git_ref = git_ref
@@ -238,7 +251,7 @@ class PullRequestEvent(AbstractGithubEvent):
         commit_sha: str,
         github_login: str,
     ):
-        super().__init__(trigger=JobTriggerType.pull_request, project_url=https_url)
+        super().__init__(trigger=TheJobTriggerType.pull_request, project_url=https_url)
         self.action = action
         self.pr_id = pr_id
         self.base_repo_namespace = base_repo_namespace
@@ -282,7 +295,7 @@ class PullRequestCommentEvent(AbstractGithubEvent):
         comment: str,
         commit_sha: str = "",
     ):
-        super().__init__(trigger=JobTriggerType.comment, project_url=https_url)
+        super().__init__(trigger=TheJobTriggerType.comment, project_url=https_url)
         self.action = action
         self.pr_id = pr_id
         self.base_repo_namespace = base_repo_namespace
@@ -331,7 +344,7 @@ class IssueCommentEvent(AbstractGithubEvent):
             str
         ] = "master",  # default is master when working with issues
     ):
-        super().__init__(trigger=JobTriggerType.comment, project_url=https_url)
+        super().__init__(trigger=TheJobTriggerType.comment, project_url=https_url)
         self.action = action
         self.issue_id = issue_id
         self.base_repo_namespace = base_repo_namespace
@@ -376,7 +389,7 @@ class InstallationEvent(Event):
         sender_login: str,
         status: WhitelistStatus = WhitelistStatus.waiting,
     ):
-        super().__init__(JobTriggerType.installation, created_at)
+        super().__init__(TheJobTriggerType.installation, created_at)
         self.installation_id = installation_id
         # account == namespace (user/organization) into which the app has been installed
         self.account_login = account_login
@@ -407,7 +420,7 @@ class DistGitEvent(Event):
         msg_id: str,
         project_url: str,
     ):
-        super().__init__(JobTriggerType.commit)
+        super().__init__(trigger=TheJobTriggerType.commit)
         self.topic = FedmsgTopic(topic)
         self.repo_namespace = repo_namespace
         self.repo_name = repo_name
@@ -447,7 +460,7 @@ class TestingFarmResultsEvent(AbstractGithubEvent):
         commit_sha: str,
     ):
         super().__init__(
-            trigger=JobTriggerType.testing_farm_results, project_url=https_url
+            trigger=TheJobTriggerType.testing_farm_results, project_url=https_url
         )
         self.pipeline_id = pipeline_id
         self.result = result
@@ -513,7 +526,7 @@ class CoprBuildEvent(AbstractGithubEvent):
             self.base_repo_namespace = build.get("repo_namespace")
             https_url = build["https_url"]
 
-        super().__init__(trigger=JobTriggerType.pull_request, project_url=https_url)
+        super().__init__(trigger=TheJobTriggerType.pull_request, project_url=https_url)
         self.topic = FedmsgTopic(topic)
         self.build_id = build_id
         self.build = build

--- a/packit_service/trigger_mapping.py
+++ b/packit_service/trigger_mapping.py
@@ -1,0 +1,51 @@
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from typing import Dict, Optional
+
+from packit.config import JobConfigTriggerType, JobConfig
+
+from packit_service.service.events import TheJobTriggerType
+
+JOB_TRIGGER_TO_CONFIG_MAPPING: Dict[
+    TheJobTriggerType, Optional[JobConfigTriggerType]
+] = {
+    TheJobTriggerType.commit: JobConfigTriggerType.commit,
+    TheJobTriggerType.release: JobConfigTriggerType.release,
+    TheJobTriggerType.pull_request: JobConfigTriggerType.pull_request,
+    TheJobTriggerType.push: JobConfigTriggerType.commit,
+    TheJobTriggerType.pr_comment: JobConfigTriggerType.pull_request,
+}
+
+
+def is_trigger_matching_job_config(
+    trigger: TheJobTriggerType, job_config: JobConfig
+) -> bool:
+    """
+    Check that the event trigger matches the one from config.
+
+    We can have multiple events for one config.
+    e.g. Both pr_comment and pull_request are compatible
+         with the pull_request config in the config
+    """
+    config_trigger = JOB_TRIGGER_TO_CONFIG_MAPPING.get(trigger)
+    return bool(config_trigger and job_config.trigger == config_trigger)

--- a/packit_service/worker/build/build_helper.py
+++ b/packit_service/worker/build/build_helper.py
@@ -36,6 +36,7 @@ from packit_service.service.events import (
     PushGitHubEvent,
     ReleaseEvent,
 )
+from packit_service.trigger_mapping import is_trigger_matching_job_config
 from packit_service.worker.reporting import StatusReporter
 
 logger = logging.getLogger(__name__)
@@ -164,7 +165,9 @@ class BaseBuildJobHelper:
 
         if not self._job_build:
             for job in self.package_config.jobs:
-                if job.type == self.job_type_build:
+                if job.type == self.job_type_build and is_trigger_matching_job_config(
+                    trigger=self.event.trigger, job_config=job
+                ):
                     self._job_build = job
                     break
         return self._job_build
@@ -180,7 +183,9 @@ class BaseBuildJobHelper:
 
         if not self._job_tests:
             for job in self.package_config.jobs:
-                if job.type == self.job_type_test:
+                if job.type == self.job_type_test and is_trigger_matching_job_config(
+                    trigger=self.event.trigger, job_config=job
+                ):
                     self._job_tests = job
                     break
         return self._job_tests

--- a/packit_service/worker/build/build_helper.py
+++ b/packit_service/worker/build/build_helper.py
@@ -164,7 +164,7 @@ class BaseBuildJobHelper:
 
         if not self._job_build:
             for job in self.package_config.jobs:
-                if job.job == self.job_type_build:
+                if job.type == self.job_type_build:
                     self._job_build = job
                     break
         return self._job_build
@@ -180,7 +180,7 @@ class BaseBuildJobHelper:
 
         if not self._job_tests:
             for job in self.package_config.jobs:
-                if job.job == self.job_type_test:
+                if job.type == self.job_type_test:
                     self._job_tests = job
                     break
         return self._job_tests

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -30,11 +30,11 @@ from pathlib import Path
 from typing import Dict, Optional, Type, List
 
 from packit.api import PackitAPI
-from packit.config import JobConfig, JobTriggerType, JobType
+from packit.config import JobConfig, JobType
 from packit.local_project import LocalProject
 
 from packit_service.config import ServiceConfig
-from packit_service.service.events import Event
+from packit_service.service.events import Event, TheJobTriggerType
 from packit_service.worker.result import HandlerResults
 from packit_service.sentry_integration import push_scope_to_sentry
 
@@ -133,11 +133,13 @@ class JobHandler(Handler):
     """ Generic interface to handle different type of inputs """
 
     name: JobType
-    triggers: List[JobTriggerType]
+    triggers: List[TheJobTriggerType]
 
-    def __init__(self, config: ServiceConfig, job: Optional[JobConfig], event: Event):
+    def __init__(
+        self, config: ServiceConfig, job_config: Optional[JobConfig], event: Event
+    ):
         super().__init__(config)
-        self.job: Optional[JobConfig] = job
+        self.job_config: Optional[JobConfig] = job_config
         self.event = event
         self._clean_workplace()
 

--- a/packit_service/worker/handlers/fedmsg_handlers.py
+++ b/packit_service/worker/handlers/fedmsg_handlers.py
@@ -252,6 +252,8 @@ class CoprBuildEndHandler(FedmsgHandler):
 
         if (
             self.build_job_helper.job_build
+            and self.build_job_helper.job_build.trigger
+            == TheJobTriggerType.pull_request
             and not self.was_last_build_successful()
             and self.package_config.notifications.pull_request.successful_build
         ):

--- a/packit_service/worker/handlers/fedmsg_handlers.py
+++ b/packit_service/worker/handlers/fedmsg_handlers.py
@@ -32,7 +32,6 @@ from ogr.abstract import CommitStatus
 from packit.api import PackitAPI
 from packit.config import (
     JobType,
-    JobTriggerType,
     JobConfig,
     get_package_config_from_repo,
 )
@@ -47,6 +46,7 @@ from packit_service.service.events import (
     DistGitEvent,
     CoprBuildEvent,
     get_copr_build_logs_url,
+    TheJobTriggerType,
 )
 from packit_service.service.urls import get_log_url
 from packit_service.worker.build.copr_build import CoprBuildJobHelper
@@ -113,8 +113,8 @@ class FedmsgHandler(JobHandler):
 
     topic: str
 
-    def __init__(self, config: ServiceConfig, job: JobConfig, event: Event):
-        super().__init__(config=config, job=job, event=event)
+    def __init__(self, config: ServiceConfig, job_config: JobConfig, event: Event):
+        super().__init__(config=config, job_config=job_config, event=event)
         self._pagure_service = None
 
     def run(self) -> HandlerResults:
@@ -124,21 +124,19 @@ class FedmsgHandler(JobHandler):
 @add_topic
 @add_to_mapping
 class NewDistGitCommitHandler(FedmsgHandler):
-    """ A new flag was added to a dist-git pull request """
+    """Sync new changes to upstream after a new git push in the dist-git."""
 
     topic = "org.fedoraproject.prod.git.receive"
     name = JobType.sync_from_downstream
-    triggers = [JobTriggerType.commit]
+    triggers = [TheJobTriggerType.commit]
 
     def __init__(
-        self, config: ServiceConfig, job: JobConfig, distgit_event: DistGitEvent
+        self, config: ServiceConfig, job_config: JobConfig, event: DistGitEvent
     ):
-        super().__init__(config=config, job=job, event=distgit_event)
-        self.distgit_event = distgit_event
-        self.project = distgit_event.get_project()
-        self.package_config = get_package_config_from_repo(
-            self.project, distgit_event.git_ref
-        )
+        super().__init__(config=config, job_config=job_config, event=event)
+        self.distgit_event = event
+        self.project = event.get_project()
+        self.package_config = get_package_config_from_repo(self.project, event.git_ref)
         if not self.package_config:
             raise ValueError(f"No config file found in {self.project.full_repo_name}")
 
@@ -181,9 +179,12 @@ class CoprBuildEndHandler(FedmsgHandler):
     name = JobType.copr_build_finished
 
     def __init__(
-        self, config: ServiceConfig, job: Optional[JobConfig], event: CoprBuildEvent
+        self,
+        config: ServiceConfig,
+        job_config: Optional[JobConfig],
+        event: CoprBuildEvent,
     ):
-        super().__init__(config=config, job=job, event=event)
+        super().__init__(config=config, job_config=job_config, event=event)
         self.project = self.event.get_project()
         self.package_config = self.event.get_package_config()
         self.build_job_helper = CoprBuildJobHelper(
@@ -286,7 +287,7 @@ class CoprBuildEndHandler(FedmsgHandler):
         ):
             testing_farm_handler = GithubTestingFarmHandler(
                 config=self.config,
-                job=self.build_job_helper.job_tests,
+                job_config=self.build_job_helper.job_tests,
                 event=self.event,
                 chroot=self.event.chroot,
             )
@@ -304,9 +305,12 @@ class CoprBuildStartHandler(FedmsgHandler):
     name = JobType.copr_build_started
 
     def __init__(
-        self, config: ServiceConfig, job: Optional[JobConfig], event: CoprBuildEvent
+        self,
+        config: ServiceConfig,
+        job_config: Optional[JobConfig],
+        event: CoprBuildEvent,
     ):
-        super().__init__(config=config, job=job, event=event)
+        super().__init__(config=config, job_config=job_config, event=event)
         self.project = self.event.get_project()
         self.package_config = self.event.get_package_config()
         self.build_job_helper = CoprBuildJobHelper(

--- a/packit_service/worker/handlers/github_handlers.py
+++ b/packit_service/worker/handlers/github_handlers.py
@@ -537,7 +537,7 @@ class GitHubIssueCommentProposeUpdateHandler(
         configured_branches = [
             job.metadata.get("dist-git-branch")
             for job in self.package_config.jobs
-            if job.job == JobType.propose_downstream
+            if job.type == JobType.propose_downstream
         ]
         if configured_branches:
             return list(get_branches(*configured_branches))

--- a/packit_service/worker/handlers/github_handlers.py
+++ b/packit_service/worker/handlers/github_handlers.py
@@ -31,7 +31,6 @@ from ogr.abstract import GitProject, CommitStatus
 from packit.api import PackitAPI
 from packit.config import (
     JobConfig,
-    JobTriggerType,
     JobType,
     PackageConfig,
 )
@@ -49,6 +48,7 @@ from packit_service.service.events import (
     IssueCommentEvent,
     CoprBuildEvent,
     PushGitHubEvent,
+    TheJobTriggerType,
 )
 from packit_service.service.models import Installation
 from packit_service import sentry_integration
@@ -80,14 +80,14 @@ class AbstractGithubJobHandler(JobHandler, GithubPackageConfigGetter):
 @add_to_mapping
 class GithubPullRequestHandler(AbstractGithubJobHandler):
     name = JobType.check_downstream
-    triggers = [JobTriggerType.pull_request]
+    triggers = [TheJobTriggerType.pull_request]
 
     # https://developer.github.com/v3/activity/events/types/#events-api-payload-28
 
     def __init__(
-        self, config: ServiceConfig, job: JobConfig, pr_event: PullRequestEvent
+        self, config: ServiceConfig, job_config: JobConfig, pr_event: PullRequestEvent
     ):
-        super().__init__(config=config, job=job, event=pr_event)
+        super().__init__(config=config, job_config=job_config, event=pr_event)
         self.pr_event = pr_event
         self.project: GitProject = pr_event.get_project()
         self.package_config: PackageConfig = self.get_package_config_from_repo(
@@ -104,7 +104,7 @@ class GithubPullRequestHandler(AbstractGithubJobHandler):
 
         self.api.sync_pr(
             pr_id=self.pr_event.pr_id,
-            dist_git_branch=self.job.metadata.get("dist-git-branch", "master"),
+            dist_git_branch=self.job_config.metadata.get("dist-git-branch", "master"),
             # TODO: figure out top upstream commit for source-git here
         )
         return HandlerResults(success=True, details={})
@@ -113,17 +113,17 @@ class GithubPullRequestHandler(AbstractGithubJobHandler):
 @add_to_mapping
 class GithubAppInstallationHandler(AbstractGithubJobHandler):
     name = JobType.add_to_whitelist
-    triggers = [JobTriggerType.installation]
+    triggers = [TheJobTriggerType.installation]
 
     # https://developer.github.com/v3/activity/events/types/#events-api-payload-28
 
     def __init__(
         self,
         config: ServiceConfig,
-        job: Optional[JobConfig],
+        job_config: Optional[JobConfig],
         installation_event: Union[InstallationEvent, Any],
     ):
-        super().__init__(config=config, job=job, event=installation_event)
+        super().__init__(config=config, job_config=job_config, event=installation_event)
 
         self.installation_event = installation_event
         self.project = self.config.get_project(
@@ -171,13 +171,13 @@ class GithubAppInstallationHandler(AbstractGithubJobHandler):
 @add_to_mapping
 class GithubReleaseHandler(AbstractGithubJobHandler):
     name = JobType.propose_downstream
-    triggers = [JobTriggerType.release]
+    triggers = [TheJobTriggerType.release]
     event: ReleaseEvent
 
     def __init__(
-        self, config: ServiceConfig, job: JobConfig, release_event: ReleaseEvent
+        self, config: ServiceConfig, job_config: JobConfig, release_event: ReleaseEvent
     ):
-        super().__init__(config=config, job=job, event=release_event)
+        super().__init__(config=config, job_config=job_config, event=release_event)
 
         self.project: GitProject = release_event.get_project()
         self.package_config: PackageConfig = self.get_package_config_from_repo(
@@ -197,7 +197,9 @@ class GithubReleaseHandler(AbstractGithubJobHandler):
         self.api = PackitAPI(self.config, self.package_config, self.local_project)
 
         errors = {}
-        for branch in get_branches(self.job.metadata.get("dist-git-branch", "master")):
+        for branch in get_branches(
+            self.job_config.metadata.get("dist-git-branch", "master")
+        ):
             try:
                 self.api.sync_release(
                     dist_git_branch=branch, version=self.event.tag_name
@@ -243,10 +245,10 @@ class AbstractGithubCoprBuildHandler(AbstractGithubJobHandler):
     def __init__(
         self,
         config: ServiceConfig,
-        job: JobConfig,
+        job_config: JobConfig,
         event: Union[PullRequestEvent, ReleaseEvent, PushGitHubEvent],
     ):
-        super().__init__(config=config, job=job, event=event)
+        super().__init__(config=config, job_config=job_config, event=event)
 
         if not isinstance(event, (PullRequestEvent, PushGitHubEvent, ReleaseEvent)):
             raise PackitException(
@@ -268,7 +270,7 @@ class AbstractGithubCoprBuildHandler(AbstractGithubJobHandler):
                 package_config=self.package_config,
                 project=self.project,
                 event=self.event,
-                job=self.job,
+                job=self.job_config,
             )
         return self._copr_build_helper
 
@@ -299,7 +301,7 @@ class AbstractGithubCoprBuildHandler(AbstractGithubJobHandler):
             [JobConfig], bool
         ] = lambda job: job.job == JobType.copr_build
 
-        if self.job.job == JobType.tests and any(
+        if self.job_config.job == JobType.tests and any(
             filter(is_copr_build, self.package_config.jobs)
         ):
             logger.info(
@@ -313,22 +315,22 @@ class AbstractGithubCoprBuildHandler(AbstractGithubJobHandler):
 @add_to_mapping_for_job(job_type=JobType.tests)
 class ReleaseGithubCoprBuildHandler(AbstractGithubCoprBuildHandler):
     triggers = [
-        JobTriggerType.release,
+        TheJobTriggerType.release,
     ]
 
     event: ReleaseEvent
 
     def __init__(
-        self, config: ServiceConfig, job: JobConfig, event: ReleaseEvent,
+        self, config: ServiceConfig, job_config: JobConfig, event: ReleaseEvent,
     ):
-        super().__init__(config=config, job=job, event=event)
+        super().__init__(config=config, job_config=job_config, event=event)
         self.base_ref = event.tag_name
 
     def pre_check(self) -> bool:
         return (
             super().pre_check()
             and isinstance(self.event, ReleaseEvent)
-            and self.event.trigger == JobTriggerType.release
+            and self.event.trigger == TheJobTriggerType.release
         )
 
 
@@ -336,14 +338,14 @@ class ReleaseGithubCoprBuildHandler(AbstractGithubCoprBuildHandler):
 @add_to_mapping_for_job(job_type=JobType.tests)
 class PullRequestGithubCoprBuildHandler(AbstractGithubCoprBuildHandler):
     triggers = [
-        JobTriggerType.pull_request,
+        TheJobTriggerType.pull_request,
     ]
     event: PullRequestEvent
 
     def __init__(
-        self, config: ServiceConfig, job: JobConfig, event: PullRequestEvent,
+        self, config: ServiceConfig, job_config: JobConfig, event: PullRequestEvent,
     ):
-        super().__init__(config=config, job=job, event=event)
+        super().__init__(config=config, job_config=job_config, event=event)
 
     def run(self) -> HandlerResults:
         if isinstance(self.event, GithubPullRequestHandler):
@@ -362,7 +364,7 @@ class PullRequestGithubCoprBuildHandler(AbstractGithubCoprBuildHandler):
         return (
             super().pre_check()
             and isinstance(self.event, PullRequestEvent)
-            and self.event.trigger == JobTriggerType.pull_request
+            and self.event.trigger == TheJobTriggerType.pull_request
         )
 
 
@@ -370,21 +372,21 @@ class PullRequestGithubCoprBuildHandler(AbstractGithubCoprBuildHandler):
 @add_to_mapping_for_job(job_type=JobType.tests)
 class PushGithubCoprBuildHandler(AbstractGithubCoprBuildHandler):
     triggers = [
-        JobTriggerType.commit,
+        TheJobTriggerType.commit,
     ]
     event: PushGitHubEvent
 
     def __init__(
-        self, config: ServiceConfig, job: JobConfig, event: PushGitHubEvent,
+        self, config: ServiceConfig, job_config: JobConfig, event: PushGitHubEvent,
     ):
-        super().__init__(config=config, job=job, event=event)
+        super().__init__(config=config, job_config=job_config, event=event)
         self.base_ref = event.commit_sha
 
     def pre_check(self) -> bool:
         valid = (
             super().pre_check()
             and isinstance(self.event, PushGitHubEvent)
-            and self.event.trigger == JobTriggerType.commit
+            and self.event.trigger == TheJobTriggerType.commit
         )
         if not valid:
             return False
@@ -408,17 +410,17 @@ class GithubTestingFarmHandler(AbstractGithubJobHandler):
     """
 
     name = JobType.tests
-    triggers = [JobTriggerType.pull_request]
+    triggers = [TheJobTriggerType.pull_request]
     event: Union[CoprBuildEvent, PullRequestCommentEvent]
 
     def __init__(
         self,
         config: ServiceConfig,
-        job: JobConfig,
+        job_config: JobConfig,
         event: Union[CoprBuildEvent, PullRequestCommentEvent],
         chroot: str,
     ):
-        super().__init__(config=config, job=job, event=event)
+        super().__init__(config=config, job_config=job_config, event=event)
         self.chroot = chroot
         self.project: GitProject = event.get_project()
         if isinstance(event, CoprBuildEvent):

--- a/packit_service/worker/handlers/testing_farm_handlers.py
+++ b/packit_service/worker/handlers/testing_farm_handlers.py
@@ -29,13 +29,16 @@ from typing import Optional
 from ogr.abstract import GitProject, CommitStatus
 from packit.config import (
     JobType,
-    JobTriggerType,
     JobConfig,
     get_package_config_from_repo,
 )
 
 from packit_service.config import ServiceConfig
-from packit_service.service.events import TestingFarmResultsEvent, TestingFarmResult
+from packit_service.service.events import (
+    TestingFarmResultsEvent,
+    TestingFarmResult,
+    TheJobTriggerType,
+)
 from packit_service.worker.handlers import AbstractGithubJobHandler
 from packit_service.worker.handlers.abstract import add_to_mapping
 from packit_service.worker.reporting import StatusReporter
@@ -48,16 +51,16 @@ logger = logging.getLogger(__name__)
 @add_to_mapping
 class TestingFarmResultsHandler(AbstractGithubJobHandler):
     name = JobType.report_test_results
-    triggers = [JobTriggerType.testing_farm_results]
+    triggers = [TheJobTriggerType.testing_farm_results]
     event: TestingFarmResultsEvent
 
     def __init__(
         self,
         config: ServiceConfig,
-        job: Optional[JobConfig],
+        job_config: Optional[JobConfig],
         test_results_event: TestingFarmResultsEvent,
     ):
-        super().__init__(config=config, job=job, event=test_results_event)
+        super().__init__(config=config, job_config=job_config, event=test_results_event)
         self.project: GitProject = test_results_event.get_project()
         self.package_config = self.get_package_config_from_repo(
             project=self.project, reference=self.event.git_ref

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -29,7 +29,7 @@ from typing import Optional, Dict, Union, Type
 
 from ogr.abstract import GitProject
 from ogr.services.github import GithubProject
-from packit.config import JobTriggerType, JobType
+from packit.config import JobType
 
 from packit_service.config import ServiceConfig
 from packit_service.service.events import (
@@ -39,6 +39,7 @@ from packit_service.service.events import (
     TestingFarmResultsEvent,
     CoprBuildEvent,
     FedmsgTopic,
+    TheJobTriggerType,
 )
 from packit_service.worker.handlers import (
     CoprBuildEndHandler,
@@ -48,7 +49,7 @@ from packit_service.worker.handlers import (
     TestingFarmResultsHandler,
     JobHandler,
 )
-from packit_service.worker.handlers.abstract import JOB_NAME_HANDLER_MAPPING
+from packit_service.worker.handlers.abstract import JOB_NAME_HANDLER_MAPPING, Handler
 from packit_service.worker.handlers.comment_action_handler import (
     COMMENT_ACTION_HANDLER_MAPPING,
     CommentAction,
@@ -103,7 +104,7 @@ class SteveJobs:
         for job in package_config.jobs:
             if event.trigger == job.trigger:
                 handler_kls: Type[JobHandler] = JOB_NAME_HANDLER_MAPPING.get(
-                    job.job, None
+                    job.type, None
                 )
                 if not handler_kls:
                     logger.warning(f"There is no handler for job {job}")
@@ -201,7 +202,8 @@ class SteveJobs:
                 success=True, details={"msg": "Account is not whitelisted!"}
             )
 
-        return handler_kls(self.config, event).run_n_clean()
+        handler_instance: Handler = handler_kls(config=self.config, event=event)
+        return handler_instance.run_n_clean()
 
     def process_message(self, event: dict, topic: str = None) -> Optional[dict]:
         """
@@ -246,35 +248,38 @@ class SteveJobs:
         jobs_results: Dict[str, HandlerResults] = {}
         # installation is handled differently b/c app is installed to GitHub account
         # not repository, so package config with jobs is missing
-        if event_object.trigger == JobTriggerType.installation:
+        if event_object.trigger == TheJobTriggerType.installation:
             handler = GithubAppInstallationHandler(
-                self.config, job=None, installation_event=event_object
+                self.config, job_config=None, installation_event=event_object
             )
             job_type = JobType.add_to_whitelist.value
             jobs_results[job_type] = handler.run_n_clean()
         # Results from testing farm is another job which is not defined in packit.yaml so
         # it needs to be handled outside process_jobs method
-        elif event_object.trigger == JobTriggerType.testing_farm_results and isinstance(
-            event_object, TestingFarmResultsEvent
+        elif (
+            event_object.trigger == TheJobTriggerType.testing_farm_results
+            and isinstance(event_object, TestingFarmResultsEvent)
         ):
             handler = TestingFarmResultsHandler(
-                self.config, job=None, test_results_event=event_object
+                self.config, job_config=None, test_results_event=event_object
             )
             job_type = JobType.report_test_results.value
             jobs_results[job_type] = handler.run_n_clean()
         elif isinstance(event_object, CoprBuildEvent):
             if event_object.topic == FedmsgTopic.copr_build_started:
                 handler = CoprBuildStartHandler(
-                    self.config, job=None, event=event_object
+                    self.config, job_config=None, event=event_object
                 )
                 job_type = JobType.copr_build_started.value
             elif event_object.topic == FedmsgTopic.copr_build_finished:
-                handler = CoprBuildEndHandler(self.config, job=None, event=event_object)
+                handler = CoprBuildEndHandler(
+                    self.config, job_config=None, event=event_object
+                )
                 job_type = JobType.copr_build_finished.value
             else:
                 raise ValueError(f"Unknown topic {event_object.topic}")
             jobs_results[job_type] = handler.run_n_clean()
-        elif event_object.trigger == JobTriggerType.comment and (
+        elif event_object.trigger == TheJobTriggerType.comment and (
             isinstance(event_object, (PullRequestCommentEvent, IssueCommentEvent))
         ):
             job_type = JobType.pull_request_action.value

--- a/packit_service/worker/whitelist.py
+++ b/packit_service/worker/whitelist.py
@@ -24,7 +24,6 @@ from typing import Optional, Any
 from fedora.client import AuthError, FedoraServiceError
 from fedora.client.fas2 import AccountSystem
 from ogr.abstract import GitProject, CommitStatus
-from packit.config import JobTriggerType
 from packit.exceptions import PackitException
 from persistentdict.dict_in_redis import PersistentDict
 
@@ -41,6 +40,7 @@ from packit_service.service.events import (
     TestingFarmResultsEvent,
     DistGitEvent,
     PushGitHubEvent,
+    TheJobTriggerType,
 )
 from packit_service.worker.build import CoprBuildJobHelper
 
@@ -219,7 +219,7 @@ class Whitelist:
                 logger.error(msg)
                 # TODO also check blacklist,
                 # but for that we need to know who triggered the action
-                if event.trigger == JobTriggerType.comment:
+                if event.trigger == TheJobTriggerType.comment:
                     project.pr_comment(event.pr_id, msg)
                 else:
                     job_helper = CoprBuildJobHelper(

--- a/packit_service/worker/whitelist.py
+++ b/packit_service/worker/whitelist.py
@@ -219,7 +219,7 @@ class Whitelist:
                 logger.error(msg)
                 # TODO also check blacklist,
                 # but for that we need to know who triggered the action
-                if event.trigger == TheJobTriggerType.comment:
+                if event.trigger == TheJobTriggerType.pr_comment:
                     project.pr_comment(event.pr_id, msg)
                 else:
                     job_helper = CoprBuildJobHelper(

--- a/tests/integration/test_handler.py
+++ b/tests/integration/test_handler.py
@@ -23,10 +23,10 @@ import os
 from pathlib import Path
 
 import pytest
-from packit.config import JobConfig, JobType, JobTriggerType
+from packit.config import JobConfig, JobType, JobConfigTriggerType
 
 from packit_service.config import ServiceConfig
-from packit_service.service.events import Event
+from packit_service.service.events import Event, TheJobTriggerType
 from packit_service.worker.handlers import JobHandler
 
 
@@ -50,8 +50,12 @@ def test_handler_cleanup(tmpdir, trick_p_s_with_k8s):
 
     c = ServiceConfig()
     c.command_handler_work_dir = t
-    jc = JobConfig(JobType.copr_build, JobTriggerType.pull_request, {})
-    j = JobHandler(c, jc, Event(JobTriggerType.pull_request))
+    jc = JobConfig(
+        type=JobType.copr_build, trigger=JobConfigTriggerType.pull_request, metadata={}
+    )
+    j = JobHandler(
+        config=c, job_config=jc, event=Event(trigger=TheJobTriggerType.pull_request)
+    )
 
     j._clean_workplace()
 

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -28,7 +28,7 @@ from flexmock import flexmock
 from ogr.abstract import CommitStatus
 from ogr.services.github import GithubProject
 from ogr.utils import RequestResponse
-from packit.config import JobConfig, JobType, JobTriggerType
+from packit.config import JobConfig, JobType, JobConfigTriggerType
 from packit.config.package_config import PackageConfig
 from packit.copr_helper import CoprHelper
 from packit.local_project import LocalProject
@@ -64,8 +64,8 @@ def pc_build():
     return PackageConfig(
         jobs=[
             JobConfig(
-                job=JobType.copr_build,
-                trigger=JobTriggerType.pull_request,
+                type=JobType.copr_build,
+                trigger=JobConfigTriggerType.pull_request,
                 metadata={"targets": ["fedora-all"]},
             )
         ]
@@ -77,8 +77,8 @@ def pc_tests():
     return PackageConfig(
         jobs=[
             JobConfig(
-                job=JobType.tests,
-                trigger=JobTriggerType.pull_request,
+                type=JobType.tests,
+                trigger=JobConfigTriggerType.pull_request,
                 metadata={"targets": ["fedora-all"]},
             )
         ]
@@ -161,13 +161,13 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build):
     config = PackageConfig(
         jobs=[
             JobConfig(
-                job=JobType.copr_build,
-                trigger=JobTriggerType.pull_request,
+                type=JobType.copr_build,
+                trigger=JobConfigTriggerType.pull_request,
                 metadata={"targets": ["fedora-rawhide"]},
             ),
             JobConfig(
-                job=JobType.tests,
-                trigger=JobTriggerType.pull_request,
+                type=JobType.tests,
+                trigger=JobConfigTriggerType.pull_request,
                 metadata={"targets": ["fedora-rawhide"]},
             ),
         ]
@@ -259,13 +259,13 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build):
     config = PackageConfig(
         jobs=[
             JobConfig(
-                job=JobType.copr_build,
-                trigger=JobTriggerType.pull_request,
+                type=JobType.copr_build,
+                trigger=JobConfigTriggerType.pull_request,
                 metadata={"targets": ["fedora-rawhide"]},
             ),
             JobConfig(
-                job=JobType.tests,
-                trigger=JobTriggerType.pull_request,
+                type=JobType.tests,
+                trigger=JobConfigTriggerType.pull_request,
                 metadata={"targets": ["fedora-rawhide"]},
             ),
         ]
@@ -356,13 +356,13 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build):
     config = PackageConfig(
         jobs=[
             JobConfig(
-                job=JobType.copr_build,
-                trigger=JobTriggerType.pull_request,
+                type=JobType.copr_build,
+                trigger=JobConfigTriggerType.pull_request,
                 metadata={"targets": ["fedora-rawhide"]},
             ),
             JobConfig(
-                job=JobType.tests,
-                trigger=JobTriggerType.pull_request,
+                type=JobType.tests,
+                trigger=JobConfigTriggerType.pull_request,
                 metadata={"targets": ["fedora-rawhide"]},
             ),
         ]

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -60,12 +60,38 @@ def copr_build_end():
 
 
 @pytest.fixture()
-def pc_build():
+def pc_build_pr():
     return PackageConfig(
         jobs=[
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.pull_request,
+                metadata={"targets": ["fedora-all"]},
+            )
+        ]
+    )
+
+
+@pytest.fixture()
+def pc_build_push():
+    return PackageConfig(
+        jobs=[
+            JobConfig(
+                type=JobType.copr_build,
+                trigger=JobConfigTriggerType.commit,
+                metadata={"targets": ["fedora-all"]},
+            )
+        ]
+    )
+
+
+@pytest.fixture()
+def pc_build_release():
+    return PackageConfig(
+        jobs=[
+            JobConfig(
+                type=JobType.copr_build,
+                trigger=JobConfigTriggerType.release,
                 metadata={"targets": ["fedora-all"]},
             )
         ]
@@ -89,7 +115,7 @@ def pc_tests():
     "pc_comment_pr_succ,pr_comment_called", ((True, True), (False, False),)
 )
 def test_copr_build_end(
-    copr_build_end, pc_build, copr_build, pc_comment_pr_succ, pr_comment_called
+    copr_build_end, pc_build_pr, copr_build, pc_comment_pr_succ, pr_comment_called
 ):
     steve = SteveJobs()
     flexmock(SteveJobs, _is_private=False)
@@ -104,8 +130,10 @@ def test_copr_build_end(
     flexmock(CoprBuildJobHelper).should_receive("copr_build_model").and_return(
         flexmock()
     )
-    pc_build.notifications.pull_request.successful_build = pc_comment_pr_succ
-    flexmock(CoprBuildEvent).should_receive("get_package_config").and_return(pc_build)
+    pc_build_pr.notifications.pull_request.successful_build = pc_comment_pr_succ
+    flexmock(CoprBuildEvent).should_receive("get_package_config").and_return(
+        pc_build_pr
+    )
     flexmock(CoprBuildEndHandler).should_receive(
         "was_last_build_successful"
     ).and_return(False)
@@ -113,6 +141,126 @@ def test_copr_build_end(
         flexmock(GithubProject).should_receive("pr_comment")
     else:
         flexmock(GithubProject).should_receive("pr_comment").never()
+
+    flexmock(CoprBuild).should_receive("get_by_build_id").and_return(copr_build)
+    flexmock(CoprBuild).should_receive("set_status").with_args("success")
+    flexmock(CoprBuildDB).should_receive("get_build").and_return(
+        {
+            "commit_sha": "XXXXX",
+            "pr_id": 24,
+            "repo_name": "hello-world",
+            "repo_namespace": "packit-service",
+            "ref": "XXXX",
+            "https_url": "https://github.com/packit-service/hello-world",
+        }
+    )
+
+    url = get_log_url(1)
+    flexmock(requests).should_receive("get").and_return(requests.Response())
+    flexmock(requests.Response).should_receive("raise_for_status").and_return(None)
+    # check if packit-service set correct PR status
+    flexmock(StatusReporter).should_receive("report").with_args(
+        state=CommitStatus.success,
+        description="RPMs were built successfully.",
+        url=url,
+        check_names=CoprBuildJobHelper.get_build_check(copr_build_end["chroot"]),
+    ).once()
+
+    # skip testing farm
+    flexmock(CoprBuildJobHelper).should_receive("job_tests").and_return(None)
+
+    steve.process_message(copr_build_end)
+
+
+@pytest.mark.skip(
+    "We need to save/load right trigger type. "
+    "Currently, there is pull_request hardcoded. "
+    "(See super call in CoprBuildEvent __init__. "
+    "Change it to commit if you want to test it.)"
+)
+def test_copr_build_end_push(copr_build_end, pc_build_push, copr_build):
+    steve = SteveJobs()
+    flexmock(SteveJobs, _is_private=False)
+    flexmock(CoprHelper).should_receive("get_copr_client").and_return(
+        Client(
+            config={
+                "copr_url": "https://copr.fedorainfracloud.org",
+                "username": "some-owner",
+            }
+        )
+    )
+    flexmock(CoprBuildJobHelper).should_receive("copr_build_model").and_return(
+        flexmock()
+    )
+    flexmock(CoprBuildEvent).should_receive("get_package_config").and_return(
+        pc_build_push
+    )
+    flexmock(CoprBuildEndHandler).should_receive(
+        "was_last_build_successful"
+    ).and_return(False)
+
+    # we cannot comment for branch push events
+    flexmock(GithubProject).should_receive("pr_comment").never()
+
+    flexmock(CoprBuild).should_receive("get_by_build_id").and_return(copr_build)
+    flexmock(CoprBuild).should_receive("set_status").with_args("success")
+    flexmock(CoprBuildDB).should_receive("get_build").and_return(
+        {
+            "commit_sha": "XXXXX",
+            "pr_id": 24,
+            "repo_name": "hello-world",
+            "repo_namespace": "packit-service",
+            "ref": "XXXX",
+            "https_url": "https://github.com/packit-service/hello-world",
+        }
+    )
+
+    url = get_log_url(1)
+    flexmock(requests).should_receive("get").and_return(requests.Response())
+    flexmock(requests.Response).should_receive("raise_for_status").and_return(None)
+    # check if packit-service set correct PR status
+    flexmock(StatusReporter).should_receive("report").with_args(
+        state=CommitStatus.success,
+        description="RPMs were built successfully.",
+        url=url,
+        check_names=CoprBuildJobHelper.get_build_check(copr_build_end["chroot"]),
+    ).once()
+
+    # skip testing farm
+    flexmock(CoprBuildJobHelper).should_receive("job_tests").and_return(None)
+
+    steve.process_message(copr_build_end)
+
+
+@pytest.mark.skip(
+    "We need to save/load right trigger type. "
+    "Currently, there is pull_request hardcoded. "
+    "(See super call in CoprBuildEvent __init__. "
+    "Change it to release if you want to test it.)"
+)
+def test_copr_build_end_release(copr_build_end, pc_build_release, copr_build):
+    steve = SteveJobs()
+    flexmock(SteveJobs, _is_private=False)
+    flexmock(CoprHelper).should_receive("get_copr_client").and_return(
+        Client(
+            config={
+                "copr_url": "https://copr.fedorainfracloud.org",
+                "username": "some-owner",
+            }
+        )
+    )
+    flexmock(CoprBuildJobHelper).should_receive("copr_build_model").and_return(
+        flexmock()
+    )
+    flexmock(CoprBuildEvent).should_receive("get_package_config").and_return(
+        pc_build_release
+    )
+    flexmock(CoprBuildEndHandler).should_receive(
+        "was_last_build_successful"
+    ).and_return(False)
+
+    # we cannot comment for branch push events
+    flexmock(GithubProject).should_receive("pr_comment").never()
 
     flexmock(CoprBuild).should_receive("get_by_build_id").and_return(copr_build)
     flexmock(CoprBuild).should_receive("set_status").with_args("success")
@@ -439,7 +587,7 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build):
     steve.process_message(copr_build_end)
 
 
-def test_copr_build_start(copr_build_start, pc_build, copr_build):
+def test_copr_build_start(copr_build_start, pc_build_pr, copr_build):
     steve = SteveJobs()
     flexmock(SteveJobs, _is_private=False)
     flexmock(CoprHelper).should_receive("get_copr_client").and_return(
@@ -453,7 +601,9 @@ def test_copr_build_start(copr_build_start, pc_build, copr_build):
     flexmock(CoprBuildJobHelper).should_receive("copr_build_model").and_return(
         flexmock()
     )
-    flexmock(CoprBuildEvent).should_receive("get_package_config").and_return(pc_build)
+    flexmock(CoprBuildEvent).should_receive("get_package_config").and_return(
+        pc_build_pr
+    )
     flexmock(CoprBuildJobHelper).should_receive("get_build_check").and_return(
         EXPECTED_BUILD_CHECK_NAME
     )
@@ -545,7 +695,7 @@ def test_copr_build_just_tests_defined(copr_build_start, pc_tests, copr_build):
     steve.process_message(copr_build_start)
 
 
-def test_copr_build_not_comment_on_success(copr_build_end, pc_build, copr_build):
+def test_copr_build_not_comment_on_success(copr_build_end, pc_build_pr, copr_build):
     steve = SteveJobs()
     flexmock(SteveJobs, _is_private=False)
     flexmock(CoprHelper).should_receive("get_copr_client").and_return(
@@ -559,7 +709,9 @@ def test_copr_build_not_comment_on_success(copr_build_end, pc_build, copr_build)
     flexmock(CoprBuildJobHelper).should_receive("copr_build_model").and_return(
         flexmock()
     )
-    flexmock(CoprBuildEvent).should_receive("get_package_config").and_return(pc_build)
+    flexmock(CoprBuildEvent).should_receive("get_package_config").and_return(
+        pc_build_pr
+    )
     flexmock(CoprBuildJobHelper).should_receive("get_build_check").and_return(
         EXPECTED_BUILD_CHECK_NAME
     )

--- a/tests/unit/test_build_helper.py
+++ b/tests/unit/test_build_helper.py
@@ -1,6 +1,6 @@
 import pytest
 from flexmock import flexmock
-from packit.config import PackageConfig, JobConfig, JobType, JobTriggerType
+from packit.config import PackageConfig, JobConfig, JobType, JobConfigTriggerType
 
 from packit_service.worker.build.copr_build import CoprBuildJobHelper
 
@@ -11,8 +11,8 @@ from packit_service.worker.build.copr_build import CoprBuildJobHelper
         pytest.param(
             [
                 JobConfig(
-                    job=JobType.copr_build,
-                    trigger=JobTriggerType.pull_request,
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
                     metadata={"targets": ["fedora-29", "fedora-31"]},
                 )
             ],
@@ -23,8 +23,8 @@ from packit_service.worker.build.copr_build import CoprBuildJobHelper
         pytest.param(
             [
                 JobConfig(
-                    job=JobType.copr_build,
-                    trigger=JobTriggerType.pull_request,
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
                     metadata={},
                 )
             ],
@@ -35,7 +35,9 @@ from packit_service.worker.build.copr_build import CoprBuildJobHelper
         pytest.param(
             [
                 JobConfig(
-                    job=JobType.tests, trigger=JobTriggerType.pull_request, metadata={},
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    metadata={},
                 )
             ],
             {"fedora-30-x86_64", "fedora-31-x86_64"},
@@ -45,8 +47,8 @@ from packit_service.worker.build.copr_build import CoprBuildJobHelper
         pytest.param(
             [
                 JobConfig(
-                    job=JobType.tests,
-                    trigger=JobTriggerType.pull_request,
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
                     metadata={"targets": ["fedora-29", "fedora-31"]},
                 )
             ],
@@ -57,12 +59,14 @@ from packit_service.worker.build.copr_build import CoprBuildJobHelper
         pytest.param(
             [
                 JobConfig(
-                    job=JobType.copr_build,
-                    trigger=JobTriggerType.pull_request,
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
                     metadata={},
                 ),
                 JobConfig(
-                    job=JobType.tests, trigger=JobTriggerType.pull_request, metadata={},
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    metadata={},
                 ),
             ],
             {"fedora-30-x86_64", "fedora-31-x86_64"},
@@ -72,12 +76,14 @@ from packit_service.worker.build.copr_build import CoprBuildJobHelper
         pytest.param(
             [
                 JobConfig(
-                    job=JobType.copr_build,
-                    trigger=JobTriggerType.pull_request,
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
                     metadata={"targets": ["fedora-29", "fedora-31"]},
                 ),
                 JobConfig(
-                    job=JobType.tests, trigger=JobTriggerType.pull_request, metadata={},
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    metadata={},
                 ),
             ],
             {"fedora-29-x86_64", "fedora-31-x86_64"},
@@ -87,13 +93,13 @@ from packit_service.worker.build.copr_build import CoprBuildJobHelper
         pytest.param(
             [
                 JobConfig(
-                    job=JobType.copr_build,
-                    trigger=JobTriggerType.pull_request,
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
                     metadata={},
                 ),
                 JobConfig(
-                    job=JobType.tests,
-                    trigger=JobTriggerType.pull_request,
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
                     metadata={"targets": ["fedora-29", "fedora-31"]},
                 ),
             ],
@@ -104,13 +110,13 @@ from packit_service.worker.build.copr_build import CoprBuildJobHelper
         pytest.param(
             [
                 JobConfig(
-                    job=JobType.copr_build,
-                    trigger=JobTriggerType.pull_request,
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
                     metadata={},
                 ),
                 JobConfig(
-                    job=JobType.tests,
-                    trigger=JobTriggerType.pull_request,
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
                     metadata={"targets": "fedora-29"},
                 ),
             ],
@@ -125,11 +131,11 @@ def test_targets(jobs, build_targets, test_targets):
         config=flexmock(),
         package_config=PackageConfig(jobs=jobs),
         project=flexmock(),
-        event=flexmock(trigger=JobTriggerType.pull_request),
+        event=flexmock(trigger=JobConfigTriggerType.pull_request),
     )
 
     assert copr_build_handler.package_config.jobs
-    assert [j.job for j in copr_build_handler.package_config.jobs]
+    assert [j.type for j in copr_build_handler.package_config.jobs]
 
     assert set(copr_build_handler.build_chroots) == build_targets
     assert set(copr_build_handler.tests_chroots) == test_targets

--- a/tests/unit/test_build_helper.py
+++ b/tests/unit/test_build_helper.py
@@ -2,11 +2,12 @@ import pytest
 from flexmock import flexmock
 from packit.config import PackageConfig, JobConfig, JobType, JobConfigTriggerType
 
+from packit_service.service.events import TheJobTriggerType
 from packit_service.worker.build.copr_build import CoprBuildJobHelper
 
 
 @pytest.mark.parametrize(
-    "jobs,build_targets,test_targets",
+    "jobs,trigger,build_targets,test_targets",
     [
         pytest.param(
             [
@@ -16,6 +17,7 @@ from packit_service.worker.build.copr_build import CoprBuildJobHelper
                     metadata={"targets": ["fedora-29", "fedora-31"]},
                 )
             ],
+            TheJobTriggerType.pull_request,
             {"fedora-29-x86_64", "fedora-31-x86_64"},
             set(),
             id="build_with_targets",
@@ -25,9 +27,103 @@ from packit_service.worker.build.copr_build import CoprBuildJobHelper
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
+                    metadata={"targets": ["fedora-29", "fedora-31"]},
+                )
+            ],
+            TheJobTriggerType.pr_comment,
+            {"fedora-29-x86_64", "fedora-31-x86_64"},
+            set(),
+            id="build_with_targets&pr_comment",
+        ),
+        pytest.param(
+            [
+                JobConfig(
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.release,
+                    metadata={"targets": ["fedora-29", "fedora-31"]},
+                )
+            ],
+            TheJobTriggerType.release,
+            {"fedora-29-x86_64", "fedora-31-x86_64"},
+            set(),
+            id="build_with_targets&release",
+        ),
+        pytest.param(
+            [
+                JobConfig(
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.commit,
+                    metadata={"targets": ["fedora-29", "fedora-31"]},
+                )
+            ],
+            TheJobTriggerType.push,
+            {"fedora-29-x86_64", "fedora-31-x86_64"},
+            set(),
+            id="build_with_targets&push",
+        ),
+        pytest.param(
+            [
+                JobConfig(
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    metadata={"targets": ["fedora-29", "fedora-31"]},
+                ),
+                JobConfig(
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.commit,
+                    metadata={"targets": ["different", "os", "target"]},
+                ),
+            ],
+            TheJobTriggerType.pull_request,
+            {"fedora-29-x86_64", "fedora-31-x86_64"},
+            set(),
+            id="build_with_targets&pull_request_with_pr_and_push_defined",
+        ),
+        pytest.param(
+            [
+                JobConfig(
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    metadata={"targets": ["fedora-29", "fedora-31"]},
+                ),
+                JobConfig(
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.commit,
+                    metadata={"targets": ["different", "os", "target"]},
+                ),
+            ],
+            TheJobTriggerType.pr_comment,
+            {"fedora-29-x86_64", "fedora-31-x86_64"},
+            set(),
+            id="build_with_targets&pr_comment_with_pr_and_push_defined",
+        ),
+        pytest.param(
+            [
+                JobConfig(
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    metadata={"targets": ["different", "os", "target"]},
+                ),
+                JobConfig(
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.commit,
+                    metadata={"targets": ["fedora-29", "fedora-31"]},
+                ),
+            ],
+            TheJobTriggerType.push,
+            {"fedora-29-x86_64", "fedora-31-x86_64"},
+            set(),
+            id="build_with_targets&push_with_pr_and_push_defined",
+        ),
+        pytest.param(
+            [
+                JobConfig(
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
                     metadata={},
                 )
             ],
+            TheJobTriggerType.pull_request,
             {"fedora-30-x86_64", "fedora-31-x86_64"},
             set(),
             id="build_without_targets",
@@ -40,6 +136,7 @@ from packit_service.worker.build.copr_build import CoprBuildJobHelper
                     metadata={},
                 )
             ],
+            TheJobTriggerType.pull_request,
             {"fedora-30-x86_64", "fedora-31-x86_64"},
             {"fedora-30-x86_64", "fedora-31-x86_64"},
             id="test_without_targets",
@@ -52,6 +149,7 @@ from packit_service.worker.build.copr_build import CoprBuildJobHelper
                     metadata={"targets": ["fedora-29", "fedora-31"]},
                 )
             ],
+            TheJobTriggerType.pull_request,
             {"fedora-29-x86_64", "fedora-31-x86_64"},
             {"fedora-29-x86_64", "fedora-31-x86_64"},
             id="test_with_targets",
@@ -69,6 +167,7 @@ from packit_service.worker.build.copr_build import CoprBuildJobHelper
                     metadata={},
                 ),
             ],
+            TheJobTriggerType.pull_request,
             {"fedora-30-x86_64", "fedora-31-x86_64"},
             {"fedora-30-x86_64", "fedora-31-x86_64"},
             id="build_without_target&test_without_targets",
@@ -86,6 +185,7 @@ from packit_service.worker.build.copr_build import CoprBuildJobHelper
                     metadata={},
                 ),
             ],
+            TheJobTriggerType.pull_request,
             {"fedora-29-x86_64", "fedora-31-x86_64"},
             {"fedora-29-x86_64", "fedora-31-x86_64"},
             id="build_with_target&test_without_targets",
@@ -103,6 +203,7 @@ from packit_service.worker.build.copr_build import CoprBuildJobHelper
                     metadata={"targets": ["fedora-29", "fedora-31"]},
                 ),
             ],
+            TheJobTriggerType.pull_request,
             {"fedora-29-x86_64", "fedora-31-x86_64"},
             {"fedora-29-x86_64", "fedora-31-x86_64"},
             id="build_without_target&test_with_targets",
@@ -120,18 +221,19 @@ from packit_service.worker.build.copr_build import CoprBuildJobHelper
                     metadata={"targets": "fedora-29"},
                 ),
             ],
+            TheJobTriggerType.pull_request,
             {"fedora-29-x86_64"},
             {"fedora-29-x86_64"},
             id="build_without_target&test_with_one_str_target",
         ),
     ],
 )
-def test_targets(jobs, build_targets, test_targets):
+def test_targets(jobs, trigger, build_targets, test_targets):
     copr_build_handler = CoprBuildJobHelper(
         config=flexmock(),
         package_config=PackageConfig(jobs=jobs),
         project=flexmock(),
-        event=flexmock(trigger=JobConfigTriggerType.pull_request),
+        event=flexmock(trigger=trigger),
     )
 
     assert copr_build_handler.package_config.jobs

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -3,7 +3,7 @@ import json
 from flexmock import flexmock
 from ogr.abstract import GitProject, GitService, CommitStatus
 from packit.api import PackitAPI
-from packit.config import PackageConfig, JobConfig, JobType, JobTriggerType
+from packit.config import PackageConfig, JobConfig, JobType, JobConfigTriggerType
 from packit.exceptions import FailedCreateSRPM
 
 from packit_service.config import ServiceConfig
@@ -63,8 +63,8 @@ def build_helper(metadata=None, trigger=None, jobs=None, event=None):
     jobs = jobs or []
     jobs.append(
         JobConfig(
-            job=JobType.copr_build,
-            trigger=trigger or JobTriggerType.pull_request,
+            type=JobType.copr_build,
+            trigger=trigger or JobConfigTriggerType.pull_request,
             metadata=metadata,
         )
     )
@@ -112,7 +112,7 @@ def test_copr_build_success_set_test_check():
     #  - Building SRPM ...
     #  - Building RPM ...
     test_job = JobConfig(
-        job=JobType.tests, trigger=JobTriggerType.pull_request, metadata={}
+        type=JobType.tests, trigger=JobConfigTriggerType.pull_request, metadata={}
     )
     helper = build_helper(jobs=[test_job])
     flexmock(GitProject).should_receive("set_commit_status").and_return().times(16)
@@ -128,8 +128,8 @@ def test_copr_build_for_branch():
     #  - Building SRPM ...
     #  - Building RPM ...
     branch_build_job = JobConfig(
-        job=JobType.build,
-        trigger=JobTriggerType.commit,
+        type=JobType.build,
+        trigger=JobConfigTriggerType.commit,
         metadata={"branch": "build-branch"},
     )
     helper = build_helper(jobs=[branch_build_job], event=branch_push_event())
@@ -146,7 +146,7 @@ def test_copr_build_for_release():
     #  - Building SRPM ...
     #  - Building RPM ...
     branch_build_job = JobConfig(
-        job=JobType.build, trigger=JobTriggerType.release, metadata={},
+        type=JobType.build, trigger=JobConfigTriggerType.release, metadata={},
     )
     helper = build_helper(jobs=[branch_build_job], event=release_event())
     flexmock(GitProject).should_receive("set_commit_status").and_return().times(8)

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -30,7 +30,6 @@ from datetime import datetime, timezone
 import pytest
 from flexmock import flexmock
 from ogr.services.github import GithubProject, GithubService
-from packit.config import JobTriggerType
 
 from packit_service.config import ServiceConfig
 from packit_service.models import CoprBuild
@@ -51,6 +50,7 @@ from packit_service.service.events import (
     DistGitEvent,
     TestResult,
     PushGitHubEvent,
+    TheJobTriggerType,
 )
 from packit_service.worker.parser import Parser
 from tests.spellbook import DATA_DIR
@@ -145,7 +145,7 @@ class TestEvents:
         event_object = Parser.parse_event(installation)
 
         assert isinstance(event_object, InstallationEvent)
-        assert event_object.trigger == JobTriggerType.installation
+        assert event_object.trigger == TheJobTriggerType.installation
         assert event_object.installation_id == 1708454
         assert event_object.account_login == "packit-service"
         assert event_object.account_id == 46870917
@@ -163,7 +163,7 @@ class TestEvents:
         event_object = Parser.parse_event(release)
 
         assert isinstance(event_object, ReleaseEvent)
-        assert event_object.trigger == JobTriggerType.release
+        assert event_object.trigger == TheJobTriggerType.release
         assert event_object.repo_namespace == "Codertocat"
         assert event_object.repo_name == "Hello-World"
         assert event_object.tag_name == "0.0.1"
@@ -173,7 +173,7 @@ class TestEvents:
         event_object = Parser.parse_event(pull_request)
 
         assert isinstance(event_object, PullRequestEvent)
-        assert event_object.trigger == JobTriggerType.pull_request
+        assert event_object.trigger == TheJobTriggerType.pull_request
         assert event_object.action == PullRequestAction.opened
         assert event_object.pr_id == 342
         assert event_object.base_repo_namespace == "packit-service"
@@ -193,7 +193,7 @@ class TestEvents:
         event_object = Parser.parse_event(pr_comment_created_request)
 
         assert isinstance(event_object, PullRequestCommentEvent)
-        assert event_object.trigger == JobTriggerType.comment
+        assert event_object.trigger == TheJobTriggerType.comment
         assert event_object.action == PullRequestCommentAction.created
         assert event_object.pr_id == 9
         assert event_object.base_repo_namespace == "packit-service"
@@ -212,7 +212,7 @@ class TestEvents:
         event_object = Parser.parse_event(pr_comment_empty_request)
 
         assert isinstance(event_object, PullRequestCommentEvent)
-        assert event_object.trigger == JobTriggerType.comment
+        assert event_object.trigger == TheJobTriggerType.comment
         assert event_object.action == PullRequestCommentAction.created
         assert event_object.pr_id == 9
         assert event_object.base_repo_namespace == "packit-service"
@@ -231,7 +231,7 @@ class TestEvents:
         event_object = Parser.parse_event(issue_comment_request)
 
         assert isinstance(event_object, IssueCommentEvent)
-        assert event_object.trigger == JobTriggerType.comment
+        assert event_object.trigger == TheJobTriggerType.comment
         assert event_object.action == IssueCommentAction.created
         assert event_object.issue_id == 512
         assert event_object.base_repo_namespace == "packit-service"
@@ -249,7 +249,7 @@ class TestEvents:
         event_object = Parser.parse_event(github_push)
 
         assert isinstance(event_object, PushGitHubEvent)
-        assert event_object.trigger == JobTriggerType.commit
+        assert event_object.trigger == TheJobTriggerType.push
         assert event_object.repo_namespace == "some-user"
         assert event_object.repo_name == "some-repo"
         assert event_object.commit_sha == "0000000000000000000000000000000000000000"
@@ -260,7 +260,7 @@ class TestEvents:
         event_object = Parser.parse_event(github_push_branch)
 
         assert isinstance(event_object, PushGitHubEvent)
-        assert event_object.trigger == JobTriggerType.commit
+        assert event_object.trigger == TheJobTriggerType.push
         assert event_object.repo_namespace == "packit-service"
         assert event_object.repo_name == "hello-world"
         assert event_object.commit_sha == "04885ff850b0fa0e206cd09db73565703d48f99b"
@@ -273,7 +273,7 @@ class TestEvents:
         event_object = Parser.parse_event(testing_farm_results)
 
         assert isinstance(event_object, TestingFarmResultsEvent)
-        assert event_object.trigger == JobTriggerType.testing_farm_results
+        assert event_object.trigger == TheJobTriggerType.testing_farm_results
         assert event_object.pipeline_id == "43e310b6-c1f1-4d3e-a95c-6c1eca235296"
         assert event_object.result == TestingFarmResult.passed
         assert event_object.repo_namespace == "packit-service"
@@ -305,7 +305,7 @@ class TestEvents:
         event_object = Parser.parse_event(testing_farm_results_error)
 
         assert isinstance(event_object, TestingFarmResultsEvent)
-        assert event_object.trigger == JobTriggerType.testing_farm_results
+        assert event_object.trigger == TheJobTriggerType.testing_farm_results
         assert event_object.pipeline_id == "43e310b6-c1f1-4d3e-a95c-6c1eca235296"
         assert event_object.result == TestingFarmResult.failed
         assert event_object.repo_namespace == "packit-service"

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -193,7 +193,7 @@ class TestEvents:
         event_object = Parser.parse_event(pr_comment_created_request)
 
         assert isinstance(event_object, PullRequestCommentEvent)
-        assert event_object.trigger == TheJobTriggerType.comment
+        assert event_object.trigger == TheJobTriggerType.pr_comment
         assert event_object.action == PullRequestCommentAction.created
         assert event_object.pr_id == 9
         assert event_object.base_repo_namespace == "packit-service"
@@ -212,7 +212,7 @@ class TestEvents:
         event_object = Parser.parse_event(pr_comment_empty_request)
 
         assert isinstance(event_object, PullRequestCommentEvent)
-        assert event_object.trigger == TheJobTriggerType.comment
+        assert event_object.trigger == TheJobTriggerType.pr_comment
         assert event_object.action == PullRequestCommentAction.created
         assert event_object.pr_id == 9
         assert event_object.base_repo_namespace == "packit-service"
@@ -231,7 +231,7 @@ class TestEvents:
         event_object = Parser.parse_event(issue_comment_request)
 
         assert isinstance(event_object, IssueCommentEvent)
-        assert event_object.trigger == TheJobTriggerType.comment
+        assert event_object.trigger == TheJobTriggerType.issue_comment
         assert event_object.action == IssueCommentAction.created
         assert event_object.issue_id == 512
         assert event_object.base_repo_namespace == "packit-service"

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -21,9 +21,8 @@
 # SOFTWARE.
 import pytest
 from flexmock import flexmock
-
 from ogr.abstract import CommitStatus
-from packit.config import JobConfig, JobType, JobTriggerType
+from packit.config import JobConfig, JobType, JobConfigTriggerType
 from packit.local_project import LocalProject
 
 from packit_service.service.events import (
@@ -31,8 +30,8 @@ from packit_service.service.events import (
     TestingFarmResult,
     TestResult,
 )
-from packit_service.worker.reporting import StatusReporter
 from packit_service.worker.handlers import TestingFarmResultsHandler
+from packit_service.worker.reporting import StatusReporter
 
 
 @pytest.mark.parametrize(
@@ -162,8 +161,8 @@ def test_testing_farm_response(
         flexmock(
             jobs=[
                 JobConfig(
-                    job=JobType.copr_build,
-                    trigger=JobTriggerType.pull_request,
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
                     metadata={},
                 )
             ],
@@ -171,7 +170,7 @@ def test_testing_farm_response(
     )
     test_farm_handler = TestingFarmResultsHandler(
         config=flexmock(command_handler_work_dir=flexmock()),
-        job=flexmock(),
+        job_config=flexmock(),
         test_results_event=TestingFarmResultsEvent(
             pipeline_id="id",
             result=tests_result,

--- a/tests/unit/test_whitelist.py
+++ b/tests/unit/test_whitelist.py
@@ -28,7 +28,7 @@ from fedora.client.fas2 import AccountSystem
 from flexmock import flexmock
 from ogr.abstract import GitProject, GitService, CommitStatus
 from ogr.services.github import GithubProject, GithubService
-from packit.config import JobType, JobConfig, JobTriggerType
+from packit.config import JobType, JobConfig, JobConfigTriggerType
 from packit.copr_helper import CoprHelper
 from packit.local_project import LocalProject
 
@@ -260,8 +260,8 @@ def test_check_and_report(
         flexmock(
             jobs=[
                 JobConfig(
-                    job=JobType.tests,
-                    trigger=JobTriggerType.pull_request,
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
                     metadata={"targets": ["fedora-rawhide"]},
                 )
             ],


### PR DESCRIPTION
- Split the JobTriggerType to one related to config and one for actual triggers.
- Requires: https://github.com/packit-service/packit/pull/746

TODO:
- [x] mapping of the `TheJobTriggerType` to `JobConfigTriggerType`.
- [x] tests for config with multiple triggers for one job
- [x] test the build workflow for other build triggers (skipped, since we need to use right trigger for received events from copr.)