### PR TITLE
Report build status in Pagure

### DIFF
--- a/packit_service/worker/build/build_helper.py
+++ b/packit_service/worker/build/build_helper.py
@@ -80,7 +80,9 @@ class BaseBuildJobHelper:
         ] = event
         self.pr_id = (
             self.event.pr_id
-            if isinstance(self.event, (PullRequestEvent, PullRequestCommentEvent))
+            if isinstance(
+                self.event, (CoprBuildEvent, PullRequestEvent, PullRequestCommentEvent)
+            )
             else None
         )
 
@@ -218,7 +220,9 @@ class BaseBuildJobHelper:
     @property
     def status_reporter(self):
         if not self._status_reporter:
-            self._status_reporter = StatusReporter(self.project, self.event.commit_sha)
+            self._status_reporter = StatusReporter(
+                self.project, self.event.commit_sha, self.pr_id
+            )
         return self._status_reporter
 
     @property

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -139,6 +139,7 @@ def test_copr_build_success_set_test_check(pull_request_event):
     )
     helper = build_helper(jobs=[test_job], event=pull_request_event)
     flexmock(GitProject).should_receive("set_commit_status").and_return().times(16)
+    flexmock(GitProject).should_receive("get_pr").and_return(flexmock())
     flexmock(SRPMBuildModel).should_receive("create").and_return(SRPMBuildModel())
     flexmock(CoprBuildModel).should_receive("get_or_create").and_return(
         CoprBuildModel(id=1)
@@ -221,6 +222,7 @@ def test_copr_build_success(pull_request_event):
     #  - Building RPM ...
     helper = build_helper(event=pull_request_event)
     flexmock(GitProject).should_receive("set_commit_status").and_return().times(8)
+    flexmock(GitProject).should_receive("get_pr").and_return(flexmock())
     flexmock(SRPMBuildModel).should_receive("create").and_return(SRPMBuildModel())
     flexmock(CoprBuildModel).should_receive("get_or_create").and_return(
         CoprBuildModel(id=1)
@@ -258,6 +260,7 @@ def test_copr_build_fails_in_packit(pull_request_event):
             templ.format(ver=v),
             trim=True,
         ).and_return().once()
+    flexmock(GitProject).should_receive("get_pr").and_return(flexmock())
     flexmock(SRPMBuildModel).should_receive("create").and_return(SRPMBuildModel(id=2))
     flexmock(CoprBuildModel).should_receive("get_or_create").and_return(
         CoprBuildModel(id=1)
@@ -277,6 +280,7 @@ def test_copr_build_no_targets(pull_request_event):
         event=pull_request_event, metadata=JobMetadataConfig(owner="nobody")
     )
     flexmock(GitProject).should_receive("set_commit_status").and_return().times(4)
+    flexmock(GitProject).should_receive("get_pr").and_return(flexmock())
     flexmock(SRPMBuildModel).should_receive("create").and_return(SRPMBuildModel())
     flexmock(CoprBuildModel).should_receive("get_or_create").and_return(
         CoprBuildModel(id=1)

--- a/tests/unit/test_reporting.py
+++ b/tests/unit/test_reporting.py
@@ -1,0 +1,123 @@
+# MIT License
+#
+# Copyright (c) 2018-2020 Red Hat, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import pytest
+import flexmock
+
+from ogr.abstract import CommitStatus
+from packit_service.worker.reporting import StatusReporter
+
+
+@pytest.mark.parametrize(
+    (
+        "project,commit_sha,"
+        "pr_id,has_pr_id,pr_object,"
+        "state,description,check_name,url,"
+        "needs_pr_flags,uid"
+    ),
+    [
+        pytest.param(
+            flexmock(),
+            "7654321",
+            "11",
+            True,
+            flexmock(),
+            CommitStatus.success,
+            "We made it!",
+            "packit/pr-rpm-build",
+            "https://api.packit.dev/build/111/logs",
+            False,
+            None,
+            id="GitHub PR",
+        ),
+        pytest.param(
+            flexmock(),
+            "7654321",
+            None,
+            False,
+            flexmock(),
+            CommitStatus.failure,
+            "We made it!",
+            "packit/branch-rpm-build",
+            "https://api.packit.dev/build/112/logs",
+            False,
+            None,
+            id="branch push",
+        ),
+        pytest.param(
+            flexmock(),
+            "7654321",
+            None,
+            False,
+            flexmock(head_commit="1234567"),
+            CommitStatus.pending,
+            "We made it!",
+            "packit/pagure-rpm-build",
+            "https://api.packit.dev/build/113/logs",
+            False,
+            None,
+            id="Pagure PR, not head commit",
+        ),
+        pytest.param(
+            flexmock(),
+            "7654321",
+            None,
+            False,
+            flexmock(head_commit="7654321"),
+            CommitStatus.error,
+            "We made it!",
+            "packit/pagure-rpm-build",
+            "https://api.packit.dev/build/114/logs",
+            True,
+            "8d8d0d428ccee1112042f6d06f6b334a",
+            id="Pagure PR, head commit",
+        ),
+    ],
+)
+def test_set_status(
+    project,
+    commit_sha,
+    pr_id,
+    has_pr_id,
+    pr_object,
+    state,
+    description,
+    check_name,
+    url,
+    needs_pr_flags,
+    uid,
+):
+    reporter = StatusReporter(project, commit_sha, pr_id)
+
+    project.should_receive("set_commit_status").with_args(
+        commit_sha, state, url, description, check_name, trim=True
+    ).once()
+
+    if has_pr_id:
+        project.should_receive("get_pr").with_args(pr_id).once().and_return(pr_object)
+
+    if needs_pr_flags:
+        pr_object.should_receive("set_flag").with_args(
+            check_name, description, url, state, uid
+        )
+
+    reporter.set_status(state, description, check_name, url)


### PR DESCRIPTION
When a build for a PR from a Pagure instance (git.centos.org, for example) starts or ends, update the flags on the PR, to make the check status visible on the PR page.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>