### PR TITLE
Do not use forks in github

### DIFF
--- a/packit_service/worker/build/build_helper.py
+++ b/packit_service/worker/build/build_helper.py
@@ -30,8 +30,8 @@ from packit.local_project import LocalProject
 
 from packit_service.config import ServiceConfig, Deployment
 from packit_service.service.events import (
-    PullRequestEvent,
-    PullRequestCommentEvent,
+    PullRequestGithubEvent,
+    PullRequestCommentGithubEvent,
     CoprBuildEvent,
     PushGitHubEvent,
     ReleaseEvent,
@@ -59,9 +59,9 @@ class BaseBuildJobHelper:
         package_config: PackageConfig,
         project: GitProject,
         event: Union[
-            PullRequestEvent,
+            PullRequestGithubEvent,
             PullRequestPagureEvent,
-            PullRequestCommentEvent,
+            PullRequestCommentGithubEvent,
             PullRequestCommentPagureEvent,
             CoprBuildEvent,
             PushGitHubEvent,
@@ -73,9 +73,9 @@ class BaseBuildJobHelper:
         self.package_config: PackageConfig = package_config
         self.project: GitProject = project
         self.event: Union[
-            PullRequestEvent,
+            PullRequestGithubEvent,
             PullRequestPagureEvent,
-            PullRequestCommentEvent,
+            PullRequestCommentGithubEvent,
             PullRequestCommentPagureEvent,
             CoprBuildEvent,
             PushGitHubEvent,

--- a/packit_service/worker/build/copr_build.py
+++ b/packit_service/worker/build/copr_build.py
@@ -35,8 +35,8 @@ from packit_service.config import ServiceConfig, Deployment
 from packit_service.constants import MSG_RETRIGGER
 from packit_service.models import CoprBuildModel, SRPMBuildModel
 from packit_service.service.events import (
-    PullRequestEvent,
-    PullRequestCommentEvent,
+    PullRequestGithubEvent,
+    PullRequestCommentGithubEvent,
     CoprBuildEvent,
     PushGitHubEvent,
     ReleaseEvent,
@@ -71,9 +71,9 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
         package_config: PackageConfig,
         project: GitProject,
         event: Union[
-            PullRequestEvent,
+            PullRequestGithubEvent,
             PullRequestPagureEvent,
-            PullRequestCommentEvent,
+            PullRequestCommentGithubEvent,
             PullRequestCommentPagureEvent,
             CoprBuildEvent,
             PushGitHubEvent,

--- a/packit_service/worker/handlers/comment_action_handler.py
+++ b/packit_service/worker/handlers/comment_action_handler.py
@@ -30,7 +30,7 @@ from typing import Dict, Type, Union, Optional
 
 from packit_service.config import ServiceConfig
 from packit_service.service.events import (
-    PullRequestCommentEvent,
+    PullRequestCommentGithubEvent,
     IssueCommentEvent,
 )
 from packit_service.service.events import (
@@ -85,12 +85,16 @@ class CommentActionHandler(Handler):
         self,
         config: ServiceConfig,
         event: Union[
-            PullRequestCommentEvent, IssueCommentEvent, PullRequestCommentPagureEvent
+            PullRequestCommentGithubEvent,
+            IssueCommentEvent,
+            PullRequestCommentPagureEvent,
         ],
     ):
         super().__init__(config)
         self.event: Union[
-            PullRequestCommentEvent, IssueCommentEvent, PullRequestCommentPagureEvent
+            PullRequestCommentGithubEvent,
+            IssueCommentEvent,
+            PullRequestCommentPagureEvent,
         ] = event
 
     def run(self) -> HandlerResults:

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -32,7 +32,7 @@ from packit.config import JobType, PackageConfig, JobConfig
 from packit_service.config import ServiceConfig
 from packit_service.log_versions import log_job_versions
 from packit_service.service.events import (
-    PullRequestCommentEvent,
+    PullRequestCommentGithubEvent,
     IssueCommentEvent,
     Event,
     TheJobTriggerType,
@@ -233,7 +233,9 @@ class SteveJobs:
     def process_comment_jobs(
         self,
         event: Union[
-            PullRequestCommentEvent, PullRequestCommentPagureEvent, IssueCommentEvent
+            PullRequestCommentGithubEvent,
+            PullRequestCommentPagureEvent,
+            IssueCommentEvent,
         ],
     ) -> HandlerResults:
 
@@ -352,7 +354,7 @@ class SteveJobs:
             isinstance(
                 event_object,
                 (
-                    PullRequestCommentEvent,
+                    PullRequestCommentGithubEvent,
                     PullRequestCommentPagureEvent,
                     IssueCommentEvent,
                 ),

--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -29,8 +29,8 @@ from typing import Optional, Union, List
 
 from packit.utils import nested_get
 from packit_service.service.events import (
-    PullRequestEvent,
-    PullRequestCommentEvent,
+    PullRequestGithubEvent,
+    PullRequestCommentGithubEvent,
     InstallationEvent,
     ReleaseEvent,
     DistGitEvent,
@@ -63,12 +63,12 @@ class Parser:
         event: dict,
     ) -> Optional[
         Union[
-            PullRequestEvent,
+            PullRequestGithubEvent,
             InstallationEvent,
             ReleaseEvent,
             DistGitEvent,
             TestingFarmResultsEvent,
-            PullRequestCommentEvent,
+            PullRequestCommentGithubEvent,
             IssueCommentEvent,
             CoprBuildEvent,
             PushGitHubEvent,
@@ -86,12 +86,12 @@ class Parser:
 
         response: Optional[
             Union[
-                PullRequestEvent,
+                PullRequestGithubEvent,
                 InstallationEvent,
                 ReleaseEvent,
                 DistGitEvent,
                 TestingFarmResultsEvent,
-                PullRequestCommentEvent,
+                PullRequestCommentGithubEvent,
                 IssueCommentEvent,
                 CoprBuildEvent,
                 PushGitHubEvent,
@@ -138,7 +138,7 @@ class Parser:
         return response
 
     @staticmethod
-    def parse_pr_event(event) -> Optional[PullRequestEvent]:
+    def parse_pr_event(event) -> Optional[PullRequestGithubEvent]:
         """ Look into the provided event and see if it's one for a new github PR. """
         if not event.get("pull_request"):
             return None
@@ -177,7 +177,7 @@ class Parser:
 
         commit_sha = nested_get(event, "pull_request", "head", "sha")
         https_url = event["repository"]["html_url"]
-        return PullRequestEvent(
+        return PullRequestGithubEvent(
             PullRequestAction[action],
             pr_id,
             base_repo_namespace,
@@ -276,7 +276,9 @@ class Parser:
         )
 
     @staticmethod
-    def parse_pull_request_comment_event(event) -> Optional[PullRequestCommentEvent]:
+    def parse_pull_request_comment_event(
+        event,
+    ) -> Optional[PullRequestCommentGithubEvent]:
         """ Look into the provided event and see if it is Github PR comment event. """
         if not nested_get(event, "issue", "pull_request"):
             return None
@@ -308,7 +310,7 @@ class Parser:
 
         logger.info(f"Target repo: {target_repo_namespace}/{target_repo_name}.")
         https_url = event["repository"]["html_url"]
-        return PullRequestCommentEvent(
+        return PullRequestCommentGithubEvent(
             action=PullRequestCommentAction[action],
             pr_id=pr_id,
             base_repo_namespace=base_repo_namespace,

--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -37,8 +37,8 @@ from packit_service.constants import TESTING_FARM_TRIGGER_URL
 from packit_service.models import TFTTestRunModel, TestingFarmResult
 from packit_service.sentry_integration import send_to_sentry
 from packit_service.service.events import (
-    PullRequestEvent,
-    PullRequestCommentEvent,
+    PullRequestGithubEvent,
+    PullRequestCommentGithubEvent,
     CoprBuildEvent,
 )
 from packit_service.worker.build import CoprBuildJobHelper
@@ -54,10 +54,10 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         package_config: PackageConfig,
         project: GitProject,
         event: Union[
-            PullRequestEvent,
-            PullRequestCommentEvent,
+            PullRequestGithubEvent,
+            PullRequestCommentGithubEvent,
             CoprBuildEvent,
-            PullRequestCommentEvent,
+            PullRequestCommentGithubEvent,
         ],
     ):
         super().__init__(config, package_config, project, event)

--- a/packit_service/worker/whitelist.py
+++ b/packit_service/worker/whitelist.py
@@ -32,8 +32,8 @@ from packit_service.models import WhitelistModel
 from packit_service.config import ServiceConfig
 from packit_service.constants import FAQ_URL
 from packit_service.service.events import (
-    PullRequestEvent,
-    PullRequestCommentEvent,
+    PullRequestGithubEvent,
+    PullRequestCommentGithubEvent,
     IssueCommentEvent,
     ReleaseEvent,
     WhitelistStatus,
@@ -214,7 +214,7 @@ class Whitelist:
             (CoprBuildEvent, TestingFarmResultsEvent, DistGitEvent, InstallationEvent),
         ):
             return True
-        if isinstance(event, (PullRequestEvent, PullRequestCommentEvent)):
+        if isinstance(event, (PullRequestGithubEvent, PullRequestCommentGithubEvent)):
             account_name = event.user_login
             if not account_name:
                 raise KeyError(f"Failed to get account_name from {type(event)}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ from packit_service.constants import SANDCASTLE_WORK_DIR
 from packit_service.models import JobTriggerModelType
 from packit_service.service.db_triggers import AddPullRequestDbTrigger
 from packit_service.service.events import (
-    PullRequestEvent,
+    PullRequestGithubEvent,
     PushGitHubEvent,
     ReleaseEvent,
 )
@@ -329,5 +329,5 @@ def release_event(release_webhook) -> ReleaseEvent:
 
 
 @pytest.fixture()
-def pull_request_event(pull_request_webhook) -> PullRequestEvent:
+def pull_request_event(pull_request_webhook) -> PullRequestGithubEvent:
     return Parser.parse_pr_event(pull_request_webhook)

--- a/tests/integration/test_handler.py
+++ b/tests/integration/test_handler.py
@@ -27,7 +27,7 @@ from flexmock import flexmock
 
 from ogr.services.github import GithubProject
 from packit.config import JobConfig, JobType, JobConfigTriggerType, PackageConfig
-from packit_service.config import ServiceConfig, PackageConfigGetterForGithub
+from packit_service.config import ServiceConfig, PackageConfigGetter
 from packit_service.service.events import Event, TheJobTriggerType
 from packit_service.worker.handlers import JobHandler
 from packit_service.worker.handlers.github_handlers import AbstractCoprBuildHandler
@@ -66,7 +66,7 @@ def test_handler_cleanup(tmpdir, trick_p_s_with_k8s):
 
 
 def test_precheck(pull_request_event):
-    flexmock(PackageConfigGetterForGithub).should_receive(
+    flexmock(PackageConfigGetter).should_receive(
         "get_package_config_from_repo"
     ).and_return(
         PackageConfig(
@@ -91,7 +91,7 @@ def test_precheck(pull_request_event):
 
 
 def test_precheck_skip_tests_when_build_defined(pull_request_event):
-    flexmock(PackageConfigGetterForGithub).should_receive(
+    flexmock(PackageConfigGetter).should_receive(
         "get_package_config_from_repo"
     ).and_return(
         PackageConfig(

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -33,7 +33,7 @@ from packit.config import JobConfig, JobType, JobConfigTriggerType
 from packit.config.job_config import JobMetadataConfig
 from packit.config.package_config import PackageConfig
 from packit.local_project import LocalProject
-from packit_service.config import PackageConfigGetterForGithub
+from packit_service.config import PackageConfigGetter
 from packit_service.constants import TESTING_FARM_TRIGGER_URL
 from packit_service.models import (
     CoprBuildModel,
@@ -250,7 +250,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
     )
 
     flexmock(CoprBuildEvent).should_receive("get_package_config").and_return(config)
-    flexmock(PackageConfigGetterForGithub).should_receive(
+    flexmock(PackageConfigGetter).should_receive(
         "get_package_config_from_repo"
     ).and_return(config)
     flexmock(CoprBuildEndHandler).should_receive(
@@ -366,7 +366,7 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
     )
 
     flexmock(CoprBuildEvent).should_receive("get_package_config").and_return(config)
-    flexmock(PackageConfigGetterForGithub).should_receive(
+    flexmock(PackageConfigGetter).should_receive(
         "get_package_config_from_repo"
     ).and_return(config)
     flexmock(CoprBuildEndHandler).should_receive(
@@ -467,7 +467,7 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
     )
 
     flexmock(CoprBuildEvent).should_receive("get_package_config").and_return(config)
-    flexmock(PackageConfigGetterForGithub).should_receive(
+    flexmock(PackageConfigGetter).should_receive(
         "get_package_config_from_repo"
     ).and_return(config)
     flexmock(CoprBuildEndHandler).should_receive(

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -38,8 +38,8 @@ from packit_service.service.db_triggers import (
     AddReleaseDbTrigger,
 )
 from packit_service.service.events import (
-    PullRequestEvent,
-    PullRequestCommentEvent,
+    PullRequestGithubEvent,
+    PullRequestCommentGithubEvent,
     CoprBuildEvent,
     PushGitHubEvent,
     ReleaseEvent,
@@ -51,8 +51,8 @@ from packit_service.worker.reporting import StatusReporter
 
 def build_helper(
     event: Union[
-        PullRequestEvent,
-        PullRequestCommentEvent,
+        PullRequestGithubEvent,
+        PullRequestCommentGithubEvent,
         CoprBuildEvent,
         PushGitHubEvent,
         ReleaseEvent,
@@ -119,7 +119,7 @@ def test_copr_build_check_names(pull_request_event):
     flexmock(CoprBuildModel).should_receive("get_or_create").and_return(
         CoprBuildModel(id=1)
     )
-    flexmock(PullRequestEvent).should_receive("db_trigger").and_return(flexmock())
+    flexmock(PullRequestGithubEvent).should_receive("db_trigger").and_return(flexmock())
     flexmock(PackitAPI).should_receive("run_copr_build").and_return(1, None)
     flexmock(Celery).should_receive("send_task").once()
 
@@ -227,7 +227,7 @@ def test_copr_build_success(pull_request_event):
     flexmock(CoprBuildModel).should_receive("get_or_create").and_return(
         CoprBuildModel(id=1)
     )
-    flexmock(PullRequestEvent).should_receive("db_trigger").and_return(flexmock())
+    flexmock(PullRequestGithubEvent).should_receive("db_trigger").and_return(flexmock())
     flexmock(PackitAPI).should_receive("run_copr_build").and_return(1, None).once()
     flexmock(Celery).should_receive("send_task").once()
     assert helper.run_copr_build()["success"]
@@ -285,7 +285,7 @@ def test_copr_build_no_targets(pull_request_event):
     flexmock(CoprBuildModel).should_receive("get_or_create").and_return(
         CoprBuildModel(id=1)
     )
-    flexmock(PullRequestEvent).should_receive("db_trigger").and_return(flexmock())
+    flexmock(PullRequestGithubEvent).should_receive("db_trigger").and_return(flexmock())
     flexmock(PackitAPI).should_receive("run_copr_build").and_return(1, None).once()
     flexmock(Celery).should_receive("send_task").once()
     assert helper.run_copr_build()["success"]

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -25,7 +25,7 @@ from flexmock import flexmock
 from ogr.abstract import CommitStatus
 from packit.config import JobConfig, JobType, JobConfigTriggerType
 from packit.local_project import LocalProject
-from packit_service.config import PackageConfigGetterForGithub
+from packit_service.config import PackageConfigGetter
 from packit_service.models import TFTTestRunModel
 
 # These names are definately not nice, still they help with making classes
@@ -162,7 +162,7 @@ from packit_service.worker.testing_farm import TestingFarmJobHelper as TFJobHelp
 def test_testing_farm_response(
     tests_result, tests_message, tests_tests, status_status, status_message
 ):
-    flexmock(PackageConfigGetterForGithub).should_receive(
+    flexmock(PackageConfigGetter).should_receive(
         "get_package_config_from_repo"
     ).and_return(
         flexmock(

--- a/tests/unit/test_whitelist.py
+++ b/tests/unit/test_whitelist.py
@@ -38,8 +38,8 @@ from packit_service.constants import FAQ_URL
 from packit_service.models import WhitelistModel as DBWhitelist
 from packit_service.service.events import (
     ReleaseEvent,
-    PullRequestEvent,
-    PullRequestCommentEvent,
+    PullRequestGithubEvent,
+    PullRequestCommentGithubEvent,
     PullRequestAction,
     PullRequestCommentAction,
     IssueCommentEvent,
@@ -136,7 +136,7 @@ def test_signed_fpca(whitelist, account_name, person_object, raises, signed_fpca
     "event, method, approved",
     [
         (
-            PullRequestCommentEvent(
+            PullRequestCommentGithubEvent(
                 action=PullRequestCommentAction.created,
                 pr_id=0,
                 base_repo_namespace="foo",
@@ -159,7 +159,7 @@ def test_signed_fpca(whitelist, account_name, person_object, raises, signed_fpca
             False,
         ),
         (
-            PullRequestCommentEvent(
+            PullRequestCommentGithubEvent(
                 action=PullRequestCommentAction.created,
                 pr_id=0,
                 base_repo_namespace="foo",
@@ -225,7 +225,7 @@ def events(request) -> List[Tuple[AbstractGithubEvent, bool]]:
     elif request.param == "pr":
         return [
             (
-                PullRequestEvent(
+                PullRequestGithubEvent(
                     PullRequestAction.opened, 1, namespace, "", "", "", "", "", login
                 ),
                 approved,
@@ -235,7 +235,7 @@ def events(request) -> List[Tuple[AbstractGithubEvent, bool]]:
     elif request.param == "pr_comment":
         return [
             (
-                PullRequestCommentEvent(
+                PullRequestCommentGithubEvent(
                     action=PullRequestCommentAction.created,
                     pr_id=1,
                     base_repo_namespace=namespace,
@@ -288,7 +288,7 @@ def test_check_and_report(
         set_commit_status=lambda *args, **kwargs: None,
         issue_comment=lambda *args, **kwargs: None,
     )
-    flexmock(PullRequestEvent).should_receive("get_package_config").and_return(
+    flexmock(PullRequestGithubEvent).should_receive("get_package_config").and_return(
         flexmock(
             jobs=[
                 JobConfig(
@@ -302,7 +302,7 @@ def test_check_and_report(
 
     git_project = GithubProject("", GithubService(), "")
     for event, is_valid in events:
-        if isinstance(event, PullRequestEvent) and not is_valid:
+        if isinstance(event, PullRequestGithubEvent) and not is_valid:
             # Report the status
             flexmock(CoprHelper).should_receive("get_copr_client").and_return(
                 Client(

--- a/tests_requre/database/test_events.py
+++ b/tests_requre/database/test_events.py
@@ -32,8 +32,8 @@ from packit_service.models import (
 from packit_service.service.events import (
     ReleaseEvent,
     PushGitHubEvent,
-    PullRequestEvent,
-    PullRequestCommentEvent,
+    PullRequestGithubEvent,
+    PullRequestCommentGithubEvent,
     TestingFarmResultsEvent,
 )
 from packit_service.worker.parser import Parser
@@ -125,7 +125,7 @@ def test_push_branch_event_non_existing_branch(
 
 def test_pr_event_existing_pr(clean_before_and_after, pr_model, pr_event_dict):
     event_object = Parser.parse_event(pr_event_dict)
-    assert isinstance(event_object, PullRequestEvent)
+    assert isinstance(event_object, PullRequestGithubEvent)
 
     assert event_object.identifier == "342"
     assert event_object.git_ref is None
@@ -143,7 +143,7 @@ def test_pr_event_existing_pr(clean_before_and_after, pr_model, pr_event_dict):
 
 def test_pr_event_non_existing_pr(clean_before_and_after, pr_event_dict):
     event_object = Parser.parse_event(pr_event_dict)
-    assert isinstance(event_object, PullRequestEvent)
+    assert isinstance(event_object, PullRequestGithubEvent)
 
     assert event_object.identifier == "342"
     assert event_object.git_ref is None
@@ -162,7 +162,7 @@ def test_pr_comment_event_existing_pr(
     clean_before_and_after, pr_model, pr_comment_event_dict_packit_build
 ):
     event_object = Parser.parse_event(pr_comment_event_dict_packit_build)
-    assert isinstance(event_object, PullRequestCommentEvent)
+    assert isinstance(event_object, PullRequestCommentGithubEvent)
 
     assert event_object.identifier == "342"
     assert event_object.git_ref is None
@@ -187,7 +187,7 @@ def test_pr_comment_event_non_existing_pr(
     clean_before_and_after, pr_comment_event_dict_packit_build
 ):
     event_object = Parser.parse_event(pr_comment_event_dict_packit_build)
-    assert isinstance(event_object, PullRequestCommentEvent)
+    assert isinstance(event_object, PullRequestCommentGithubEvent)
 
     assert event_object.identifier == "342"
     assert event_object.git_ref is None


### PR DESCRIPTION
Do not use event.base_project in Github. As a GitHub app, we cannot authenticate to the fork projects.

Requires: https://github.com/packit-service/packit/pull/818

TODO:
- [x] Add tests for actual config loading. (We mock the getter in all tests.)