### PR TITLE
Use packit-service-fedmsg:stg in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,7 +96,7 @@ services:
 
   fedora-messaging:
     container_name: fedora-messaging
-    image: usercont/packit-service-fedmsg:latest
+    image: docker.io/usercont/packit-service-fedmsg:stg
     # command: listen-to-fedora-messaging
     environment:
       FEDORA_MESSAGING_CONF: /home/packit/.config/fedora.toml


### PR DESCRIPTION
The `latest` tag is going to get deprecated once the image built from
the master branch is going to be tagged with `stg`, while the one built
from the stable branch is going to be tagged with `prod`.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>