### PR TITLE
Refactor the "is private repository" check

### DIFF
--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -60,7 +60,7 @@ def test_issue_comment_propose_update_handler(
         GithubProject,
         get_files=lambda ref, filter_regex: [],
         get_web_url=lambda: "https://github.com/the-namespace/the-repo",
+        is_private=lambda: False,
     )
-    flexmock(SteveJobs, _is_private=False)
     results = SteveJobs().process_message(issue_comment_propose_update_event)
     assert results["jobs"]["pull_request_action"]["success"]

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -124,7 +124,7 @@ def test_copr_build_end(
     copr_build_end, pc_build_pr, copr_build_pr, pc_comment_pr_succ, pr_comment_called,
 ):
     steve = SteveJobs()
-    flexmock(SteveJobs, _is_private=False)
+    flexmock(GithubProject).should_receive("is_private").and_return(False)
     pc_build_pr.notifications.pull_request.successful_build = pc_comment_pr_succ
     flexmock(CoprBuildEvent).should_receive("get_package_config").and_return(
         pc_build_pr
@@ -158,7 +158,7 @@ def test_copr_build_end(
 
 def test_copr_build_end_push(copr_build_end, pc_build_push, copr_build_branch_push):
     steve = SteveJobs()
-    flexmock(SteveJobs, _is_private=False)
+    flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(CoprBuildEvent).should_receive("get_package_config").and_return(
         pc_build_push
     )
@@ -194,7 +194,7 @@ def test_copr_build_end_push(copr_build_end, pc_build_push, copr_build_branch_pu
 
 def test_copr_build_end_release(copr_build_end, pc_build_release, copr_build_release):
     steve = SteveJobs()
-    flexmock(SteveJobs, _is_private=False)
+    flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(CoprBuildEvent).should_receive("get_package_config").and_return(
         pc_build_release
     )
@@ -229,7 +229,7 @@ def test_copr_build_end_release(copr_build_end, pc_build_release, copr_build_rel
 
 def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
     steve = SteveJobs()
-    flexmock(SteveJobs, _is_private=False)
+    flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(TestingFarmJobHelper).should_receive("job_owner").and_return("some-owner")
     flexmock(TestingFarmJobHelper).should_receive("job_project").and_return(
         "foo-bar-123-stg"
@@ -345,7 +345,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
 
 def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
     steve = SteveJobs()
-    flexmock(SteveJobs, _is_private=False)
+    flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(TestingFarmJobHelper).should_receive("job_owner").and_return("some-owner")
     flexmock(TestingFarmJobHelper).should_receive("job_project").and_return(
         "foo-bar-123-stg"
@@ -446,7 +446,7 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
 
 def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_pr):
     steve = SteveJobs()
-    flexmock(SteveJobs, _is_private=False)
+    flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(TestingFarmJobHelper).should_receive("job_owner").and_return("some-owner")
     flexmock(TestingFarmJobHelper).should_receive("job_project").and_return(
         "foo-bar-123-stg"
@@ -550,7 +550,7 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
 
 def test_copr_build_start(copr_build_start, pc_build_pr, copr_build_pr):
     steve = SteveJobs()
-    flexmock(SteveJobs, _is_private=False)
+    flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(CoprBuildEvent).should_receive("get_package_config").and_return(
         pc_build_pr
     )
@@ -580,7 +580,7 @@ def test_copr_build_start(copr_build_start, pc_build_pr, copr_build_pr):
 
 def test_copr_build_just_tests_defined(copr_build_start, pc_tests, copr_build_pr):
     steve = SteveJobs()
-    flexmock(SteveJobs, _is_private=False)
+    flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(CoprBuildEvent).should_receive("get_package_config").and_return(pc_tests)
     flexmock(TestingFarmJobHelper).should_receive("get_build_check").and_return(
         EXPECTED_BUILD_CHECK_NAME
@@ -617,7 +617,7 @@ def test_copr_build_just_tests_defined(copr_build_start, pc_tests, copr_build_pr
 
 def test_copr_build_not_comment_on_success(copr_build_end, pc_build_pr, copr_build_pr):
     steve = SteveJobs()
-    flexmock(SteveJobs, _is_private=False)
+    flexmock(GithubProject).should_receive("is_private").and_return(False)
     flexmock(CoprBuildEvent).should_receive("get_package_config").and_return(
         pc_build_pr
     )

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -89,7 +89,7 @@ def test_pr_comment_copr_build_handler(
     flexmock(GithubProject).should_receive("get_web_url").and_return(
         "https://github.com/the-namespace/the-repo"
     )
-    flexmock(SteveJobs, _is_private=False)
+    flexmock(GithubProject).should_receive("is_private").and_return(False)
     results = SteveJobs().process_message(pr_copr_build_comment_event)
 
     assert results["jobs"]["pull_request_action"]["success"]
@@ -105,7 +105,7 @@ def test_pr_comment_build_handler(
         {"phracek"}
     ).once()
     flexmock(GithubProject, get_files="foo.spec")
-    flexmock(SteveJobs, _is_private=False)
+    flexmock(GithubProject).should_receive("is_private").and_return(False)
     results = SteveJobs().process_message(pr_build_comment_event)
     assert results["jobs"]["pull_request_action"]["success"]
 
@@ -155,7 +155,7 @@ def test_pr_embedded_command_handler(
         {"phracek"}
     ).once()
     flexmock(GithubProject, get_files="foo.spec")
-    flexmock(SteveJobs, _is_private=False)
+    flexmock(GithubProject).should_receive("is_private").and_return(False)
     results = SteveJobs().process_message(pr_embedded_command_comment_event)
     assert results["jobs"]["pull_request_action"]["success"]
 
@@ -163,7 +163,7 @@ def test_pr_embedded_command_handler(
 def test_pr_comment_empty_handler(
     mock_pr_comment_functionality, pr_empty_comment_event
 ):
-    flexmock(SteveJobs, _is_private=False)
+    flexmock(GithubProject).should_receive("is_private").and_return(False)
 
     results = SteveJobs().process_message(pr_empty_comment_event)
     assert results["jobs"]["pull_request_action"]["success"]
@@ -174,7 +174,7 @@ def test_pr_comment_empty_handler(
 def test_pr_comment_packit_only_handler(
     mock_pr_comment_functionality, pr_packit_only_comment_event
 ):
-    flexmock(SteveJobs, _is_private=False)
+    flexmock(GithubProject).should_receive("is_private").and_return(False)
 
     results = SteveJobs().process_message(pr_packit_only_comment_event)
     assert results["jobs"]["pull_request_action"]["success"]
@@ -185,7 +185,7 @@ def test_pr_comment_packit_only_handler(
 def test_pr_comment_wrong_packit_command_handler(
     mock_pr_comment_functionality, pr_wrong_packit_comment_event
 ):
-    flexmock(SteveJobs, _is_private=False)
+    flexmock(GithubProject).should_receive("is_private").and_return(False)
 
     results = SteveJobs().process_message(pr_wrong_packit_comment_event)
     assert results["jobs"]["pull_request_action"]["success"]

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -35,10 +35,10 @@ def test_dist_git_push_release_handle(release_event):
         get_files=lambda ref, filter_regex: [],
         get_sha_from_tag=lambda tag_name: "123456",
         get_web_url=lambda: "https://github.com/packit-service/hello-world",
+        is_private=lambda: False,
     )
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
     flexmock(Whitelist, check_and_report=True)
-    flexmock(SteveJobs, _is_private=False)
     config = ServiceConfig()
     config.command_handler_work_dir = SANDCASTLE_WORK_DIR
     config.get_project = lambda url: project
@@ -71,10 +71,10 @@ def test_dist_git_push_release_handle_multiple_branches(release_event):
         get_files=lambda ref, filter_regex: [],
         get_sha_from_tag=lambda tag_name: "123456",
         get_web_url=lambda: "https://github.com/packit-service/hello-world",
+        is_private=lambda: False,
     )
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
     flexmock(Whitelist, check_and_report=True)
-    flexmock(SteveJobs, _is_private=False)
     config = ServiceConfig()
     config.command_handler_work_dir = SANDCASTLE_WORK_DIR
     config.get_project = lambda url: project
@@ -120,6 +120,7 @@ def test_dist_git_push_release_handle_one_failed(release_event):
             get_files=lambda ref, filter_regex: [],
             get_sha_from_tag=lambda tag_name: "123456",
             get_web_url=lambda: "https://github.com/packit-service/hello-world",
+            is_private=lambda: False,
         )
         .should_receive("create_issue")
         .once()
@@ -127,7 +128,6 @@ def test_dist_git_push_release_handle_one_failed(release_event):
     )
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
     flexmock(Whitelist, check_and_report=True)
-    flexmock(SteveJobs, _is_private=False)
     config = ServiceConfig()
     config.command_handler_work_dir = SANDCASTLE_WORK_DIR
     config.get_project = lambda url: project
@@ -174,6 +174,7 @@ def test_dist_git_push_release_handle_all_failed(release_event):
             get_files=lambda ref, filter_regex: [],
             get_sha_from_tag=lambda tag_name: "123456",
             get_web_url=lambda: "https://github.com/packit-service/hello-world",
+            is_private=lambda: False,
         )
         .should_receive("create_issue")
         .with_args(
@@ -193,7 +194,6 @@ def test_dist_git_push_release_handle_all_failed(release_event):
     )
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
     flexmock(Whitelist, check_and_report=True)
-    flexmock(SteveJobs, _is_private=False)
     config = ServiceConfig()
     config.command_handler_work_dir = SANDCASTLE_WORK_DIR
     config.get_project = lambda url: project

--- a/tests/unit/test_steve.py
+++ b/tests/unit/test_steve.py
@@ -71,6 +71,7 @@ def test_process_message(event):
         get_files=lambda ref, filter_regex: [],
         get_sha_from_tag=lambda tag_name: "12345",
         get_web_url=lambda: "https://github.com/the-namespace/the-repo",
+        is_private=lambda: False,
     )
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
     config = ServiceConfig()
@@ -83,7 +84,6 @@ def test_process_message(event):
         flexmock(job_config_trigger_type=JobConfigTriggerType.release)
     )
     flexmock(Whitelist, check_and_report=True)
-    flexmock(SteveJobs, _is_private=False)
     results = SteveJobs().process_message(event)
     assert "propose_downstream" in results["jobs"]
     assert results["event"]["trigger"] == "release"


### PR DESCRIPTION
Use the "project" property of "event_object" instead of a local
variable. This way, the project is cached and handlers will not need to
recreate them once again.

Also: don't do this only for GithubProjects. GitLab and Pagure projects
have the `is_private()` method implemented in OGR, so it is safe to skip
the type check and call `is_private()` whenever it's possible to tell
the project from the event.

Should cause #595 to happen less.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>