### PR TITLE
Get testing farm trigger from db

### DIFF
--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -42,6 +42,7 @@ from packit_service.models import (
     AbstractTriggerDbType,
     JobTriggerModelType,
     TestingFarmResult,
+    TFTTestRunModel,
 )
 from packit_service.service.db_triggers import (
     AddReleaseDbTrigger,
@@ -504,6 +505,13 @@ class TestingFarmResultsEvent(AbstractGithubEvent):
             return None
         package_config.upstream_project_url = self.project_url
         return package_config
+
+    @property
+    def db_trigger(self) -> Optional[AbstractTriggerDbType]:
+        run_model = TFTTestRunModel.get_by_pipeline_id(pipeline_id=self.pipeline_id)
+        if not run_model:
+            return None
+        return run_model.job_trigger.get_trigger_object()
 
 
 # Wait, what? copr build event doesn't sound like github event

--- a/tests_requre/database/test_models.py
+++ b/tests_requre/database/test_models.py
@@ -345,6 +345,48 @@ def test_tmt_test_run_set_web_url(clean_before_and_after, pr_model):
     assert b.web_url == new_url
 
 
+def test_tmt_test_get_by_pipeline_id_pr(clean_before_and_after, pr_model):
+    test_run_model = TFTTestRunModel.create(
+        pipeline_id="123456",
+        commit_sha="687abc76d67d",
+        target=TARGET,
+        status=TestingFarmResult.new,
+        trigger_model=pr_model,
+    )
+
+    b = TFTTestRunModel.get_by_pipeline_id(test_run_model.pipeline_id)
+    assert b
+    assert b.job_trigger.get_trigger_object() == pr_model
+
+
+def test_tmt_test_get_by_pipeline_id_branch_push(clean_before_and_after, branch_model):
+    test_run_model = TFTTestRunModel.create(
+        pipeline_id="123456",
+        commit_sha="687abc76d67d",
+        target=TARGET,
+        status=TestingFarmResult.new,
+        trigger_model=branch_model,
+    )
+
+    b = TFTTestRunModel.get_by_pipeline_id(test_run_model.pipeline_id)
+    assert b
+    assert b.job_trigger.get_trigger_object() == branch_model
+
+
+def test_tmt_test_get_by_pipeline_id_release(clean_before_and_after, release_model):
+    test_run_model = TFTTestRunModel.create(
+        pipeline_id="123456",
+        commit_sha="687abc76d67d",
+        target=TARGET,
+        status=TestingFarmResult.new,
+        trigger_model=release_model,
+    )
+
+    b = TFTTestRunModel.get_by_pipeline_id(test_run_model.pipeline_id)
+    assert b
+    assert b.job_trigger.get_trigger_object() == release_model
+
+
 def test_get_task_results(clean_before_and_after, multiple_task_results_entries):
     results = TaskResultModel.get_all()
     assert len(results) == 2


### PR DESCRIPTION
- Get the trigger from the database for the testing-farm response so we can set the correct status for branch-push and release.
- This should be the last thing needed to make the copr-builds and tests work for branch-push and release events. (We only need to turn on the push events for the production GitHub app -- see the relevant PR: #239 )