### PR TITLE
store chroot build details in db

### DIFF
--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -374,6 +374,12 @@ class CoprBuildModel(Base):
     # metadata is reserved to sqlalch
     data = Column(JSON)
 
+    def set_start_end_time(self, start_time: DateTime, end_time: DateTime):
+        with get_sa_session() as session:
+            self.build_start_time = start_time
+            self.build_finished_time = end_time
+            session.add(self)
+
     def set_status(self, status: str):
         with get_sa_session() as session:
             self.status = status

--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -535,6 +535,9 @@ class CoprBuildEvent(AbstractGithubEvent):
         owner: str,
         project_name: str,
         pkg: str,
+        logs_url: str,
+        started_on: datetime,
+        ended_on: datetime,
     ):
         trigger_db = build.job_trigger.get_trigger_object()
         self.commit_sha = build.commit_sha
@@ -564,6 +567,9 @@ class CoprBuildEvent(AbstractGithubEvent):
         self.owner = owner
         self.project_name = project_name
         self.pkg = pkg
+        self.logs_url = logs_url
+        self.started_on = started_on
+        self.ended_on = ended_on
 
         trigger_type = build.job_trigger.type
         trigger_db = build.job_trigger.get_trigger_object()
@@ -591,13 +597,28 @@ class CoprBuildEvent(AbstractGithubEvent):
         owner: str,
         project_name: str,
         pkg: str,
+        logs_url: str,
+        started_on: datetime,
+        ended_on: datetime,
     ) -> Optional["CoprBuildEvent"]:
         """ Return cls instance or None if build_id not in CoprBuildDB"""
         build = CoprBuildModel.get_by_build_id(str(build_id), chroot)
         if not build:
             logger.warning(f"Build id: {build_id} not in CoprBuildDB")
             return None
-        return cls(topic, build_id, build, chroot, status, owner, project_name, pkg,)
+        return cls(
+            topic,
+            build_id,
+            build,
+            chroot,
+            status,
+            owner,
+            project_name,
+            pkg,
+            logs_url,
+            started_on,
+            ended_on,
+        )
 
     def pre_check(self):
         if not self.build:

--- a/packit_service/worker/handlers/fedmsg_handlers.py
+++ b/packit_service/worker/handlers/fedmsg_handlers.py
@@ -28,6 +28,7 @@ import logging
 from typing import Type, Optional
 
 import requests
+from datetime import datetime
 from ogr.abstract import CommitStatus
 from packit.api import PackitAPI
 from packit.config import (
@@ -283,6 +284,10 @@ class CoprBuildEndHandler(FedmsgHandler):
         )
         build.set_status(PG_COPR_BUILD_STATUS_SUCCESS)
 
+        build_start_time = datetime.utcfromtimestamp(self.event.started_on)
+        build_end_time = datetime.utcfromtimestamp(self.event.ended_on)
+        build.set_start_end_time(build_start_time, build_end_time)
+        build.set_build_logs_url(self.event.logs_url)
         if (
             self.build_job_helper.job_tests
             and self.event.chroot in self.build_job_helper.tests_chroots

--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -501,7 +501,19 @@ class Parser:
         owner = event.get("owner")
         project_name = event.get("copr")
         pkg = event.get("pkg")
+        logs_url = event.get("logs_url")
+        started_on = event.get("started_on")
+        ended_on = event.get("ended_on")
 
         return CoprBuildEvent.from_build_id(
-            topic, build_id, chroot, status, owner, project_name, pkg
+            topic,
+            build_id,
+            chroot,
+            status,
+            owner,
+            project_name,
+            pkg,
+            logs_url,
+            started_on,
+            ended_on,
         )

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -103,6 +103,9 @@ def babysit_copr_build(self, build_id: int):
                 pkg=build_copr.source_package.get(
                     "name", ""
                 ),  # this seems to be the SRPM name
+                logs_url=chroot_build.result_url,
+                started_on=chroot_build.started_on,
+                ended_on=chroot_build.ended_on,
             )
             CoprBuildEndHandler(
                 ServiceConfig.get_service_config(), job_config=None, event=event

--- a/tests/data/fedmsg/copr_build_end.json
+++ b/tests/data/fedmsg/copr_build_end.json
@@ -11,5 +11,8 @@
   "version": "0.7.0.3.ga593893-1.fc30",
   "build": 1044215,
   "owner": "packit",
-  "pkg": "hello"
+  "pkg": "hello",
+  "result_url": "https://download.copr.fedorainfracloud.org/results/rishavanand/rishavanand-hello-world-1/fedora-30-x86_64/01339556-hello/",
+  "started_on": 1587037156,
+  "ended_on": 1587037183
 }

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -147,7 +147,11 @@ def test_copr_build_end(
         flexmock(GithubProject).should_receive("pr_comment").never()
 
     flexmock(CoprBuildModel).should_receive("get_by_build_id").and_return(copr_build_pr)
+    flexmock(CoprBuildModel).should_receive("set_start_end_time")
+    flexmock(CoprBuildModel).should_receive("set_build_logs_url")
     copr_build_pr.should_receive("set_status").with_args("success")
+    copr_build_pr.should_receive("set_start_end_time").once()
+    copr_build_pr.should_receive("set_build_logs_url").once()
     url = get_log_url(1)
     flexmock(requests).should_receive("get").and_return(requests.Response())
     flexmock(requests.Response).should_receive("raise_for_status").and_return(None)
@@ -189,7 +193,11 @@ def test_copr_build_end_push(copr_build_end, pc_build_push, copr_build_branch_pu
     flexmock(CoprBuildModel).should_receive("get_by_build_id").and_return(
         copr_build_branch_push
     )
+    flexmock(CoprBuildModel).should_receive("set_start_end_time")
+    flexmock(CoprBuildModel).should_receive("set_build_logs_url")
     copr_build_branch_push.should_receive("set_status").with_args("success")
+    copr_build_branch_push.should_receive("set_start_end_time").once()
+    copr_build_branch_push.should_receive("set_build_logs_url").once()
     url = get_log_url(1)
     flexmock(requests).should_receive("get").and_return(requests.Response())
     flexmock(requests.Response).should_receive("raise_for_status").and_return(None)
@@ -231,7 +239,11 @@ def test_copr_build_end_release(copr_build_end, pc_build_release, copr_build_rel
     flexmock(CoprBuildModel).should_receive("get_by_build_id").and_return(
         copr_build_release
     )
+    flexmock(CoprBuildModel).should_receive("set_start_end_time")
+    flexmock(CoprBuildModel).should_receive("set_build_logs_url")
     copr_build_release.should_receive("set_status").with_args("success")
+    copr_build_release.should_receive("set_start_end_time").once()
+    copr_build_release.should_receive("set_build_logs_url").once()
     url = get_log_url(1)
     flexmock(requests).should_receive("get").and_return(requests.Response())
     flexmock(requests.Response).should_receive("raise_for_status").and_return(None)
@@ -291,7 +303,11 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
     flexmock(LocalProject).should_receive("refresh_the_arguments").and_return(None)
 
     flexmock(CoprBuildModel).should_receive("get_by_build_id").and_return(copr_build_pr)
+    flexmock(CoprBuildModel).should_receive("set_start_end_time")
+    flexmock(CoprBuildModel).should_receive("set_build_logs_url")
     copr_build_pr.should_receive("set_status").with_args("success")
+    copr_build_pr.should_receive("set_start_end_time").once()
+    copr_build_pr.should_receive("set_build_logs_url").once()
     url = "https://localhost:5000/copr-build/1/logs"
     flexmock(requests).should_receive("get").and_return(requests.Response())
     flexmock(requests.Response).should_receive("raise_for_status").and_return(None)
@@ -414,7 +430,11 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
     flexmock(LocalProject).should_receive("refresh_the_arguments").and_return(None)
 
     flexmock(CoprBuildModel).should_receive("get_by_build_id").and_return(copr_build_pr)
+    flexmock(CoprBuildModel).should_receive("set_start_end_time")
+    flexmock(CoprBuildModel).should_receive("set_build_logs_url")
     copr_build_pr.should_receive("set_status").with_args("success")
+    copr_build_pr.should_receive("set_start_end_time").once()
+    copr_build_pr.should_receive("set_build_logs_url").once()
     flexmock(requests).should_receive("get").and_return(requests.Response())
     flexmock(requests.Response).should_receive("raise_for_status").and_return(None)
     # check if packit-service set correct PR status
@@ -522,7 +542,11 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
     flexmock(LocalProject).should_receive("refresh_the_arguments").and_return(None)
 
     flexmock(CoprBuildModel).should_receive("get_by_build_id").and_return(copr_build_pr)
+    flexmock(CoprBuildModel).should_receive("set_start_end_time")
+    flexmock(CoprBuildModel).should_receive("set_build_logs_url")
     copr_build_pr.should_receive("set_status").with_args("success")
+    copr_build_pr.should_receive("set_start_end_time").once()
+    copr_build_pr.should_receive("set_build_logs_url").once()
     url = get_log_url(1)
     flexmock(requests).should_receive("get").and_return(requests.Response())
     flexmock(requests.Response).should_receive("raise_for_status").and_return(None)
@@ -697,7 +721,11 @@ def test_copr_build_not_comment_on_success(copr_build_end, pc_build_pr, copr_bui
     flexmock(GithubProject).should_receive("pr_comment").never()
 
     flexmock(CoprBuildModel).should_receive("get_by_build_id").and_return(copr_build_pr)
+    flexmock(CoprBuildModel).should_receive("set_start_end_time")
+    flexmock(CoprBuildModel).should_receive("set_build_logs_url")
     copr_build_pr.should_receive("set_status").with_args("success")
+    copr_build_pr.should_receive("set_start_end_time").once()
+    copr_build_pr.should_receive("set_build_logs_url").once()
     url = get_log_url(1)
     flexmock(requests).should_receive("get").and_return(requests.Response())
     flexmock(requests.Response).should_receive("raise_for_status").and_return(None)


### PR DESCRIPTION
resolves #566  

Will store `build start time`, `build end time` and `build result/logs url` in DB for individual chroots. 