### PR TITLE
Two db fixes

### DIFF
--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -745,9 +745,13 @@ class TFTTestRunModel(Base):
         commit_sha: str,
         status: TestingFarmResult,
         target: str,
-        job_trigger: AbstractTriggerDbType,
+        trigger_model: AbstractTriggerDbType,
         web_url: Optional[str] = None,
     ) -> "TFTTestRunModel":
+        job_trigger = JobTriggerModel.get_or_create(
+            type=trigger_model.job_trigger_model_type, trigger_id=trigger_model.id
+        )
+
         with get_sa_session() as session:
             test_run = cls()
             test_run.pipeline_id = pipeline_id

--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -381,6 +381,9 @@ class CoprBuildModel(Base):
             self.build_logs_url = build_logs
             session.add(self)
 
+    def get_project(self) -> GitProjectModel:
+        return self.job_trigger.get_trigger_object().project
+
     @classmethod
     def get_by_id(cls, id_: int) -> Optional["CoprBuildModel"]:
         with get_sa_session() as session:
@@ -498,6 +501,9 @@ class KojiBuildModel(Base):
         with get_sa_session() as session:
             self.build_logs_url = build_logs
             session.add(self)
+
+    def get_project(self) -> GitProjectModel:
+        return self.job_trigger.get_trigger_object().project
 
     @classmethod
     def get_by_id(cls, id_: int) -> Optional["KojiBuildModel"]:

--- a/packit_service/service/api/copr_builds.py
+++ b/packit_service/service/api/copr_builds.py
@@ -35,9 +35,7 @@ from packit_service.models import CoprBuildModel
 
 from typing import Union
 
-
 logger = getLogger("packit_service")
-
 
 ns = Namespace("copr-builds", description="COPR builds")
 
@@ -65,15 +63,17 @@ class CoprBuildsList(Resource):
         checklist = []
         for build in builds_list:
             if int(build.build_id) not in checklist:
+
+                project = build.get_project()
                 build_dict = {
                     "project": build.project_name,
                     "owner": build.owner,
-                    "repo_name": build.pr.project.repo_name,
+                    "repo_name": project.repo_name,
                     "build_id": build.build_id,
                     "status": build.status,
                     "chroots": [],
                     "build_submitted_time": optional_time(build.build_submitted_time),
-                    "repo_namespace": build.pr.project.namespace,
+                    "repo_namespace": project.namespace,
                     "web_url": build.web_url,
                 }
                 # same_buildid_builds are copr builds created due to the same trigger

--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -125,7 +125,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             status=TestingFarmResult.new,
             target=chroot,
             web_url=None,
-            job_trigger=self.event.db_trigger,
+            trigger_model=self.event.db_trigger,
         )
 
         payload: dict = {

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -35,7 +35,12 @@ from packit.copr_helper import CoprHelper
 from packit.local_project import LocalProject
 
 from packit_service.constants import TESTING_FARM_TRIGGER_URL
-from packit_service.models import CoprBuildModel, TestingFarmResult, TFTTestRunModel
+from packit_service.models import (
+    CoprBuildModel,
+    TestingFarmResult,
+    TFTTestRunModel,
+    JobTriggerModelType,
+)
 from packit_service.service.events import CoprBuildEvent
 from packit_service.service.urls import get_log_url
 from packit_service.worker.build.copr_build import CoprBuildJobHelper
@@ -375,7 +380,10 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
             "git-ref": "0011223344",
         },
     }
-    trigger = flexmock(job_config_trigger_type=JobConfigTriggerType.pull_request)
+    trigger = flexmock(
+        job_config_trigger_type=JobConfigTriggerType.pull_request,
+        job_trigger_model_type=JobTriggerModelType.pull_request,
+    )
     flexmock(CoprBuildEvent).should_receive("db_trigger").and_return(trigger)
 
     tft_test_run_model = flexmock()
@@ -387,7 +395,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
         commit_sha="0011223344",
         status=TestingFarmResult.new,
         target="fedora-rawhide-x86_64",
-        job_trigger=trigger,
+        trigger_model=trigger,
         web_url=None,
     ).and_return(tft_test_run_model)
 
@@ -513,7 +521,10 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
         url="",
     ).once()
 
-    trigger = flexmock(job_config_trigger_type=JobConfigTriggerType.pull_request)
+    trigger = flexmock(
+        job_config_trigger_type=JobConfigTriggerType.pull_request,
+        job_trigger_model_type=JobTriggerModelType.pull_request,
+    )
     flexmock(CoprBuildEvent).should_receive("db_trigger").and_return(trigger)
 
     tft_test_run_model = flexmock()
@@ -527,7 +538,7 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
         commit_sha="0011223344",
         status=TestingFarmResult.new,
         target="fedora-rawhide-x86_64",
-        job_trigger=trigger,
+        trigger_model=trigger,
         web_url=None,
     ).and_return(tft_test_run_model)
 
@@ -632,7 +643,10 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
         url="",
     ).once()
 
-    trigger = flexmock(job_config_trigger_type=JobConfigTriggerType.pull_request)
+    trigger = flexmock(
+        job_config_trigger_type=JobConfigTriggerType.pull_request,
+        job_trigger_model_type=JobTriggerModelType.pull_request,
+    )
     flexmock(CoprBuildEvent).should_receive("db_trigger").and_return(trigger)
 
     tft_test_run_model = flexmock()
@@ -646,7 +660,7 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
         commit_sha="0011223344",
         status=TestingFarmResult.new,
         target="fedora-rawhide-x86_64",
-        job_trigger=trigger,
+        trigger_model=trigger,
         web_url=None,
     ).and_return(tft_test_run_model)
 

--- a/tests_requre/database/conftest.py
+++ b/tests_requre/database/conftest.py
@@ -250,14 +250,14 @@ def multiple_koji_builds(pr_trigger_model, different_pr_trigger_model):
             target="fedora-43-x86_64",
             status="pending",
             srpm_build=srpm_build,
-            job_trigger=different_pr_trigger_model,
+            trigger_model=different_pr_trigger_model,
         ),
     ]
 
 
 # Create a single test run
 @pytest.fixture()
-def a_new_test_run(pr_trigger_model):
+def a_new_test_run(pr_model):
     yield TFTTestRunModel.create(
         pipeline_id="123456",
         commit_sha="687abc76d67d",
@@ -265,14 +265,14 @@ def a_new_test_run(pr_trigger_model):
         "pipeline/02271aa8-2917-4741-a39e-78d8706c56c1",
         target=TARGET,
         status=TestingFarmResult.new,
-        job_trigger=pr_trigger_model,
+        trigger_model=pr_model,
     )
 
 
 # Create multiple builds
 # Used for testing queries
 @pytest.fixture()
-def multiple_new_test_runs(pr_trigger_model, different_pr_trigger_model):
+def multiple_new_test_runs(pr_model, different_pr_model):
     yield [
         TFTTestRunModel.create(
             pipeline_id="123456",
@@ -281,7 +281,7 @@ def multiple_new_test_runs(pr_trigger_model, different_pr_trigger_model):
             "pipeline/02271aa8-2917-4741-a39e-78d8706c56c1",
             target="fedora-42-x86_64",
             status=TestingFarmResult.new,
-            job_trigger=pr_trigger_model,
+            trigger_model=pr_model,
         ),
         # Same commit_sha but different chroot and pipeline_id
         TFTTestRunModel.create(
@@ -291,7 +291,7 @@ def multiple_new_test_runs(pr_trigger_model, different_pr_trigger_model):
             "pipeline/02271aa8-2917-4741-a39e-78d8706c56c2",
             target="fedora-43-x86_64",
             status=TestingFarmResult.new,
-            job_trigger=pr_trigger_model,
+            trigger_model=pr_model,
         ),
         # Completely different build
         TFTTestRunModel.create(
@@ -301,7 +301,7 @@ def multiple_new_test_runs(pr_trigger_model, different_pr_trigger_model):
             "pipeline/12272ba8-2918-4751-a40e-78d8706c56d4",
             target="fedora-43-x86_64",
             status=TestingFarmResult.running,
-            job_trigger=different_pr_trigger_model,
+            trigger_model=different_pr_model,
         ),
     ]
 

--- a/tests_requre/database/test_models.py
+++ b/tests_requre/database/test_models.py
@@ -323,13 +323,13 @@ def test_tmt_test_run_set_status(clean_before_and_after, a_new_test_run):
     assert b.status == TestingFarmResult.running
 
 
-def test_tmt_test_run_set_web_url(clean_before_and_after, pr_trigger_model):
+def test_tmt_test_run_set_web_url(clean_before_and_after, pr_model):
     test_run_model = TFTTestRunModel.create(
         pipeline_id="123456",
         commit_sha="687abc76d67d",
         target=TARGET,
         status=TestingFarmResult.new,
-        job_trigger=pr_trigger_model,
+        trigger_model=pr_model,
     )
     assert not test_run_model.web_url
     new_url = (

--- a/tests_requre/database/test_models.py
+++ b/tests_requre/database/test_models.py
@@ -36,6 +36,7 @@ from packit_service.models import (
     TestingFarmResult,
     TFTTestRunModel,
     TaskResultModel,
+    GitProjectModel,
 )
 from tests_requre.database.conftest import TARGET
 
@@ -357,3 +358,17 @@ def test_get_task_result_by_id(
     assert TaskResultModel.get_by_id("ab1").event == task_results[0].get("event")
     assert TaskResultModel.get_by_id("ab2").jobs == task_results[1].get("jobs")
     assert TaskResultModel.get_by_id("ab2").event == task_results[1].get("event")
+
+
+def test_project_property_for_copr_build(a_copr_build):
+    project = a_copr_build.get_project()
+    assert isinstance(project, GitProjectModel)
+    assert project.namespace == "the-namespace"
+    assert project.repo_name == "the-repo-name"
+
+
+def test_project_property_for_koji_build(a_koji_build):
+    project = a_koji_build.get_project()
+    assert isinstance(project, GitProjectModel)
+    assert project.namespace == "the-namespace"
+    assert project.repo_name == "the-repo-name"


### PR DESCRIPTION
- Get the project from the build model properly.
  - Solves the problem, that API returns "Internal Error" instead of the log view.
- Fix the type mismatch for testing-farm triggers.
  - The same thing was done for copr/koji builds in #527.