### PR TITLE
Fix getting of start and end time in CoprBuildEnd event

### DIFF
--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -374,9 +374,13 @@ class CoprBuildModel(Base):
     # metadata is reserved to sqlalch
     data = Column(JSON)
 
-    def set_start_end_time(self, start_time: DateTime, end_time: DateTime):
+    def set_start_time(self, start_time: DateTime):
         with get_sa_session() as session:
             self.build_start_time = start_time
+            session.add(self)
+
+    def set_end_time(self, end_time: DateTime):
+        with get_sa_session() as session:
             self.build_finished_time = end_time
             session.add(self)
 

--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -541,9 +541,6 @@ class CoprBuildEvent(AbstractGithubEvent):
         owner: str,
         project_name: str,
         pkg: str,
-        logs_url: str,
-        started_on: datetime,
-        ended_on: datetime,
     ):
         trigger_db = build.job_trigger.get_trigger_object()
         self.commit_sha = build.commit_sha
@@ -573,9 +570,6 @@ class CoprBuildEvent(AbstractGithubEvent):
         self.owner = owner
         self.project_name = project_name
         self.pkg = pkg
-        self.logs_url = logs_url
-        self.started_on = started_on
-        self.ended_on = ended_on
 
         trigger_type = build.job_trigger.type
         trigger_db = build.job_trigger.get_trigger_object()
@@ -603,28 +597,13 @@ class CoprBuildEvent(AbstractGithubEvent):
         owner: str,
         project_name: str,
         pkg: str,
-        logs_url: str,
-        started_on: datetime,
-        ended_on: datetime,
     ) -> Optional["CoprBuildEvent"]:
         """ Return cls instance or None if build_id not in CoprBuildDB"""
         build = CoprBuildModel.get_by_build_id(str(build_id), chroot)
         if not build:
             logger.warning(f"Build id: {build_id} not in CoprBuildDB")
             return None
-        return cls(
-            topic,
-            build_id,
-            build,
-            chroot,
-            status,
-            owner,
-            project_name,
-            pkg,
-            logs_url,
-            started_on,
-            ended_on,
-        )
+        return cls(topic, build_id, build, chroot, status, owner, project_name, pkg,)
 
     def pre_check(self):
         if not self.build:

--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -541,6 +541,7 @@ class CoprBuildEvent(AbstractGithubEvent):
         owner: str,
         project_name: str,
         pkg: str,
+        timestamp,
     ):
         trigger_db = build.job_trigger.get_trigger_object()
         self.commit_sha = build.commit_sha
@@ -570,6 +571,7 @@ class CoprBuildEvent(AbstractGithubEvent):
         self.owner = owner
         self.project_name = project_name
         self.pkg = pkg
+        self.timestamp = timestamp
 
         trigger_type = build.job_trigger.type
         trigger_db = build.job_trigger.get_trigger_object()
@@ -597,13 +599,16 @@ class CoprBuildEvent(AbstractGithubEvent):
         owner: str,
         project_name: str,
         pkg: str,
+        timestamp,
     ) -> Optional["CoprBuildEvent"]:
         """ Return cls instance or None if build_id not in CoprBuildDB"""
         build = CoprBuildModel.get_by_build_id(str(build_id), chroot)
         if not build:
             logger.warning(f"Build id: {build_id} not in CoprBuildDB")
             return None
-        return cls(topic, build_id, build, chroot, status, owner, project_name, pkg,)
+        return cls(
+            topic, build_id, build, chroot, status, owner, project_name, pkg, timestamp
+        )
 
     def pre_check(self):
         if not self.build:

--- a/packit_service/worker/handlers/fedmsg_handlers.py
+++ b/packit_service/worker/handlers/fedmsg_handlers.py
@@ -238,7 +238,12 @@ class CoprBuildEndHandler(FedmsgHandler):
             logger.info(msg)
             return HandlerResults(success=True, details={"msg": msg})
 
-        build.set_end_time(datetime.utcnow())
+        end_time = (
+            datetime.utcfromtimestamp(self.event.timestamp)
+            if self.event.timestamp
+            else None
+        )
+        build.set_end_time(end_time)
         url = get_log_url(build.id)
 
         # https://pagure.io/copr/copr/blob/master/f/common/copr_common/enums.py#_42
@@ -342,7 +347,12 @@ class CoprBuildStartHandler(FedmsgHandler):
             logger.warning(msg)
             return HandlerResults(success=False, details={"msg": msg})
 
-        build.set_start_time(datetime.utcnow())
+        start_time = (
+            datetime.utcfromtimestamp(self.event.timestamp)
+            if self.event.timestamp
+            else None
+        )
+        build.set_start_time(start_time)
         url = get_log_url(build.id)
         build.set_status("pending")
         copr_build_logs = get_copr_build_logs_url(self.event)

--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -505,21 +505,9 @@ class Parser:
         owner = event.get("owner")
         project_name = event.get("copr")
         pkg = event.get("pkg")
-        logs_url = event.get("logs_url")
-        started_on = event.get("started_on")
-        ended_on = event.get("ended_on")
 
         return CoprBuildEvent.from_build_id(
-            topic,
-            build_id,
-            chroot,
-            status,
-            owner,
-            project_name,
-            pkg,
-            logs_url,
-            started_on,
-            ended_on,
+            topic, build_id, chroot, status, owner, project_name, pkg,
         )
 
 

--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -505,9 +505,10 @@ class Parser:
         owner = event.get("owner")
         project_name = event.get("copr")
         pkg = event.get("pkg")
+        timestamp = event.get("timestamp")
 
         return CoprBuildEvent.from_build_id(
-            topic, build_id, chroot, status, owner, project_name, pkg,
+            topic, build_id, chroot, status, owner, project_name, pkg, timestamp
         )
 
 

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -115,9 +115,6 @@ def babysit_copr_build(self, build_id: int):
                 pkg=build_copr.source_package.get(
                     "name", ""
                 ),  # this seems to be the SRPM name
-                logs_url=chroot_build.result_url,
-                started_on=chroot_build.started_on,
-                ended_on=chroot_build.ended_on,
             )
             CoprBuildEndHandler(
                 ServiceConfig.get_service_config(), job_config=None, event=event

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -115,6 +115,7 @@ def babysit_copr_build(self, build_id: int):
                 pkg=build_copr.source_package.get(
                     "name", ""
                 ),  # this seems to be the SRPM name
+                timestamp=chroot_build.ended_on,
             )
             CoprBuildEndHandler(
                 ServiceConfig.get_service_config(), job_config=None, event=event

--- a/tests/data/fedmsg/copr_build_end.json
+++ b/tests/data/fedmsg/copr_build_end.json
@@ -11,8 +11,5 @@
   "version": "0.7.0.3.ga593893-1.fc30",
   "build": 1044215,
   "owner": "packit",
-  "pkg": "hello",
-  "result_url": "https://download.copr.fedorainfracloud.org/results/rishavanand/rishavanand-hello-world-1/fedora-30-x86_64/01339556-hello/",
-  "started_on": 1587037156,
-  "ended_on": 1587037183
+  "pkg": "hello"
 }

--- a/tests_requre/database/test_models.py
+++ b/tests_requre/database/test_models.py
@@ -95,6 +95,8 @@ def test_create_copr_build(clean_before_and_after, a_copr_build_for_pr):
     # we will check if a_copr_build has build_submitted_time value that's within the past hour
     time_last_hour = datetime.utcnow() - timedelta(hours=1)
     assert a_copr_build_for_pr.build_submitted_time > time_last_hour
+    a_copr_build_for_pr.set_end_time(None)
+    assert a_copr_build_for_pr.build_finished_time is None
 
 
 def test_copr_build_get_pr_id(


### PR DESCRIPTION
Fixes #575 

- There is no info about the start and end time in the fedmsg event. In this PR we set the start and end time to time when processing CoprBuildStart and CoprBuildEnd event (not using Copr API calls to avoid possible loss of the message when Copr API is down)

- The copr logs url is set during CoprBuildStart, so it is not needed to set it in the CoprBuildEnd