### PR TITLE
Rework mapping

### DIFF
--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -529,8 +529,16 @@ class CoprBuildEvent(AbstractGithubEvent):
             self.base_repo_namespace = build.get("repo_namespace")
             https_url = build["https_url"]
 
-        super().__init__(trigger=TheJobTriggerType.pull_request, project_url=https_url)
         self.topic = FedmsgTopic(topic)
+        if self.topic == FedmsgTopic.copr_build_started:
+            trigger = TheJobTriggerType.copr_start
+        elif self.topic == FedmsgTopic.copr_build_finished:
+            trigger = TheJobTriggerType.copr_end
+        else:
+            raise ValueError(f"Unknown topic for CoprEvent: '{self.topic}'")
+
+        super().__init__(trigger=trigger, project_url=https_url)
+
         self.build_id = build_id
         self.build = build
         self.chroot = chroot

--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -87,6 +87,8 @@ class TheJobTriggerType(str, enum.Enum):
     testing_farm_results = "testing_farm_results"
     pr_comment = "pr_comment"
     issue_comment = "issue_comment"
+    copr_start = "copr_start"
+    copr_end = "copr_end"
 
 
 class TestResult(dict):

--- a/packit_service/trigger_mapping.py
+++ b/packit_service/trigger_mapping.py
@@ -26,7 +26,9 @@ from packit.config import JobConfigTriggerType, JobConfig, JobType
 
 from packit_service.service.events import TheJobTriggerType
 
-JOB_TRIGGER_TO_CONFIG_MAPPING: Dict[TheJobTriggerType, JobConfigTriggerType] = {
+MAP_JOB_TRIGGER_TO_JOB_CONFIG_TRIGGER_TYPE: Dict[
+    TheJobTriggerType, JobConfigTriggerType
+] = {
     TheJobTriggerType.commit: JobConfigTriggerType.commit,
     TheJobTriggerType.release: JobConfigTriggerType.release,
     TheJobTriggerType.pull_request: JobConfigTriggerType.pull_request,
@@ -47,7 +49,7 @@ def is_trigger_matching_job_config(
     e.g. Both pr_comment and pull_request are compatible
          with the pull_request config in the config
     """
-    config_trigger = JOB_TRIGGER_TO_CONFIG_MAPPING.get(trigger)
+    config_trigger = MAP_JOB_TRIGGER_TO_JOB_CONFIG_TRIGGER_TYPE.get(trigger)
     return bool(config_trigger and job_config.trigger == config_trigger)
 
 

--- a/packit_service/trigger_mapping.py
+++ b/packit_service/trigger_mapping.py
@@ -20,20 +20,20 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import Dict, Optional
+from typing import Dict
 
 from packit.config import JobConfigTriggerType, JobConfig, JobType
 
 from packit_service.service.events import TheJobTriggerType
 
-JOB_TRIGGER_TO_CONFIG_MAPPING: Dict[
-    TheJobTriggerType, Optional[JobConfigTriggerType]
-] = {
+JOB_TRIGGER_TO_CONFIG_MAPPING: Dict[TheJobTriggerType, JobConfigTriggerType] = {
     TheJobTriggerType.commit: JobConfigTriggerType.commit,
     TheJobTriggerType.release: JobConfigTriggerType.release,
     TheJobTriggerType.pull_request: JobConfigTriggerType.pull_request,
     TheJobTriggerType.push: JobConfigTriggerType.commit,
     TheJobTriggerType.pr_comment: JobConfigTriggerType.pull_request,
+    TheJobTriggerType.copr_start: JobConfigTriggerType.pull_request,
+    TheJobTriggerType.copr_end: JobConfigTriggerType.pull_request,
 }
 
 

--- a/packit_service/worker/handlers/__init__.py
+++ b/packit_service/worker/handlers/__init__.py
@@ -45,8 +45,8 @@ from packit_service.worker.handlers.github_handlers import (
     GitHubIssueCommentProposeUpdateHandler,
     GitHubPullRequestCommentCoprBuildHandler,
     GitHubPullRequestCommentTestingFarmHandler,
-    GithubPullRequestHandler,
-    GithubReleaseHandler,
+    PullRequestGithubCheckDownstreamHandler,
+    ProposeDownstreamHandler,
     GithubTestingFarmHandler,
 )
 
@@ -67,8 +67,8 @@ __all__ = [
     GitHubIssueCommentProposeUpdateHandler.__name__,
     GitHubPullRequestCommentCoprBuildHandler.__name__,
     GitHubPullRequestCommentTestingFarmHandler.__name__,
-    GithubPullRequestHandler.__name__,
-    GithubReleaseHandler.__name__,
+    PullRequestGithubCheckDownstreamHandler.__name__,
+    ProposeDownstreamHandler.__name__,
     GithubTestingFarmHandler.__name__,
     Handler.__name__,
     JobHandler.__name__,

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -41,9 +41,9 @@ from packit_service.worker.result import HandlerResults
 
 logger = logging.getLogger(__name__)
 
-JOB_REQUIRED_MAPPING: Dict[JobType, Set[Type["JobHandler"]]] = defaultdict(set)
+MAP_REQUIRED_JOB_TO_HANDLERS: Dict[JobType, Set[Type["JobHandler"]]] = defaultdict(set)
 
-MAP_EVENT_TRIGGER_TO_HANDLER: Dict[
+MAP_EVENT_TRIGGER_TO_HANDLERS: Dict[
     TheJobTriggerType, Set[Type["JobHandler"]]
 ] = defaultdict(set)
 
@@ -56,7 +56,7 @@ def add_to_mapping(kls: Type["JobHandler"]):
     Add the handler to the trigger->handler mapping.
     """
     for trigger in kls.triggers:
-        MAP_EVENT_TRIGGER_TO_HANDLER[trigger].add(kls)
+        MAP_EVENT_TRIGGER_TO_HANDLERS[trigger].add(kls)
     return kls
 
 
@@ -69,7 +69,7 @@ def add_alias(job_type: JobType):
 
     def _add_to_mapping(kls: Type["JobHandler"]):
         for trigger in kls.triggers:
-            MAP_EVENT_TRIGGER_TO_HANDLER[trigger].add(kls)
+            MAP_EVENT_TRIGGER_TO_HANDLERS[trigger].add(kls)
         MAP_HANDLER_TO_JOB_TYPES[kls].add(job_type)
         return kls
 
@@ -85,7 +85,7 @@ def required_by(job_type: JobType):
     """
 
     def _add_to_mapping(kls: Type["JobHandler"]):
-        JOB_REQUIRED_MAPPING[job_type].add(kls)
+        MAP_REQUIRED_JOB_TO_HANDLERS[job_type].add(kls)
         return kls
 
     return _add_to_mapping

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -25,32 +25,80 @@ This file defines generic job handler
 """
 import logging
 import shutil
+from collections import defaultdict
 from os import getenv
 from pathlib import Path
-from typing import Dict, Optional, Type, List
+from typing import Dict, Optional, Type, List, Set
 
 from packit.api import PackitAPI
 from packit.config import JobConfig, JobType
 from packit.local_project import LocalProject
 
 from packit_service.config import ServiceConfig
+from packit_service.sentry_integration import push_scope_to_sentry
 from packit_service.service.events import Event, TheJobTriggerType
 from packit_service.worker.result import HandlerResults
-from packit_service.sentry_integration import push_scope_to_sentry
 
 logger = logging.getLogger(__name__)
 
-JOB_NAME_HANDLER_MAPPING: Dict[JobType, Type["JobHandler"]] = {}
+JOB_REQUIRED_MAPPING: Dict[JobType, Set[Type["JobHandler"]]] = defaultdict(set)
+
+MAP_EVENT_TRIGGER_TO_HANDLER: Dict[
+    TheJobTriggerType, Set[Type["JobHandler"]]
+] = defaultdict(set)
+
+MAP_HANDLER_TO_JOB_TYPES: Dict[Type["JobHandler"], Set[JobType]] = defaultdict(set)
 
 
 def add_to_mapping(kls: Type["JobHandler"]):
-    JOB_NAME_HANDLER_MAPPING[kls.name] = kls
+    """
+    [class decorator]
+    Add the handler to the trigger->handler mapping.
+    """
+    for trigger in kls.triggers:
+        MAP_EVENT_TRIGGER_TO_HANDLER[trigger].add(kls)
     return kls
 
 
-def add_to_mapping_for_job(job_type: JobType):
+def add_alias(job_type: JobType):
+    """
+    [class decorator]
+    Use the given type as an alias for this job class.
+    This decorator will updated needed mapping so users can combine all and new types.
+    """
+
     def _add_to_mapping(kls: Type["JobHandler"]):
-        JOB_NAME_HANDLER_MAPPING[job_type] = kls
+        for trigger in kls.triggers:
+            MAP_EVENT_TRIGGER_TO_HANDLER[trigger].add(kls)
+        MAP_HANDLER_TO_JOB_TYPES[kls].add(job_type)
+        return kls
+
+    return _add_to_mapping
+
+
+def required_by(job_type: JobType):
+    """
+    [class decorator]
+    Set when you need to run for some job even if this one is not configured.
+
+    (e.g. we want to run build for test even if only the test is defined)
+    """
+
+    def _add_to_mapping(kls: Type["JobHandler"]):
+        JOB_REQUIRED_MAPPING[job_type].add(kls)
+        return kls
+
+    return _add_to_mapping
+
+
+def use_for(job_type: JobType):
+    """
+    [class decorator]
+    Specify a job type for which we want to use this handler.
+    """
+
+    def _add_to_mapping(kls: Type["JobHandler"]):
+        MAP_HANDLER_TO_JOB_TYPES[kls].add(job_type)
         return kls
 
     return _add_to_mapping
@@ -132,7 +180,7 @@ class Handler:
 class JobHandler(Handler):
     """ Generic interface to handle different type of inputs """
 
-    name: JobType
+    type: JobType
     triggers: List[TheJobTriggerType]
 
     def __init__(

--- a/packit_service/worker/handlers/comment_action_handler.py
+++ b/packit_service/worker/handlers/comment_action_handler.py
@@ -47,11 +47,20 @@ COMMENT_ACTION_HANDLER_MAPPING: Dict[CommentAction, Type["CommentActionHandler"]
 
 
 def add_to_comment_action_mapping(kls: Type["CommentActionHandler"]):
-    COMMENT_ACTION_HANDLER_MAPPING[kls.name] = kls
+    """
+    [class decorator]
+    Add a comment handler to the mapping.
+    """
+    COMMENT_ACTION_HANDLER_MAPPING[kls.type] = kls
     return kls
 
 
-def add_to_comment_action_mapping_with_name(name):
+def add_to_comment_action_mapping_with_name(name: CommentAction):
+    """
+    [class decorator]
+    Use this handler for the given comment action.
+    """
+
     def add_to_comment_action_mapping_with_name_inner(
         kls: Type["CommentActionHandler"],
     ):
@@ -62,7 +71,7 @@ def add_to_comment_action_mapping_with_name(name):
 
 
 class CommentActionHandler(Handler):
-    name: CommentAction
+    type: CommentAction
 
     def __init__(
         self,

--- a/packit_service/worker/handlers/comment_action_handler.py
+++ b/packit_service/worker/handlers/comment_action_handler.py
@@ -43,7 +43,7 @@ class CommentAction(enum.Enum):
     build = "build"
 
 
-COMMENT_ACTION_HANDLER_MAPPING: Dict[CommentAction, Type["CommentActionHandler"]] = {}
+MAP_COMMENT_ACTION_TO_HANDLER: Dict[CommentAction, Type["CommentActionHandler"]] = {}
 
 
 def add_to_comment_action_mapping(kls: Type["CommentActionHandler"]):
@@ -51,7 +51,7 @@ def add_to_comment_action_mapping(kls: Type["CommentActionHandler"]):
     [class decorator]
     Add a comment handler to the mapping.
     """
-    COMMENT_ACTION_HANDLER_MAPPING[kls.type] = kls
+    MAP_COMMENT_ACTION_TO_HANDLER[kls.type] = kls
     return kls
 
 
@@ -64,7 +64,7 @@ def add_to_comment_action_mapping_with_name(name: CommentAction):
     def add_to_comment_action_mapping_with_name_inner(
         kls: Type["CommentActionHandler"],
     ):
-        COMMENT_ACTION_HANDLER_MAPPING[name] = kls
+        MAP_COMMENT_ACTION_TO_HANDLER[name] = kls
         return kls
 
     return add_to_comment_action_mapping_with_name_inner

--- a/packit_service/worker/handlers/fedmsg_handlers.py
+++ b/packit_service/worker/handlers/fedmsg_handlers.py
@@ -51,7 +51,7 @@ from packit_service.service.events import (
 from packit_service.service.urls import get_log_url
 from packit_service.worker.build.copr_build import CoprBuildJobHelper
 from packit_service.worker.copr_db import CoprBuildDB
-from packit_service.worker.handlers.abstract import JobHandler
+from packit_service.worker.handlers.abstract import JobHandler, use_for, required_by
 from packit_service.worker.handlers.abstract import add_to_mapping
 from packit_service.worker.handlers.github_handlers import GithubTestingFarmHandler
 from packit_service.worker.result import HandlerResults
@@ -123,11 +123,11 @@ class FedmsgHandler(JobHandler):
 
 @add_topic
 @add_to_mapping
+@use_for(job_type=JobType.sync_from_downstream)
 class NewDistGitCommitHandler(FedmsgHandler):
     """Sync new changes to upstream after a new git push in the dist-git."""
 
     topic = "org.fedoraproject.prod.git.receive"
-    name = JobType.sync_from_downstream
     triggers = [TheJobTriggerType.commit]
 
     def __init__(
@@ -174,9 +174,11 @@ class NewDistGitCommitHandler(FedmsgHandler):
 
 @add_topic
 @add_to_mapping
+@use_for(job_type=JobType.copr_build)
+@required_by(job_type=JobType.tests)
 class CoprBuildEndHandler(FedmsgHandler):
     topic = "org.fedoraproject.prod.copr.build.end"
-    name = JobType.copr_build_finished
+    triggers = [TheJobTriggerType.copr_end]
 
     def __init__(
         self,
@@ -302,9 +304,11 @@ class CoprBuildEndHandler(FedmsgHandler):
 
 @add_topic
 @add_to_mapping
+@use_for(job_type=JobType.copr_build)
+@required_by(job_type=JobType.tests)
 class CoprBuildStartHandler(FedmsgHandler):
     topic = "org.fedoraproject.prod.copr.build.start"
-    name = JobType.copr_build_started
+    triggers = [TheJobTriggerType.copr_start]
 
     def __init__(
         self,

--- a/packit_service/worker/handlers/github_handlers.py
+++ b/packit_service/worker/handlers/github_handlers.py
@@ -179,15 +179,15 @@ class ProposeDownstreamHandler(AbstractGithubJobHandler):
     event: ReleaseEvent
 
     def __init__(
-        self, config: ServiceConfig, job_config: JobConfig, release_event: ReleaseEvent
+        self, config: ServiceConfig, job_config: JobConfig, event: ReleaseEvent
     ):
-        super().__init__(config=config, job_config=job_config, event=release_event)
+        super().__init__(config=config, job_config=job_config, event=event)
 
-        self.project: GitProject = release_event.get_project()
+        self.project: GitProject = event.get_project()
         self.package_config: PackageConfig = self.get_package_config_from_repo(
-            self.project, release_event.tag_name
+            self.project, event.tag_name
         )
-        self.package_config.upstream_project_url = release_event.project_url
+        self.package_config.upstream_project_url = event.project_url
 
     def run(self) -> HandlerResults:
         """
@@ -505,6 +505,7 @@ class GitHubIssueCommentProposeUpdateHandler(
     """ Handler for issue comment `/packit propose-update` """
 
     type = CommentAction.propose_update
+    triggers = [TheJobTriggerType.issue_comment]
     event: IssueCommentEvent
 
     def __init__(self, config: ServiceConfig, event: IssueCommentEvent):
@@ -614,7 +615,7 @@ class GitHubPullRequestCommentTestingFarmHandler(
 
     type = CommentAction.test
     event: PullRequestCommentEvent
-    trgggers = [TheJobTriggerType.pr_comment]
+    triggers = [TheJobTriggerType.pr_comment]
 
     def __init__(self, config: ServiceConfig, event: PullRequestCommentEvent):
         super().__init__(config=config, event=event)

--- a/packit_service/worker/handlers/testing_farm_handlers.py
+++ b/packit_service/worker/handlers/testing_farm_handlers.py
@@ -40,7 +40,7 @@ from packit_service.service.events import (
     TheJobTriggerType,
 )
 from packit_service.worker.handlers import AbstractGithubJobHandler
-from packit_service.worker.handlers.abstract import add_to_mapping
+from packit_service.worker.handlers.abstract import add_to_mapping, use_for
 from packit_service.worker.reporting import StatusReporter
 from packit_service.worker.result import HandlerResults
 from packit_service.worker.testing_farm import TestingFarmJobHelper
@@ -49,8 +49,9 @@ logger = logging.getLogger(__name__)
 
 
 @add_to_mapping
+@use_for(job_type=JobType.tests)
 class TestingFarmResultsHandler(AbstractGithubJobHandler):
-    name = JobType.report_test_results
+    type = JobType.report_test_results
     triggers = [TheJobTriggerType.testing_farm_results]
     event: TestingFarmResultsEvent
 

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -1,0 +1,243 @@
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import pytest
+from flexmock import flexmock
+from packit.config import JobConfig, JobType, JobConfigTriggerType
+
+from packit_service.service.events import TheJobTriggerType
+from packit_service.worker.handlers import (
+    PullRequestGithubCoprBuildHandler,
+    ProposeDownstreamHandler,
+    CoprBuildStartHandler,
+    CoprBuildEndHandler,
+)
+from packit_service.worker.jobs import get_handlers_for_event
+
+
+@pytest.mark.parametrize(
+    "trigger,jobs,result",
+    [
+        pytest.param(
+            TheJobTriggerType.pull_request, [], set(), id="nothing_configured"
+        ),
+        pytest.param(
+            TheJobTriggerType.pull_request,
+            [
+                JobConfig(
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    metadata={},
+                )
+            ],
+            {PullRequestGithubCoprBuildHandler},
+            id="config=copr_build@trigger=pull_request",
+        ),
+        pytest.param(
+            TheJobTriggerType.pull_request,
+            [
+                JobConfig(
+                    type=JobType.build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    metadata={},
+                )
+            ],
+            {PullRequestGithubCoprBuildHandler},
+            id="config=build@trigger=pull_request",
+        ),
+        pytest.param(
+            TheJobTriggerType.release,
+            [
+                JobConfig(
+                    type=JobType.propose_downstream,
+                    trigger=JobConfigTriggerType.release,
+                    metadata={},
+                )
+            ],
+            {ProposeDownstreamHandler},
+            id="propose_downstream",
+        ),
+        pytest.param(
+            TheJobTriggerType.copr_start,
+            [
+                JobConfig(
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    metadata={},
+                )
+            ],
+            {CoprBuildStartHandler},
+            id="config=copr_build@trigger=copr_start",
+        ),
+        pytest.param(
+            TheJobTriggerType.copr_end,
+            [
+                JobConfig(
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    metadata={},
+                )
+            ],
+            {CoprBuildEndHandler},
+            id="config=copr_build@trigger=copr_end",
+        ),
+        pytest.param(
+            TheJobTriggerType.pull_request,
+            [
+                JobConfig(
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    metadata={},
+                ),
+                JobConfig(
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.release,
+                    metadata={},
+                ),
+            ],
+            {PullRequestGithubCoprBuildHandler},
+            id="config=copr_build_on_pull_request_and_release@trigger=pull_request",
+        ),
+        pytest.param(
+            TheJobTriggerType.copr_end,
+            [
+                JobConfig(
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    metadata={},
+                ),
+                JobConfig(
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.release,
+                    metadata={},
+                ),
+            ],
+            {CoprBuildEndHandler},
+            id="config=copr_build_on_pull_request_and_release@trigger=copr_end",
+        ),
+        pytest.param(
+            TheJobTriggerType.pull_request,
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    metadata={},
+                )
+            ],
+            {PullRequestGithubCoprBuildHandler},
+            id="config=tests@trigger=pull_request",
+        ),
+        pytest.param(
+            TheJobTriggerType.copr_start,
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    metadata={},
+                )
+            ],
+            {CoprBuildStartHandler},
+            id="config=tests@trigger=copr_start",
+        ),
+        pytest.param(
+            TheJobTriggerType.copr_end,
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    metadata={},
+                )
+            ],
+            {CoprBuildEndHandler},
+            id="config=tests@trigger=copr_end",
+        ),
+        pytest.param(
+            TheJobTriggerType.pull_request,
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    metadata={},
+                ),
+                JobConfig(
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    metadata={},
+                ),
+            ],
+            {PullRequestGithubCoprBuildHandler},
+            id="config=tests_and_copr_build@trigger=pull_request",
+        ),
+        pytest.param(
+            TheJobTriggerType.copr_start,
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    metadata={},
+                ),
+                JobConfig(
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    metadata={},
+                ),
+            ],
+            {CoprBuildStartHandler},
+            id="config=tests_and_copr_build@trigger=copr_start",
+        ),
+        pytest.param(
+            TheJobTriggerType.copr_start,
+            [
+                JobConfig(
+                    type=JobType.tests,
+                    trigger=JobConfigTriggerType.pull_request,
+                    metadata={},
+                ),
+                JobConfig(
+                    type=JobType.copr_build,
+                    trigger=JobConfigTriggerType.pull_request,
+                    metadata={},
+                ),
+                JobConfig(
+                    type=JobType.propose_downstream,
+                    trigger=JobConfigTriggerType.release,
+                    metadata={},
+                ),
+                JobConfig(
+                    type=JobType.sync_from_downstream,
+                    trigger=JobConfigTriggerType.commit,
+                    metadata={},
+                ),
+            ],
+            {CoprBuildStartHandler},
+            id="config=tests_and_copr_build_and_propose_and_sync@trigger=copr_start",
+        ),
+    ],
+)
+def test_get_handlers_for_event(trigger, jobs, result):
+    assert (
+        set(
+            get_handlers_for_event(
+                event=flexmock(trigger=trigger), package_config=flexmock(jobs=jobs)
+            )
+        )
+        == result
+    )


### PR DESCRIPTION
- Make the mapping of handlers to events work and easier to use.
  - Testing farm results and Copr events are handled as other events.
  - Mapping support multiple triggers for one job and get's a correct config part.
- Fixes: #465

TODO:
- [x] More tests (more combinations of triggers and configs).
- [x] Check the commenting.
- [x] Add docs for the decorators.
- [ ] Remove internal job type (e.g. `copr_end`) from the `JobType` enum in packit. (After this PR, it can contain only the config-relevant values.)