### PR TITLE
Optionally Disable Sentry

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,8 @@ services:
       - redis
       - postgres
     environment:
+      # Sentry secret is passed via an env var, not the secrets folder.
+      # SENTRY_SECRET: https://<key>@<organization>.ingest.sentry.io/<project>
       DEPLOYMENT: dev
       REDIS_SERVICE_HOST: redis
       APP: packit_service.worker.tasks

--- a/packit_service/config.py
+++ b/packit_service/config.py
@@ -60,6 +60,7 @@ class ServiceConfig(Config):
         webhook_secret: str = "",
         testing_farm_secret: str = "",
         validate_webhooks: bool = True,
+        disable_sentry: bool = False,
         admins: list = None,
         fas_password: Optional[str] = "",
         **kwargs,
@@ -70,7 +71,7 @@ class ServiceConfig(Config):
         self.webhook_secret = webhook_secret
         self.testing_farm_secret = testing_farm_secret
         self.validate_webhooks = validate_webhooks
-
+        self.disable_sentry = disable_sentry
         # fas.fedoraproject.org needs password to authenticate
         # 'fas_user' is inherited from packit.config.Config
         self.fas_password = fas_password
@@ -92,6 +93,7 @@ class ServiceConfig(Config):
             f"webhook_secret='{hide(self.webhook_secret)}', "
             f"testing_farm_secret='{hide(self.testing_farm_secret)}', "
             f"validate_webhooks='{self.validate_webhooks}', "
+            f"disable_sentry='{self.disable_sentry}', "
             f"admins='{self.admins}', "
             f"fas_password='{hide(self.fas_password)}', "
             f"server_name='{self.server_name}')"

--- a/packit_service/schema.py
+++ b/packit_service/schema.py
@@ -51,6 +51,7 @@ class ServiceConfigSchema(UserConfigSchema):
     testing_farm_secret = fields.String()
     fas_password = fields.String(default="")
     validate_webhooks = fields.Bool(default=False)
+    disable_sentry = fields.Bool(default=False)
     admins = fields.List(fields.String())
     server_name = fields.String()
 

--- a/packit_service/sentry_integration.py
+++ b/packit_service/sentry_integration.py
@@ -24,8 +24,10 @@ from contextlib import contextmanager
 from os import getenv
 
 from packit_service.utils import only_once
+from packit_service.config import ServiceConfig
 
 logger = logging.getLogger(__name__)
+config = ServiceConfig.get_service_config()
 
 
 @only_once
@@ -35,6 +37,8 @@ def configure_sentry(
     flask_integration: bool = False,
     sqlalchemy_integration: bool = False,
 ) -> None:
+    """Sentry Configuration. Called once for each container."""
+
     logger.debug(
         f"Setup sentry for {runner_type}: "
         f"celery_integration={celery_integration}, "
@@ -42,9 +46,17 @@ def configure_sentry(
         f"sqlalchemy_integration={sqlalchemy_integration}"
     )
 
-    secret_key = getenv("SENTRY_SECRET")
-    if not secret_key:
+    if config.disable_sentry:
         return
+
+    secret_key = getenv("SENTRY_SECRET")
+
+    if not secret_key:
+        err_msg = (
+            "\n* Sentry is enabled but no key has been provided."
+            "\n* Please add 'disable_sentry: True' to packit-service.yaml to disable it."
+        )
+        raise NoSentryKeyError(err_msg)
 
     # so that we don't have to have sentry sdk installed locally
     import sentry_sdk
@@ -100,3 +112,9 @@ def push_scope_to_sentry():
 
         with sentry_sdk.push_scope() as scope:
             yield scope
+
+
+class NoSentryKeyError(Exception):
+    """Raise when sentry is enabled but key has not been provided."""
+
+    pass

--- a/packit_service/service/app.py
+++ b/packit_service/service/app.py
@@ -28,7 +28,8 @@ from lazy_object_proxy import Proxy
 from packit.utils import set_logging
 
 from packit_service.config import ServiceConfig
-from packit_service.sentry_integration import configure_sentry
+
+# from packit_service.sentry_integration import configure_sentry
 from packit_service.service.api import blueprint
 from packit_service.log_versions import log_service_versions
 from packit_service.service.views import builds_blueprint
@@ -37,12 +38,18 @@ set_logging(logger_name="packit_service", level=logging.DEBUG)
 
 
 def get_flask_application():
-    configure_sentry(
-        runner_type="packit-service",
-        celery_integration=True,
-        sqlalchemy_integration=True,
-        flask_integration=True,
-    )
+
+    # Sentry does not work in the service for now
+    # SENTRY_SECRET is not passed to the service pod or container
+    # https://github.com/packit-service/deployment/blob/master/openshift/packit-service.yml.j2
+
+    # configure_sentry(
+    #     runner_type="packit-service",
+    #     celery_integration=True,
+    #     sqlalchemy_integration=True,
+    #     flask_integration=True,
+    # )
+
     app = Flask(__name__)
     app.register_blueprint(blueprint)
     app.register_blueprint(builds_blueprint)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -45,6 +45,7 @@ def service_config_valid():
         "keytab_path": "/secrets/fedora.keytab",
         "webhook_secret": "secret",
         "validate_webhooks": True,
+        "disable_sentry": False,
         "testing_farm_secret": "granko",
         "command_handler": "sandcastle",
         "command_handler_work_dir": "/sandcastle",
@@ -64,6 +65,7 @@ def test_parse_valid(service_config_valid):
     assert config.keytab_path == "/secrets/fedora.keytab"
     assert config.webhook_secret == "secret"
     assert config.validate_webhooks
+    assert config.disable_sentry is False
     assert config.testing_farm_secret == "granko"
     assert config.command_handler_work_dir == "/sandcastle"
     assert config.admins == {"Dasher", "Dancer", "Vixen", "Comet", "Blitzen"}
@@ -120,3 +122,4 @@ def test_config_opts(sc):
     assert sc.github_requests_log_path is not None
     assert sc.webhook_secret is not None
     assert sc.validate_webhooks is not None
+    assert sc.disable_sentry is not None

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -120,6 +120,8 @@ def test_copr_build_check_names(pull_request_event):
     flexmock(PackitAPI).should_receive("run_copr_build").and_return(1, None)
     flexmock(Celery).should_receive("send_task").once()
 
+    config = ServiceConfig.get_service_config()
+    config.disable_sentry = True
     assert helper.run_copr_build()["success"]
 
 


### PR DESCRIPTION
Fixes #558 

- Adding `disable_sentry: True` to _secrets/packit-service.yaml_ disables sentry. 
- If this line is not present or `disable_sentry: False` is set then events will be sent to sentry like normal.


