### PR TITLE
 [packit-httpd.conf] MaxRequestWorkers 8 -> 6 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       POSTGRESQL_DATABASE: packit
     volumes:
       - ./packit_service:/usr/local/lib/python3.7/site-packages/packit_service:ro,z
-      - ./files/packit-httpd.conf:/etc/httpd/conf.d/httpd-packit.conf:ro,z
+      - ./files/packit-httpd.conf:/etc/httpd/conf.d/packit-httpd.conf:ro,z
       # There's no secrets/ by default. You have to create (or symlink to other dir) it yourself.
       # Make sure to set `command_handler: local` since there is no kube in d-c
       - ./secrets/dev/packit-service.yaml:/home/packit/.config/packit-service.yaml:ro,z

--- a/files/packit-httpd.conf
+++ b/files/packit-httpd.conf
@@ -38,7 +38,7 @@ MinSpareThreads 2
 # Maximum number of idle threads
 MaxSpareThreads 2
 # Maximum number of connections that will be processed simultaneously (others are queued)
-MaxRequestWorkers 8
+MaxRequestWorkers 6
 
 <VirtualHost *:8443>
     SSLEngine on

--- a/files/tasks/httpd.yaml
+++ b/files/tasks/httpd.yaml
@@ -74,7 +74,7 @@
 - name: Copy packit-httpd.conf
   copy:
     src: packit-httpd.conf
-    dest: /etc/httpd/conf.d/httpd-packit.conf
+    dest: /etc/httpd/conf.d/packit-httpd.conf
     mode: 0644
 - name: Copy packit.wsgi file
   copy:


### PR DESCRIPTION
To avoid:
```
WARNING: MaxRequestWorkers of 8 is not an integer multiple of ThreadsPerChild of 6, decreasing to nearest multiple 6, for a maximum of 1 servers.
```