### PR TITLE
Create one issue per user in notifications repo

### DIFF
--- a/packit_service/worker/whitelist.py
+++ b/packit_service/worker/whitelist.py
@@ -104,7 +104,7 @@ class Whitelist:
         :param event: Github app installation info
         :return: was the account (auto/already)-whitelisted?
         """
-        if self.is_approved(event.account_login):
+        if WhitelistModel.get_account(event.account_login):
             return True
 
         WhitelistModel.add_account(event.account_login, WhitelistStatus.waiting.value)


### PR DESCRIPTION
The issue in notifications repo is created when add_account method return value is False