### PR TITLE
Fix error in API when old data exists.

### DIFF
--- a/packit_service/service/api/copr_builds.py
+++ b/packit_service/service/api/copr_builds.py
@@ -29,10 +29,21 @@ from flask_restplus import Namespace, Resource
 from packit_service.service.api.parsers import indices, pagination_arguments
 from packit_service.models import CoprBuild
 
+from typing import Union
+
+
 logger = getLogger("packit_service")
 
 
 ns = Namespace("copr-builds", description="COPR builds")
+
+
+def optional_time(datetime_object) -> Union[str, None]:
+    """Returns a string if argument is a datetime object."""
+    if datetime_object is None:
+        return None
+    else:
+        return datetime_object.strftime("%d/%m/%Y %H:%M:%S")
 
 
 @ns.route("")
@@ -57,9 +68,7 @@ class CoprBuildsList(Resource):
                     "build_id": build.build_id,
                     "status": build.status,
                     "chroots": [],
-                    "build_submitted_time": build.build_submitted_time.strftime(
-                        "%d/%m/%Y %H:%M:%S"
-                    ),
+                    "build_submitted_time": optional_time(build.build_submitted_time),
                     "repo_namespace": build.pr.project.namespace,
                     "web_url": build.web_url,
                 }
@@ -98,9 +107,7 @@ class InstallationItem(Resource):
                 "build_id": build.build_id,
                 "status": build.status,
                 "chroots": [],
-                "build_submitted_time": build.build_submitted_time.strftime(
-                    "%d/%m/%Y %H:%M:%S"
-                ),
+                "build_submitted_time": optional_time(build.build_submitted_time),
                 "build_start_time": build.build_start_time,
                 "build_finished_time": build.build_finished_time,
                 "pr_id": build.pr.pr_id,

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,0 +1,12 @@
+from packit_service.service.api.copr_builds import optional_time
+from datetime import datetime
+import pytest
+
+
+@pytest.mark.parametrize(
+    "input_object,expected_type", [(datetime.utcnow(), str), (None, type(None))]
+)
+def test_optional_time(input_object, expected_type):
+    # optional_time returns a string if its passed a datetime object
+    # None if passed a NoneType object
+    assert isinstance(optional_time(input_object), expected_type)


### PR DESCRIPTION
https://stg.packit.dev/api/copr-builds Is returning internal server error in staging since #479 was deployed.

This is because the database has rows of old data where fields like build_submitted_time are empty. (thanks @csomh )

Fixed that.

