### PR TITLE
Add BaseBuildJobHelper.job_build_branch()

### DIFF
--- a/packit_service/worker/build/build_helper.py
+++ b/packit_service/worker/build/build_helper.py
@@ -191,6 +191,16 @@ class BaseBuildJobHelper:
         return self._job_build
 
     @property
+    def job_build_branch(self) -> Optional[str]:
+        """
+        Branch used for the build job or "master".
+        """
+        if self.job_build and self.job_build.metadata.branch:
+            return self.job_build.metadata.branch
+
+        return "master"
+
+    @property
     def job_tests(self) -> Optional[JobConfig]:
         """
         Check if there is JobConfig for tests defined

--- a/packit_service/worker/handlers/github_handlers.py
+++ b/packit_service/worker/handlers/github_handlers.py
@@ -324,7 +324,7 @@ class PushCoprBuildHandler(AbstractCoprBuildHandler):
         if not valid:
             return False
 
-        configured_branch = self.copr_build_helper.job_build.metadata.branch or "master"
+        configured_branch = self.copr_build_helper.job_build_branch
         if self.event.git_ref != configured_branch:
             logger.info(
                 f"Skipping build on '{self.event.git_ref}'. "
@@ -450,7 +450,7 @@ class PushGithubKojiBuildHandler(AbstractGithubKojiBuildHandler):
         if not valid:
             return False
 
-        configured_branch = self.koji_build_helper.job_build.metadata.branch or "master"
+        configured_branch = self.koji_build_helper.job_build_branch
         if self.event.git_ref != configured_branch:
             logger.info(
                 f"Skipping build on '{self.event.git_ref}'. "


### PR DESCRIPTION
Fixes https://sentry.io/organizations/red-hat-0p/issues/1659010194

Maybe `BaseBuildJobHelper` is not the proper place for this?