### PR TITLE
Use right namespace in whitelist

### DIFF
--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -343,7 +343,8 @@ class PullRequestGithubEvent(AddPullRequestDbTrigger, AbstractGithubEvent):
         base_repo_namespace: str,
         base_repo_name: str,
         base_ref: str,
-        target_repo: str,
+        target_repo_namespace: str,
+        target_repo_name: str,
         https_url: str,
         commit_sha: str,
         user_login: str,
@@ -355,7 +356,8 @@ class PullRequestGithubEvent(AddPullRequestDbTrigger, AbstractGithubEvent):
         self.base_repo_namespace = base_repo_namespace
         self.base_repo_name = base_repo_name
         self.base_ref = base_ref
-        self.target_repo = target_repo
+        self.target_repo_namespace = target_repo_namespace
+        self.target_repo_name = target_repo_name
         self.commit_sha = commit_sha
         self.user_login = user_login
         self.identifier = str(pr_id)

--- a/packit_service/worker/parser.py
+++ b/packit_service/worker/parser.py
@@ -172,21 +172,25 @@ class Parser:
             logger.warning("No GitHub login name from event.")
             return None
 
-        target_repo = nested_get(event, "repository", "full_name")
-        logger.info(f"Target repo: {target_repo}.")
+        target_repo_namespace = nested_get(
+            event, "pull_request", "base", "repo", "owner", "login"
+        )
+        target_repo_name = nested_get(event, "pull_request", "base", "repo", "name")
+        logger.info(f"Target repo: {target_repo_namespace}/{target_repo_name}.")
 
         commit_sha = nested_get(event, "pull_request", "head", "sha")
         https_url = event["repository"]["html_url"]
         return PullRequestGithubEvent(
-            PullRequestAction[action],
-            pr_id,
-            base_repo_namespace,
-            base_repo_name,
-            base_ref,
-            target_repo,
-            https_url,
-            commit_sha,
-            user_login,
+            action=PullRequestAction[action],
+            pr_id=pr_id,
+            base_repo_namespace=base_repo_namespace,
+            base_repo_name=base_repo_name,
+            base_ref=base_ref,
+            target_repo_namespace=target_repo_namespace,
+            target_repo_name=target_repo_name,
+            https_url=https_url,
+            commit_sha=commit_sha,
+            user_login=user_login,
         )
 
     @staticmethod

--- a/packit_service/worker/whitelist.py
+++ b/packit_service/worker/whitelist.py
@@ -218,7 +218,7 @@ class Whitelist:
             account_name = event.user_login
             if not account_name:
                 raise KeyError(f"Failed to get account_name from {type(event)}")
-            namespace = event.base_repo_namespace
+            namespace = event.target_repo_namespace
             # FIXME:
             #  Why check account_name when we whitelist namespace only (in whitelist.add_account())?
             if not (self.is_approved(account_name) or self.is_approved(namespace)):

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -191,7 +191,8 @@ class TestEvents:
         assert event_object.base_repo_namespace == "lbarcziova"
         assert event_object.base_repo_name == "packit"
         assert event_object.base_ref == "528b803be6f93e19ca4130bf4976f2800a3004c4"
-        assert event_object.target_repo == "packit-service/packit"
+        assert event_object.target_repo_namespace == "packit-service"
+        assert event_object.target_repo_name == "packit"
         assert event_object.project_url == "https://github.com/packit-service/packit"
         assert event_object.commit_sha == "528b803be6f93e19ca4130bf4976f2800a3004c4"
 

--- a/tests/unit/test_whitelist.py
+++ b/tests/unit/test_whitelist.py
@@ -139,10 +139,10 @@ def test_signed_fpca(whitelist, account_name, person_object, raises, signed_fpca
             PullRequestCommentGithubEvent(
                 action=PullRequestCommentAction.created,
                 pr_id=0,
-                base_repo_namespace="foo",
+                base_repo_namespace="base",
                 base_repo_name="",
                 base_ref="",
-                target_repo_namespace="",
+                target_repo_namespace="foo",
                 target_repo_name="",
                 project_url="",
                 user_login="bar",
@@ -226,7 +226,16 @@ def events(request) -> List[Tuple[AbstractGithubEvent, bool]]:
         return [
             (
                 PullRequestGithubEvent(
-                    PullRequestAction.opened, 1, namespace, "", "", "", "", "", login
+                    action=PullRequestAction.opened,
+                    pr_id=1,
+                    base_repo_namespace="",
+                    base_repo_name="",
+                    target_repo_namespace=namespace,
+                    target_repo_name="",
+                    https_url="",
+                    commit_sha="",
+                    user_login=login,
+                    base_ref="",
                 ),
                 approved,
             )


### PR DESCRIPTION
- Parse target_name/namespace for PR correctly and use it in whitelist.
- We need to rename `base_*` to something more descriptive like `source_*` since Github uses `base` for the target.
- Fixes: https://github.com/packit-service/packit-service/issues/598