### PR TITLE
store build state per chroot in DB

### DIFF
--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -80,8 +80,6 @@ def babysit_copr_build(self, build_id: int):
             self.retry()
         logger.info(f"The status is {build_copr.state}")
 
-        # copr doesn't tell status of how a build in the chroot went:
-        #   https://bugzilla.redhat.com/show_bug.cgi?id=1813227
         for build in builds:
             if build.status != "pending":
                 logger.info(
@@ -89,6 +87,7 @@ def babysit_copr_build(self, build_id: int):
                     "things were taken care of already, skipping."
                 )
                 continue
+            chroot_build = copr_client.build_chroot_proxy.get(build_id, build.target)
             event = CoprBuildEvent(
                 topic=FedmsgTopic.copr_build_finished.value,
                 build_id=build_id,
@@ -96,7 +95,7 @@ def babysit_copr_build(self, build_id: int):
                 chroot=build.target,
                 status=(
                     COPR_API_SUCC_STATE
-                    if build_copr.state == COPR_SUCC_STATE
+                    if chroot_build.state == COPR_SUCC_STATE
                     else COPR_API_FAIL_STATE
                 ),
                 owner=build.owner,

--- a/tests_requre/database/test_tasks.py
+++ b/tests_requre/database/test_tasks.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 import pytest
-from copr.v3 import Client, BuildProxy
+from copr.v3 import Client, BuildProxy, BuildChrootProxy
 from flexmock import flexmock
 from munch import Munch
 from packit.config import PackageConfig
@@ -124,6 +124,21 @@ def test_babysit_copr_build(clean_before_and_after, packit_build_752):
         }
     )
     flexmock(BuildProxy).should_receive("get").and_return(coprs_response)
+
+    chroot_response = Munch(
+        {
+            "ended_on": 1583916564,
+            "name": "fedora-rawhide-x86_64",
+            "result_url": "https://download.copr.fedorainfracloud.org/"
+            "results/packit/packit-service-packit-752/fedora-rawhide-x86_64/"
+            "01300329-packit/",
+            "started_on": 1583916315,
+            "state": "succeeded",
+        }
+    )
+    flexmock(BuildChrootProxy).should_receive("get").with_args(
+        BUILD_ID, "fedora-rawhide-x86_64"
+    ).and_return(chroot_response)
 
     babysit_copr_build(BUILD_ID)
     assert packit_build_752.status == PG_COPR_BUILD_STATUS_SUCCESS


### PR DESCRIPTION
fixes #517 

- store individual chroot state in db instead of relying on the final build state
- add mock flexmock for BuildChrootProxy