### PR TITLE
dont send deployment.dev events to sentry

### DIFF
--- a/packit_service/sentry_integration.py
+++ b/packit_service/sentry_integration.py
@@ -23,6 +23,7 @@ import logging
 from contextlib import contextmanager
 from os import getenv
 
+from packit_service.config import ServiceConfig, Deployment
 from packit_service.utils import only_once
 
 logger = logging.getLogger(__name__)
@@ -77,10 +78,11 @@ def configure_sentry(
 
 
 def send_to_sentry(ex):
-    # so that we don't have to have sentry sdk installed locally
-    import sentry_sdk
+    if ServiceConfig.get_service_config().deployment != Deployment.dev:
+        # so that we don't have to have sentry sdk installed locally
+        import sentry_sdk
 
-    sentry_sdk.capture_exception(ex)
+        sentry_sdk.capture_exception(ex)
 
 
 @contextmanager

--- a/packit_service/worker/build/copr_build.py
+++ b/packit_service/worker/build/copr_build.py
@@ -29,8 +29,8 @@ from packit.config import PackageConfig, JobType, JobConfig
 from packit.utils import PackitFormatter
 from sandcastle import SandcastleTimeoutReached
 
-from packit_service.celerizer import celery_app
 from packit_service import sentry_integration
+from packit_service.celerizer import celery_app
 from packit_service.config import ServiceConfig, Deployment
 from packit_service.constants import MSG_RETRIGGER
 from packit_service.models import CoprBuildModel, SRPMBuildModel
@@ -231,7 +231,6 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
 
             c.srpm_failed = True
 
-            # when do we NOT want to send stuff to sentry?
             sentry_integration.send_to_sentry(ex)
 
             # this needs to be done AFTER we gather logs


### PR DESCRIPTION
I was getting annoyed by the nasty tracebacks lately.