### PR TITLE
Add koji build handlers and simplify the handler decorators

### DIFF
--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -50,32 +50,6 @@ MAP_EVENT_TRIGGER_TO_HANDLERS: Dict[
 MAP_HANDLER_TO_JOB_TYPES: Dict[Type["JobHandler"], Set[JobType]] = defaultdict(set)
 
 
-def add_to_mapping(kls: Type["JobHandler"]):
-    """
-    [class decorator]
-    Add the handler to the trigger->handler mapping.
-    """
-    for trigger in kls.triggers:
-        MAP_EVENT_TRIGGER_TO_HANDLERS[trigger].add(kls)
-    return kls
-
-
-def add_alias(job_type: JobType):
-    """
-    [class decorator]
-    Use the given type as an alias for this job class.
-    This decorator will updated needed mapping so users can combine all and new types.
-    """
-
-    def _add_to_mapping(kls: Type["JobHandler"]):
-        for trigger in kls.triggers:
-            MAP_EVENT_TRIGGER_TO_HANDLERS[trigger].add(kls)
-        MAP_HANDLER_TO_JOB_TYPES[kls].add(job_type)
-        return kls
-
-    return _add_to_mapping
-
-
 def required_by(job_type: JobType):
     """
     [class decorator]
@@ -98,6 +72,8 @@ def use_for(job_type: JobType):
     """
 
     def _add_to_mapping(kls: Type["JobHandler"]):
+        for trigger in kls.triggers:
+            MAP_EVENT_TRIGGER_TO_HANDLERS[trigger].add(kls)
         MAP_HANDLER_TO_JOB_TYPES[kls].add(job_type)
         return kls
 

--- a/packit_service/worker/handlers/fedmsg_handlers.py
+++ b/packit_service/worker/handlers/fedmsg_handlers.py
@@ -52,7 +52,6 @@ from packit_service.service.urls import get_log_url
 from packit_service.worker.build.copr_build import CoprBuildJobHelper
 from packit_service.worker.copr_db import CoprBuildDB
 from packit_service.worker.handlers.abstract import JobHandler, use_for, required_by
-from packit_service.worker.handlers.abstract import add_to_mapping
 from packit_service.worker.handlers.github_handlers import GithubTestingFarmHandler
 from packit_service.worker.result import HandlerResults
 
@@ -122,7 +121,6 @@ class FedmsgHandler(JobHandler):
 
 
 @add_topic
-@add_to_mapping
 @use_for(job_type=JobType.sync_from_downstream)
 class NewDistGitCommitHandler(FedmsgHandler):
     """Sync new changes to upstream after a new git push in the dist-git."""
@@ -173,7 +171,6 @@ class NewDistGitCommitHandler(FedmsgHandler):
 
 
 @add_topic
-@add_to_mapping
 @use_for(job_type=JobType.copr_build)
 @required_by(job_type=JobType.tests)
 class CoprBuildEndHandler(FedmsgHandler):
@@ -303,7 +300,6 @@ class CoprBuildEndHandler(FedmsgHandler):
 
 
 @add_topic
-@add_to_mapping
 @use_for(job_type=JobType.copr_build)
 @required_by(job_type=JobType.tests)
 class CoprBuildStartHandler(FedmsgHandler):

--- a/packit_service/worker/handlers/github_handlers.py
+++ b/packit_service/worker/handlers/github_handlers.py
@@ -59,9 +59,7 @@ from packit_service.worker.handlers import (
     JobHandler,
 )
 from packit_service.worker.handlers.abstract import (
-    add_to_mapping,
     required_by,
-    add_alias,
     use_for,
 )
 from packit_service.worker.handlers.comment_action_handler import (
@@ -80,7 +78,6 @@ class AbstractGithubJobHandler(JobHandler, GithubPackageConfigGetter):
     pass
 
 
-@add_to_mapping
 @use_for(job_type=JobType.check_downstream)
 class PullRequestGithubCheckDownstreamHandler(AbstractGithubJobHandler):
     type = JobType.check_downstream
@@ -114,7 +111,6 @@ class PullRequestGithubCheckDownstreamHandler(AbstractGithubJobHandler):
         return HandlerResults(success=True, details={})
 
 
-@add_to_mapping
 class GithubAppInstallationHandler(AbstractGithubJobHandler):
     type = JobType.add_to_whitelist
     triggers = [TheJobTriggerType.installation]
@@ -172,7 +168,6 @@ class GithubAppInstallationHandler(AbstractGithubJobHandler):
         return HandlerResults(success=True, details={"msg": msg})
 
 
-@add_to_mapping
 @use_for(job_type=JobType.propose_downstream)
 class ProposeDownstreamHandler(AbstractGithubJobHandler):
     type = JobType.propose_downstream
@@ -316,10 +311,9 @@ class AbstractGithubCoprBuildHandler(AbstractGithubJobHandler):
         return True
 
 
-@add_to_mapping
-@add_alias(job_type=JobType.build)
-@required_by(job_type=JobType.tests)
 @use_for(job_type=JobType.copr_build)
+@use_for(job_type=JobType.build)
+@required_by(job_type=JobType.tests)
 class ReleaseGithubCoprBuildHandler(AbstractGithubCoprBuildHandler):
     triggers = [
         TheJobTriggerType.release,
@@ -341,10 +335,9 @@ class ReleaseGithubCoprBuildHandler(AbstractGithubCoprBuildHandler):
         )
 
 
-@add_to_mapping
-@add_alias(job_type=JobType.build)
-@required_by(job_type=JobType.tests)
 @use_for(job_type=JobType.copr_build)
+@use_for(job_type=JobType.build)
+@required_by(job_type=JobType.tests)
 class PullRequestGithubCoprBuildHandler(AbstractGithubCoprBuildHandler):
     triggers = [
         TheJobTriggerType.pull_request,
@@ -377,10 +370,9 @@ class PullRequestGithubCoprBuildHandler(AbstractGithubCoprBuildHandler):
         )
 
 
-@add_to_mapping
-@add_alias(job_type=JobType.build)
-@required_by(job_type=JobType.tests)
 @use_for(job_type=JobType.copr_build)
+@use_for(job_type=JobType.build)
+@required_by(job_type=JobType.tests)
 class PushGithubCoprBuildHandler(AbstractGithubCoprBuildHandler):
     triggers = [
         TheJobTriggerType.push,
@@ -488,7 +480,6 @@ class AbstractGithubKojiBuildHandler(AbstractGithubJobHandler):
         return True
 
 
-@add_to_mapping
 @use_for(job_type=JobType.production_build)
 class ReleaseGithubKojiBuildHandler(AbstractGithubKojiBuildHandler):
     triggers = [
@@ -511,7 +502,6 @@ class ReleaseGithubKojiBuildHandler(AbstractGithubKojiBuildHandler):
         )
 
 
-@add_to_mapping
 @use_for(job_type=JobType.production_build)
 class PullRequestGithubKojiBuildHandler(AbstractGithubKojiBuildHandler):
     triggers = [
@@ -545,7 +535,6 @@ class PullRequestGithubKojiBuildHandler(AbstractGithubKojiBuildHandler):
         )
 
 
-@add_to_mapping
 @use_for(job_type=JobType.production_build)
 class PushGithubKojiBuildHandler(AbstractGithubKojiBuildHandler):
     triggers = [

--- a/packit_service/worker/handlers/testing_farm_handlers.py
+++ b/packit_service/worker/handlers/testing_farm_handlers.py
@@ -40,7 +40,7 @@ from packit_service.service.events import (
     TheJobTriggerType,
 )
 from packit_service.worker.handlers import AbstractGithubJobHandler
-from packit_service.worker.handlers.abstract import add_to_mapping, use_for
+from packit_service.worker.handlers.abstract import use_for
 from packit_service.worker.reporting import StatusReporter
 from packit_service.worker.result import HandlerResults
 from packit_service.worker.testing_farm import TestingFarmJobHelper
@@ -48,7 +48,6 @@ from packit_service.worker.testing_farm import TestingFarmJobHelper
 logger = logging.getLogger(__name__)
 
 
-@add_to_mapping
 @use_for(job_type=JobType.tests)
 class TestingFarmResultsHandler(AbstractGithubJobHandler):
     type = JobType.report_test_results


### PR DESCRIPTION
- Simplify the decorators for handlers.
- Add handlers for Koji builds and add missing 'use_for' to PushKojiBuild.
- Use commit and push triggers for Push* build handlers to be compatible between github and fedmsg terminology.