### PR TITLE
Fix copr project name for testing farm and add response url

### DIFF
--- a/packit_service/worker/build/build_helper.py
+++ b/packit_service/worker/build/build_helper.py
@@ -114,6 +114,14 @@ class BaseBuildJobHelper:
         return self._api
 
     @property
+    def api_url(self) -> str:
+        return (
+            "https://prod.packit.dev/api/"
+            if self.config.deployment == Deployment.prod
+            else "https://stg.packit.dev/api/"
+        )
+
+    @property
     def build_chroots(self) -> List[str]:
         """
         Return the chroots to build.

--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -121,6 +121,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         payload: dict = {
             "pipeline": {"id": pipeline_id},
             "api": {"token": self.config.testing_farm_secret},
+            "response-url": self.api_url,
             "artifact": {
                 "repo-name": self.project.repo,
                 "repo-namespace": self.project.namespace,

--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -125,7 +125,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             "artifact": {
                 "repo-name": self.project.repo,
                 "repo-namespace": self.project.namespace,
-                "copr-repo-name": self.default_project_name,
+                "copr-repo-name": f"{self.job_owner}/{self.default_project_name}",
                 "copr-chroot": chroot,
                 "commit-sha": self.event.commit_sha,
                 "git-url": self.event.project_url,

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -305,6 +305,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build):
             }
         )
     )
+    flexmock(CoprBuildJobHelper).should_receive("job_owner").and_return("some-owner")
     flexmock(CoprBuildJobHelper).should_receive("copr_build_model").and_return(
         flexmock()
     )
@@ -371,10 +372,11 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build):
     payload: dict = {
         "pipeline": {"id": "5e8079d8-f181-41cf-af96-28e99774eb68"},
         "api": {"token": ""},
+        "response-url": "https://stg.packit.dev/api/",
         "artifact": {
             "repo-name": "bar",
             "repo-namespace": "foo",
-            "copr-repo-name": "foo-bar-123-stg",
+            "copr-repo-name": "some-owner/foo-bar-123-stg",
             "copr-chroot": "fedora-rawhide-x86_64",
             "commit-sha": "0011223344",
             "git-url": "https://github.com/foo/bar.git",
@@ -420,6 +422,7 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build):
             }
         )
     )
+    flexmock(CoprBuildJobHelper).should_receive("job_owner").and_return("some-owner")
     flexmock(CoprBuildJobHelper).should_receive("copr_build_model").and_return(
         flexmock()
     )
@@ -517,6 +520,7 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build):
             }
         )
     )
+    flexmock(CoprBuildJobHelper).should_receive("job_owner").and_return("some-owner")
     flexmock(CoprBuildJobHelper).should_receive("copr_build_model").and_return(
         flexmock()
     )


### PR DESCRIPTION
- Fix the copr-repo-name in testing-farm payload.
- Add response url to testing-farm payload.