### PR TITLE
Use ogr's 'can_merge_pr()' API

### DIFF
--- a/packit_service/worker/handlers/github_handlers.py
+++ b/packit_service/worker/handlers/github_handlers.py
@@ -286,8 +286,8 @@ class PullRequestCoprBuildHandler(AbstractCoprBuildHandler):
 
     def run(self) -> HandlerResults:
         if isinstance(self.event, PullRequestGithubEvent):
-            collaborators = self.event.project.who_can_merge_pr()
-            if self.event.user_login not in collaborators | self.config.admins:
+            user_can_merge_pr = self.event.project.can_merge_pr(self.event.user_login)
+            if not (user_can_merge_pr or self.event.user_login in self.config.admins):
                 self.copr_build_helper.report_status_to_all(
                     description=PERMISSIONS_ERROR_WRITE_OR_ADMIN,
                     state=CommitStatus.failure,
@@ -414,8 +414,8 @@ class PullRequestGithubKojiBuildHandler(AbstractGithubKojiBuildHandler):
 
     def run(self) -> HandlerResults:
         if isinstance(self.event, PullRequestGithubEvent):
-            collaborators = self.event.project.who_can_merge_pr()
-            if self.event.user_login not in collaborators | self.config.admins:
+            user_can_merge_pr = self.event.project.can_merge_pr(self.event.user_login)
+            if not (user_can_merge_pr or self.event.user_login in self.config.admins):
                 self.koji_build_helper.report_status_to_all(
                     description=PERMISSIONS_ERROR_WRITE_OR_ADMIN,
                     state=CommitStatus.failure,
@@ -500,8 +500,8 @@ class GitHubPullRequestCommentCoprBuildHandler(CommentActionHandler):
     event: PullRequestCommentGithubEvent
 
     def run(self) -> HandlerResults:
-        collaborators = self.event.project.who_can_merge_pr()
-        if self.event.user_login not in collaborators | self.config.admins:
+        user_can_merge_pr = self.event.project.can_merge_pr(self.event.user_login)
+        if not (user_can_merge_pr or self.event.user_login in self.config.admins):
             self.event.project.pr_comment(
                 self.event.pr_id, PERMISSIONS_ERROR_WRITE_OR_ADMIN
             )
@@ -556,8 +556,8 @@ class GitHubIssueCommentProposeUpdateHandler(CommentActionHandler):
             upstream_local_project=local_project,
         )
 
-        collaborators = self.event.project.who_can_merge_pr()
-        if self.event.user_login not in collaborators | self.config.admins:
+        user_can_merge_pr = self.event.project.can_merge_pr(self.event.user_login)
+        if not (user_can_merge_pr or self.event.user_login in self.config.admins):
             self.event.project.issue_comment(
                 self.event.issue_id, PERMISSIONS_ERROR_WRITE_OR_ADMIN
             )
@@ -618,8 +618,8 @@ class GitHubPullRequestCommentTestingFarmHandler(CommentActionHandler):
             project=self.event.project,
             event=self.event,
         )
-        collaborators = self.event.project.who_can_merge_pr()
-        if self.event.user_login not in collaborators | self.config.admins:
+        user_can_merge_pr = self.event.project.can_merge_pr(self.event.user_login)
+        if not (user_can_merge_pr or self.event.user_login in self.config.admins):
             self.event.project.pr_comment(
                 self.event.pr_id, PERMISSIONS_ERROR_WRITE_OR_ADMIN
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,7 +145,12 @@ def mock_issue_comment_functionality():
         full_repo_name="packit-service/packit",
     )
     flexmock(Github, get_repo=lambda full_name_or_id: None)
-    flexmock(GithubProject).should_receive("who_can_merge_pr").and_return({"phracek"})
+    (
+        flexmock(GithubProject)
+        .should_receive("can_merge_pr")
+        .with_args("phracek")
+        .and_return(True)
+    )
     flexmock(GithubProject).should_receive("issue_comment").and_return(None)
     flexmock(GithubProject).should_receive("issue_close").and_return(None)
     gr = GithubRelease(

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -82,9 +82,13 @@ def test_pr_comment_copr_build_handler(
     flexmock(CoprBuildJobHelper).should_receive("run_copr_build").and_return(
         HandlerResults(success=True, details={})
     ).once()
-    flexmock(GithubProject).should_receive("who_can_merge_pr").and_return(
-        {"phracek"}
-    ).once()
+    (
+        flexmock(GithubProject)
+        .should_receive("can_merge_pr")
+        .with_args("phracek")
+        .and_return(True)
+        .once()
+    )
     flexmock(GithubProject).should_receive("get_files").and_return(["foo.spec"])
     flexmock(GithubProject).should_receive("get_web_url").and_return(
         "https://github.com/the-namespace/the-repo"
@@ -101,9 +105,13 @@ def test_pr_comment_build_handler(
     flexmock(CoprBuildJobHelper).should_receive("run_copr_build").and_return(
         HandlerResults(success=True, details={})
     )
-    flexmock(GithubProject).should_receive("who_can_merge_pr").and_return(
-        {"phracek"}
-    ).once()
+    (
+        flexmock(GithubProject)
+        .should_receive("can_merge_pr")
+        .with_args("phracek")
+        .and_return(True)
+        .once()
+    )
     flexmock(GithubProject, get_files="foo.spec")
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     results = SteveJobs().process_message(pr_build_comment_event)
@@ -151,9 +159,13 @@ def test_pr_embedded_command_handler(
     flexmock(CoprBuildJobHelper).should_receive("run_copr_build").and_return(
         HandlerResults(success=True, details={})
     )
-    flexmock(GithubProject).should_receive("who_can_merge_pr").and_return(
-        {"phracek"}
-    ).once()
+    (
+        flexmock(GithubProject)
+        .should_receive("can_merge_pr")
+        .with_args("phracek")
+        .and_return(True)
+        .once()
+    )
     flexmock(GithubProject, get_files="foo.spec")
     flexmock(GithubProject).should_receive("is_private").and_return(False)
     results = SteveJobs().process_message(pr_embedded_command_comment_event)


### PR DESCRIPTION
When deciding whether to react to events, use ogr's 'can_merge_pr()' API
instead of 'who_can_merge_pr()'. The former is more limited in scope and
just right for the purpose.

Will also result in fewer GitHub API calls once packit-service/ogr#410
is merged.

Relates to #612.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>