### PR TITLE
Right testing farm response url

### DIFF
--- a/packit_service/worker/build/build_helper.py
+++ b/packit_service/worker/build/build_helper.py
@@ -116,9 +116,9 @@ class BaseBuildJobHelper:
     @property
     def api_url(self) -> str:
         return (
-            "https://prod.packit.dev/api/"
+            "https://prod.packit.dev/api"
             if self.config.deployment == Deployment.prod
-            else "https://stg.packit.dev/api/"
+            else "https://stg.packit.dev/api"
         )
 
     @property

--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -121,7 +121,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         payload: dict = {
             "pipeline": {"id": pipeline_id},
             "api": {"token": self.config.testing_farm_secret},
-            "response-url": self.api_url,
+            "response-url": f"{self.api_url}/testing-farm/results",
             "artifact": {
                 "repo-name": self.project.repo,
                 "repo-namespace": self.project.namespace,

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -372,7 +372,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build):
     payload: dict = {
         "pipeline": {"id": "5e8079d8-f181-41cf-af96-28e99774eb68"},
         "api": {"token": ""},
-        "response-url": "https://stg.packit.dev/api/",
+        "response-url": "https://stg.packit.dev/api/testing-farm/results",
         "artifact": {
             "repo-name": "bar",
             "repo-namespace": "foo",


### PR DESCRIPTION
- Use the full endpoint for the testing-farm response-url.
- We need to send the whole URL: https://stg.packit.dev/api/testing-farm/results and not only the https://stg.packit.dev/api