### PR TITLE
Implement get_project() in InstallationEvent

### DIFF
--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -497,6 +497,13 @@ class InstallationEvent(Event):
         result["status"] = result["status"].value
         return result
 
+    @property
+    def project(self):
+        return self.get_project()
+
+    def get_project(self):
+        return None
+
 
 class DistGitEvent(AbstractForgeIndependentEvent):
     def __init__(


### PR DESCRIPTION
I was checking the `events.py` file and all the events except `InstallationEvent` inherit from `AbstractForgeIndependentEvent`, which has implemented project() and get_project() methods, therefore this could solve the problem.