### PR TITLE
Fix triggers creation in database

### DIFF
--- a/packit_service/worker/build/copr_build.py
+++ b/packit_service/worker/build/copr_build.py
@@ -163,7 +163,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
                 target=chroot,
                 status="pending",
                 srpm_build=srpm_build_model,
-                job_trigger=self.event.db_trigger,
+                trigger_model=self.event.db_trigger,
             )
             url = get_log_url(id_=copr_build.id)
             self.report_status_to_all_for_chroot(

--- a/tests_requre/database/conftest.py
+++ b/tests_requre/database/conftest.py
@@ -143,7 +143,7 @@ def branch_trigger_model(branch_model):
 
 # Create a single build
 @pytest.fixture()
-def a_copr_build(pr_trigger_model):
+def a_copr_build(pr_model):
     srpm_build = SRPMBuildModel.create("asd\nqwe\n")
     yield CoprBuildModel.get_or_create(
         build_id="123456",
@@ -154,14 +154,14 @@ def a_copr_build(pr_trigger_model):
         target=TARGET,
         status="pending",
         srpm_build=srpm_build,
-        job_trigger=pr_trigger_model,
+        trigger_model=pr_model,
     )
 
 
 # Create multiple builds
 # Used for testing queries
 @pytest.fixture()
-def multiple_copr_builds(pr_trigger_model, different_pr_trigger_model):
+def multiple_copr_builds(pr_model, different_pr_model):
     srpm_build = SRPMBuildModel.create("asd\nqwe\n")
     yield [
         CoprBuildModel.get_or_create(
@@ -173,7 +173,7 @@ def multiple_copr_builds(pr_trigger_model, different_pr_trigger_model):
             target="fedora-42-x86_64",
             status="pending",
             srpm_build=srpm_build,
-            job_trigger=pr_trigger_model,
+            trigger_model=pr_model,
         ),
         # Same build_id but different chroot
         CoprBuildModel.get_or_create(
@@ -185,7 +185,7 @@ def multiple_copr_builds(pr_trigger_model, different_pr_trigger_model):
             target="fedora-43-x86_64",
             status="pending",
             srpm_build=srpm_build,
-            job_trigger=pr_trigger_model,
+            trigger_model=pr_model,
         ),
         # Completely different build
         CoprBuildModel.get_or_create(
@@ -197,14 +197,14 @@ def multiple_copr_builds(pr_trigger_model, different_pr_trigger_model):
             target="fedora-43-x86_64",
             status="pending",
             srpm_build=srpm_build,
-            job_trigger=different_pr_trigger_model,
+            trigger_model=different_pr_model,
         ),
     ]
 
 
 # Create a single build
 @pytest.fixture()
-def a_koji_build(pr_trigger_model):
+def a_koji_build(pr_model):
     srpm_build = SRPMBuildModel.create("asd\nqwe\n")
     yield KojiBuildModel.get_or_create(
         build_id="123456",
@@ -213,7 +213,7 @@ def a_koji_build(pr_trigger_model):
         target=TARGET,
         status="pending",
         srpm_build=srpm_build,
-        job_trigger=pr_trigger_model,
+        trigger_model=pr_model,
     )
 
 
@@ -230,7 +230,7 @@ def multiple_koji_builds(pr_trigger_model, different_pr_trigger_model):
             target="fedora-42-x86_64",
             status="pending",
             srpm_build=srpm_build,
-            job_trigger=pr_trigger_model,
+            trigger_model=pr_trigger_model,
         ),
         # Same build_id but different chroot
         KojiBuildModel.get_or_create(
@@ -240,7 +240,7 @@ def multiple_koji_builds(pr_trigger_model, different_pr_trigger_model):
             target="fedora-43-x86_64",
             status="pending",
             srpm_build=srpm_build,
-            job_trigger=pr_trigger_model,
+            trigger_model=pr_trigger_model,
         ),
         # Completely different build
         KojiBuildModel.get_or_create(

--- a/tests_requre/database/test_models.py
+++ b/tests_requre/database/test_models.py
@@ -269,7 +269,7 @@ def test_copr_and_koji_build_for_one_trigger(clean_before_and_after):
         target=TARGET,
         status="pending",
         srpm_build=srpm_build,
-        job_trigger=pr1_trigger,
+        trigger_model=pr1,
     )
     koji_build = KojiBuildModel.get_or_create(
         build_id="987654",
@@ -278,7 +278,7 @@ def test_copr_and_koji_build_for_one_trigger(clean_before_and_after):
         target=TARGET,
         status="pending",
         srpm_build=srpm_build,
-        job_trigger=pr1_trigger,
+        trigger_model=pr1,
     )
 
     assert copr_build in pr1_trigger.copr_builds

--- a/tests_requre/database/test_tasks.py
+++ b/tests_requre/database/test_tasks.py
@@ -31,8 +31,6 @@ from packit_service.models import (
     CoprBuildModel,
     SRPMBuildModel,
     PullRequestModel,
-    JobTriggerModel,
-    JobTriggerModelType,
 )
 from packit_service.service.events import CoprBuildEvent
 from packit_service.worker.tasks import babysit_copr_build
@@ -70,9 +68,7 @@ def packit_build_752():
     pr_model = PullRequestModel.get_or_create(
         pr_id=752, namespace="packit-service", repo_name="packit"
     )
-    pr_trigger_model = JobTriggerModel.get_or_create(
-        type=JobTriggerModelType.pull_request, trigger_id=pr_model.id
-    )
+
     srpm_build = SRPMBuildModel.create("asd\nqwe\n")
     yield CoprBuildModel.get_or_create(
         build_id=str(BUILD_ID),
@@ -86,7 +82,7 @@ def packit_build_752():
         target="fedora-rawhide-x86_64",
         status="pending",
         srpm_build=srpm_build,
-        job_trigger=pr_trigger_model,
+        trigger_model=pr_model,
     )
 
 


### PR DESCRIPTION
- Use specific model for build trigger, not the JobConfig.

We mixed the JobTriggerModel with the PullRequestModel,GitBranchModel,... The JobTriggerModel is only for maapping the build model to the specific trigger model.