### PR TITLE
deployment: process path_to_secrets actually + random commits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,33 @@ check_in_container: test_image
 		-v $(CURDIR)/files/packit-service.yaml:/root/.config/packit-service.yaml \
 		$(TEST_IMAGE) make check
 
+# This is my target so don't touch it! :) How to:
+# * No dependencies - take care of them yourself
+# * Make sure to set `command_handler: local`: there is no kube API in pristine containers
+# * Make sure to `docker-compose up redis postgres`
+# Features:
+# * Can regen requre stuff (`TEST_TARGET=./tests_requre/openshift_integration/`)
+# * Mounts your source code in the container
+# * Mounts secrets in the container: make sure all are valid
+# * Can touch redis and psql
+check-in-container-tomas:
+	@# don't use -ti here in CI, TTY is not allocated in zuul
+	$(CONTAINER_ENGINE) run --rm \
+		-v $(CURDIR):/src-packit-service \
+		-v $(CURDIR)/packit_service:/usr/local/lib/python3.7/site-packages/packit_service:ro,z \
+		-v $(CURDIR)/secrets/dev/packit-service.yaml:/home/packit/.config/packit-service.yaml:ro,z \
+		-v $(CURDIR)/secrets/dev/fedora.keytab:/secrets/fedora.keytab:ro,z \
+		-v $(CURDIR)/secrets/dev/private-key.pem:/secrets/private-key.pem:ro,z \
+		-v $(CURDIR)/secrets/dev/fullchain.pem:/secrets/fullchain.pem:ro,z \
+		-v $(CURDIR)/secrets/dev/privkey.pem:/secrets/privkey.pem:ro,z \
+		-w /src-packit-service \
+		--security-opt label=disable \
+		-v $(CURDIR)/files/packit-service.yaml:/root/.config/packit-service.yaml \
+		-v $(CURDIR)/tests_requre/test_data/:/tmp/test_data/ \
+		--network packit-service_default \
+		-e REDIS_SERVICE_HOST=redis \
+		$(TEST_IMAGE) make check TEST_TARGET=$(TEST_TARGET)
+
 # deploy a pod with tests and run them
 check-inside-openshift: worker test_image
 	@# http://timmurphy.org/2015/09/27/how-to-get-a-makefile-directory-path/

--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,3 @@ check-inside-openshift: worker test_image
 
 check-inside-openshift-zuul: test_image
 	ANSIBLE_STDOUT_CALLBACK=debug $(AP) files/check-inside-openshift.yaml
-
-
-# this target is expected to run within an openshift pod
-check-within-openshift:
-	/src-packit-service/files/setup_env_in_openshift.sh
-	pytest-3 -k test_update

--- a/files/check-inside-openshift.yaml
+++ b/files/check-inside-openshift.yaml
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 ---
-- name: Deploy secrets for integration tests
+- name: Run requre tests inside an openshift pod
   hosts: localhost
   vars:
     local_data_dir: "../tests_requre"

--- a/files/deployment.yaml
+++ b/files/deployment.yaml
@@ -29,52 +29,71 @@
       command: oc whoami -t
       register: kubeconfig_token
       become: "{{ as_root }}"
-    - name: Creates zuul secrets directory
+
+    # path_to_secrets = this is what we get from the outside
+    # internal_secrets_path = this is what we'll use here
+    - set_fact: internal_secrets_path={{ deployment_dir }}/secrets/dev
+    - name: Create the directory secrets/
       file:
-        path: "{{ deployment_dir }}/secrets/dev"
+        path: "{{ deployment_dir }}/secrets/"
         state: directory
-    - name: Generate dummy keys
-      command: "openssl genrsa -out {{ deployment_dir }}/secrets/dev/{{ item }} 4096"
-      with_items:
-        - private-key.pem
-        - privkey.pem
-        - dashboard-privkey.pem
-    - name: Generate dummy certs
-      command: "openssl req -x509 -new -key {{ deployment_dir }}/secrets/dev/{{ item.key }} -out {{ deployment_dir }}/secrets/dev/{{ item.out }} -days 1 -subj '/CN=just.for.the.ci' -passin pass:somepassword -passout pass:anotherpassword -nodes"
-      with_items:
-        - { key: privkey.pem, out: fullchain.pem }
-        - { key: dashboard-privkey.pem, out: dashboard-fullchain.pem }
+    - name: Prepare secrets
+      when: path_to_secrets is not defined
+      block:
+        - name: Create {{ internal_secrets_path }}
+          file:
+            path: "{{ internal_secrets_path }}"
+            state: directory
+        - name: Generate dummy keys
+          command: "openssl genrsa -out {{ internal_secrets_path }}/{{ item }} 4096"
+          with_items:
+            - private-key.pem
+            - privkey.pem
+            - dashboard-privkey.pem
+        - name: Generate dummy certs
+          command: "openssl req -x509 -new -key {{ internal_secrets_path }}/{{ item.key }} -out {{ internal_secrets_path }}/{{ item.out }} -days 1 -subj '/CN=just.for.the.ci' -passin pass:somepassword -passout pass:anotherpassword -nodes"
+          with_items:
+            - { key: privkey.pem, out: fullchain.pem }
+            - { key: dashboard-privkey.pem, out: dashboard-fullchain.pem }
 
-    - name: Generate /etc/ssh/ RSA host key
-      command: "ssh-keygen -q -t rsa -f {{ deployment_dir }}/secrets/dev/id_rsa -C '' -N ''"
-      args:
-        creates: "{{ deployment_dir }}/secrets/dev/id_rsa"
-    # Ansible 2.8+, does not work in Zuul (???)
-    #  - name: Generate an OpenSSH keypair with the default values (4096 bits, rsa)
-    #    openssh_keypair:
-    #      path: "{{ deployment_dir }}/secrets/dev/id_rsa"
+        - name: Generate /etc/ssh/ RSA host key
+          command: "ssh-keygen -q -t rsa -f {{ internal_secrets_path }}/id_rsa -C '' -N ''"
+          args:
+            creates: "{{ internal_secrets_path }}/id_rsa"
+        # Ansible 2.8+, does not work in Zuul (???)
+        #  - name: Generate an OpenSSH keypair with the default values (4096 bits, rsa)
+        #    openssh_keypair:
+        #      path: "{{ deployment_dir }}/secrets/dev/id_rsa"
 
-    - name: Create fedora.keytab
+        - name: Create fedora.keytab
+          file:
+            path: "{{ internal_secrets_path }}/fedora.keytab"
+            state: touch
+
+        - name: Create sentry_key
+          file:
+            path: "{{ internal_secrets_path }}/sentry_key"
+            state: touch
+
+        - name: Copy the rest of the secrets from template
+          copy:
+            src: "{{ deployment_dir }}/secrets/template/{{ item }}"
+            dest: "{{ internal_secrets_path }}/{{ item }}"
+            remote_src: yes
+          with_items:
+            - packit-service.yaml
+            - copr
+            - ssh_config
+            - fedora.toml
+            - extra-vars.yml
+    # end of the block
+
+    - name: symlink secrets when provided
+      when: path_to_secrets is defined
       file:
-        path: "{{ deployment_dir }}/secrets/dev/fedora.keytab"
-        state: touch
-
-    - name: Create sentry_key
-      file:
-        path: "{{ deployment_dir }}/secrets/dev/sentry_key"
-        state: touch
-
-    - name: Copy the rest of the secrets from template
-      copy:
-        src: "{{ deployment_dir }}/secrets/template/{{ item }}"
-        dest: "{{ deployment_dir }}/secrets/dev/{{ item }}"
-        remote_src: yes
-      with_items:
-        - packit-service.yaml
-        - copr
-        - ssh_config
-        - fedora.toml
-        - extra-vars.yml
+        state: link
+        src: "{{ path_to_secrets }}/dev"
+        dest: "{{ internal_secrets_path }}"
 
     - name: Create dev.yml
       copy:


### PR DESCRIPTION
* check-inside-os: correct playbook name
* make: new target for local in-container testing
* make: drop unused target check-within-os

I can rename, change or merge the new target - don't really care

This PR does:
* actually provides our secrets/dev/ during local requre regeneration
* creates new make target to run requre tests w/o openshift (!!!)