### PR TITLE
Use the configured COPR project when triggering Testing Farm

### DIFF
--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -135,7 +135,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             "artifact": {
                 "repo-name": self.project.repo,
                 "repo-namespace": self.project.namespace,
-                "copr-repo-name": f"{self.job_owner}/{self.default_project_name}",
+                "copr-repo-name": f"{self.job_owner}/{self.job_project}",
                 "copr-chroot": chroot,
                 "commit-sha": self.event.commit_sha,
                 "git-url": self.event.project_url,


### PR DESCRIPTION
Before this, we always referred to the default COPR project when
triggering Testing Farm. This caused tests to fail in repos which choose
to build in their own COPR namespace and project.

Relates to #523.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>