### PR TITLE
Fix event argument for handlers

### DIFF
--- a/packit_service/worker/handlers/testing_farm_handlers.py
+++ b/packit_service/worker/handlers/testing_farm_handlers.py
@@ -58,17 +58,17 @@ class TestingFarmResultsHandler(AbstractGithubJobHandler):
         self,
         config: ServiceConfig,
         job_config: Optional[JobConfig],
-        test_results_event: TestingFarmResultsEvent,
+        event: TestingFarmResultsEvent,
     ):
-        super().__init__(config=config, job_config=job_config, event=test_results_event)
-        self.project: GitProject = test_results_event.get_project()
+        super().__init__(config=config, job_config=job_config, event=event)
+        self.project: GitProject = event.get_project()
         self.package_config = self.get_package_config_from_repo(
             project=self.project, reference=self.event.git_ref
         )
         if not self.package_config:
             raise ValueError(f"No config file found in {self.project.full_repo_name}")
 
-        self.package_config.upstream_project_url = test_results_event.project_url
+        self.package_config.upstream_project_url = event.project_url
 
     def get_package_config_from_repo(
         self,

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -308,7 +308,7 @@ class SteveJobs:
         # not repository, so package config with jobs is missing
         if event_object.trigger == TheJobTriggerType.installation:
             handler = GithubAppInstallationHandler(
-                self.config, job_config=None, installation_event=event_object
+                self.config, job_config=None, event=event_object
             )
             job_type = JobType.add_to_whitelist.value
             jobs_results[job_type] = handler.run_n_clean()

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -171,7 +171,7 @@ def test_testing_farm_response(
     test_farm_handler = TestingFarmResultsHandler(
         config=flexmock(command_handler_work_dir=flexmock()),
         job_config=flexmock(),
-        test_results_event=TestingFarmResultsEvent(
+        event=TestingFarmResultsEvent(
             pipeline_id="id",
             result=tests_result,
             environment=flexmock(),


### PR DESCRIPTION
- Use name 'event' for all handlers to match the call in jobs.
- Fixes RED-HAT-0P-2BK