### PR TITLE
Revert "[install-deps-worker.yaml] install marshmallow-3"

### DIFF
--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -17,9 +17,6 @@
           - python3-psycopg2
           - python3-lazy-object-proxy
           #- python3-flask-restx # https://bugzilla.redhat.com/show_bug.cgi?id=1817535
-          # To raise upon unknown config key (packit#782)
-          # Remove once we base packit image on fedora:32 (which ships marshmallow v3)
-          - https://jpopelka.fedorapeople.org/python3-marshmallow-3.5.1-1.fc31.noarch.rpm
         state: present
     - name: Install pip deps
       pip:


### PR DESCRIPTION
This reverts commit 75d468630b2e399a83c4ba06601cc29e32d13905.

Fixes:
```
/usr/lib/python3.7/site-packages/copr/client_v2/entities.py:45: in ProjectEntity
    _schema = ProjectSchema(strict=True)
E   TypeError: __init__() got an unexpected keyword argument 'strict'
```

I'm sorry for 75d4686 but my tests were not running locally at all.