### PR TITLE
Use the alias list from Packit in the tests

### DIFF
--- a/tests/unit/test_build_helper.py
+++ b/tests/unit/test_build_helper.py
@@ -3,9 +3,13 @@ from flexmock import flexmock
 
 from packit.config import PackageConfig, JobConfig, JobType, JobConfigTriggerType
 from packit.config.job_config import JobMetadataConfig
+from packit.config.aliases import ALIASES
 from packit_service.service.events import TheJobTriggerType
 from packit_service.worker.build.copr_build import CoprBuildJobHelper
 from packit_service.worker.build.koji_build import KojiBuildJobHelper
+
+stable_versions = ALIASES["fedora-stable"]
+stable_targets = [f"{version}-x86_64" for version in stable_versions]
 
 
 @pytest.mark.parametrize(
@@ -16,13 +20,13 @@ from packit_service.worker.build.koji_build import KojiBuildJobHelper
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(targets=["fedora-29", "fedora-31"]),
+                    metadata=JobMetadataConfig(targets=stable_versions),
                 )
             ],
             TheJobTriggerType.pull_request,
             JobConfigTriggerType.pull_request,
-            {"fedora-29-x86_64", "fedora-31-x86_64"},
-            set(),
+            stable_targets,
+            list(),
             id="build_with_targets",
         ),
         pytest.param(
@@ -30,13 +34,13 @@ from packit_service.worker.build.koji_build import KojiBuildJobHelper
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(targets=["fedora-29", "fedora-31"]),
+                    metadata=JobMetadataConfig(targets=stable_versions),
                 )
             ],
             TheJobTriggerType.pr_comment,
             JobConfigTriggerType.pull_request,
-            {"fedora-29-x86_64", "fedora-31-x86_64"},
-            set(),
+            stable_targets,
+            list(),
             id="build_with_targets&pr_comment",
         ),
         pytest.param(
@@ -44,13 +48,13 @@ from packit_service.worker.build.koji_build import KojiBuildJobHelper
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.release,
-                    metadata=JobMetadataConfig(targets=["fedora-29", "fedora-31"]),
+                    metadata=JobMetadataConfig(targets=stable_versions),
                 )
             ],
             TheJobTriggerType.release,
             JobConfigTriggerType.release,
-            {"fedora-29-x86_64", "fedora-31-x86_64"},
-            set(),
+            stable_targets,
+            list(),
             id="build_with_targets&release",
         ),
         pytest.param(
@@ -58,13 +62,13 @@ from packit_service.worker.build.koji_build import KojiBuildJobHelper
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(targets=["fedora-29", "fedora-31"]),
+                    metadata=JobMetadataConfig(targets=stable_versions),
                 )
             ],
             TheJobTriggerType.push,
             JobConfigTriggerType.commit,
-            {"fedora-29-x86_64", "fedora-31-x86_64"},
-            set(),
+            stable_targets,
+            list(),
             id="build_with_targets&push",
         ),
         pytest.param(
@@ -72,7 +76,7 @@ from packit_service.worker.build.koji_build import KojiBuildJobHelper
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(targets=["fedora-29", "fedora-31"]),
+                    metadata=JobMetadataConfig(targets=stable_versions),
                 ),
                 JobConfig(
                     type=JobType.copr_build,
@@ -82,8 +86,8 @@ from packit_service.worker.build.koji_build import KojiBuildJobHelper
             ],
             TheJobTriggerType.pull_request,
             JobConfigTriggerType.pull_request,
-            {"fedora-29-x86_64", "fedora-31-x86_64"},
-            set(),
+            stable_targets,
+            list(),
             id="build_with_targets&pull_request_with_pr_and_push_defined",
         ),
         pytest.param(
@@ -91,7 +95,7 @@ from packit_service.worker.build.koji_build import KojiBuildJobHelper
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(targets=["fedora-29", "fedora-31"]),
+                    metadata=JobMetadataConfig(targets=stable_versions),
                 ),
                 JobConfig(
                     type=JobType.copr_build,
@@ -101,8 +105,8 @@ from packit_service.worker.build.koji_build import KojiBuildJobHelper
             ],
             TheJobTriggerType.pr_comment,
             JobConfigTriggerType.pull_request,
-            {"fedora-29-x86_64", "fedora-31-x86_64"},
-            set(),
+            stable_targets,
+            list(),
             id="build_with_targets&pr_comment_with_pr_and_push_defined",
         ),
         pytest.param(
@@ -115,13 +119,13 @@ from packit_service.worker.build.koji_build import KojiBuildJobHelper
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.commit,
-                    metadata=JobMetadataConfig(targets=["fedora-29", "fedora-31"]),
+                    metadata=JobMetadataConfig(targets=stable_versions),
                 ),
             ],
             TheJobTriggerType.push,
             JobConfigTriggerType.commit,
-            {"fedora-29-x86_64", "fedora-31-x86_64"},
-            set(),
+            stable_targets,
+            list(),
             id="build_with_targets&push_with_pr_and_push_defined",
         ),
         pytest.param(
@@ -132,16 +136,16 @@ from packit_service.worker.build.koji_build import KojiBuildJobHelper
             ],
             TheJobTriggerType.pull_request,
             JobConfigTriggerType.pull_request,
-            {"fedora-30-x86_64", "fedora-31-x86_64"},
-            set(),
+            stable_targets,
+            list(),
             id="build_without_targets",
         ),
         pytest.param(
             [JobConfig(type=JobType.tests, trigger=JobConfigTriggerType.pull_request,)],
             TheJobTriggerType.pull_request,
             JobConfigTriggerType.pull_request,
-            {"fedora-30-x86_64", "fedora-31-x86_64"},
-            {"fedora-30-x86_64", "fedora-31-x86_64"},
+            stable_targets,
+            stable_targets,
             id="test_without_targets",
         ),
         pytest.param(
@@ -149,13 +153,13 @@ from packit_service.worker.build.koji_build import KojiBuildJobHelper
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(targets=["fedora-29", "fedora-31"]),
+                    metadata=JobMetadataConfig(targets=stable_versions),
                 )
             ],
             TheJobTriggerType.pull_request,
             JobConfigTriggerType.pull_request,
-            {"fedora-29-x86_64", "fedora-31-x86_64"},
-            {"fedora-29-x86_64", "fedora-31-x86_64"},
+            stable_targets,
+            stable_targets,
             id="test_with_targets",
         ),
         pytest.param(
@@ -169,8 +173,8 @@ from packit_service.worker.build.koji_build import KojiBuildJobHelper
             ],
             TheJobTriggerType.pull_request,
             JobConfigTriggerType.pull_request,
-            {"fedora-30-x86_64", "fedora-31-x86_64"},
-            {"fedora-30-x86_64", "fedora-31-x86_64"},
+            stable_targets,
+            stable_targets,
             id="build_without_target&test_without_targets",
         ),
         pytest.param(
@@ -178,7 +182,7 @@ from packit_service.worker.build.koji_build import KojiBuildJobHelper
                 JobConfig(
                     type=JobType.copr_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(targets=["fedora-29", "fedora-31"]),
+                    metadata=JobMetadataConfig(targets=stable_versions),
                 ),
                 JobConfig(
                     type=JobType.tests, trigger=JobConfigTriggerType.pull_request,
@@ -186,8 +190,8 @@ from packit_service.worker.build.koji_build import KojiBuildJobHelper
             ],
             TheJobTriggerType.pull_request,
             JobConfigTriggerType.pull_request,
-            {"fedora-29-x86_64", "fedora-31-x86_64"},
-            {"fedora-29-x86_64", "fedora-31-x86_64"},
+            stable_targets,
+            stable_targets,
             id="build_with_target&test_without_targets",
         ),
         pytest.param(
@@ -198,13 +202,13 @@ from packit_service.worker.build.koji_build import KojiBuildJobHelper
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(targets=["fedora-29", "fedora-31"]),
+                    metadata=JobMetadataConfig(targets=stable_versions),
                 ),
             ],
             TheJobTriggerType.pull_request,
             JobConfigTriggerType.pull_request,
-            {"fedora-29-x86_64", "fedora-31-x86_64"},
-            {"fedora-29-x86_64", "fedora-31-x86_64"},
+            stable_targets,
+            stable_targets,
             id="build_without_target&test_with_targets",
         ),
         pytest.param(
@@ -215,13 +219,13 @@ from packit_service.worker.build.koji_build import KojiBuildJobHelper
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(targets=["fedora-29"]),
+                    metadata=JobMetadataConfig(targets=stable_versions[0:1]),
                 ),
             ],
             TheJobTriggerType.pull_request,
             JobConfigTriggerType.pull_request,
-            {"fedora-29-x86_64"},
-            {"fedora-29-x86_64"},
+            stable_targets[0:1],
+            stable_targets[0:1],
             id="build_without_target&test_with_one_str_target",
         ),
         pytest.param(
@@ -232,13 +236,13 @@ from packit_service.worker.build.koji_build import KojiBuildJobHelper
                 JobConfig(
                     type=JobType.tests,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(targets=["fedora-29"]),
+                    metadata=JobMetadataConfig(targets=stable_versions[0:1]),
                 ),
             ],
             TheJobTriggerType.pull_request,
             JobConfigTriggerType.pull_request,
-            {"fedora-29-x86_64"},
-            {"fedora-29-x86_64"},
+            stable_targets[0:1],
+            stable_targets[0:1],
             id="build_with_mixed_build_alias",
         ),
         pytest.param(
@@ -246,13 +250,13 @@ from packit_service.worker.build.koji_build import KojiBuildJobHelper
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(targets=["fedora-29", "fedora-31"]),
+                    metadata=JobMetadataConfig(targets=stable_versions),
                 )
             ],
             TheJobTriggerType.pull_request,
             JobConfigTriggerType.pull_request,
-            {"fedora-30-x86_64", "fedora-31-x86_64"},
-            set(),
+            stable_targets,
+            list(),
             id="koji_build_with_targets_for_pr",
         ),
     ],
@@ -272,8 +276,9 @@ def test_targets(jobs, trigger, job_config_trigger_type, build_targets, test_tar
     assert copr_build_handler.package_config.jobs
     assert [j.type for j in copr_build_handler.package_config.jobs]
 
-    assert set(copr_build_handler.build_chroots) == build_targets
-    assert set(copr_build_handler.tests_chroots) == test_targets
+    # Compare sets to not get caught by list order
+    assert set(copr_build_handler.build_chroots) == set(build_targets)
+    assert set(copr_build_handler.tests_chroots) == set(test_targets)
 
 
 @pytest.mark.parametrize(
@@ -284,13 +289,13 @@ def test_targets(jobs, trigger, job_config_trigger_type, build_targets, test_tar
                 JobConfig(
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(targets=["fedora-29", "fedora-31"]),
+                    metadata=JobMetadataConfig(targets=stable_versions),
                 )
             ],
             TheJobTriggerType.pull_request,
             JobConfigTriggerType.pull_request,
-            {"fedora-29-x86_64", "fedora-31-x86_64"},
-            set(),
+            stable_targets,
+            list(),
             id="koji_build_with_targets_for_pr",
         ),
         pytest.param(
@@ -299,14 +304,14 @@ def test_targets(jobs, trigger, job_config_trigger_type, build_targets, test_tar
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.commit,
                     metadata=JobMetadataConfig(
-                        targets=["fedora-29", "fedora-31"], branch="build-branch"
+                        targets=stable_versions, branch="build-branch"
                     ),
                 )
             ],
             TheJobTriggerType.push,
             JobConfigTriggerType.commit,
-            {"fedora-29-x86_64", "fedora-31-x86_64"},
-            set(),
+            stable_targets,
+            list(),
             id="koji_build_with_targets_for_commit",
         ),
         pytest.param(
@@ -315,14 +320,14 @@ def test_targets(jobs, trigger, job_config_trigger_type, build_targets, test_tar
                     type=JobType.production_build,
                     trigger=JobConfigTriggerType.release,
                     metadata=JobMetadataConfig(
-                        targets=["fedora-29", "fedora-31"], branch="build-branch"
+                        targets=stable_versions, branch="build-branch"
                     ),
                 )
             ],
             TheJobTriggerType.release,
             JobConfigTriggerType.release,
-            {"fedora-29-x86_64", "fedora-31-x86_64"},
-            set(),
+            stable_targets,
+            list(),
             id="koji_build_with_targets_for_release",
         ),
     ],
@@ -344,5 +349,5 @@ def test_targets_for_koji_build(
     assert koji_build_handler.package_config.jobs
     assert [j.type for j in koji_build_handler.package_config.jobs]
 
-    assert set(koji_build_handler.build_chroots) == build_targets
-    assert set(koji_build_handler.tests_chroots) == test_targets
+    assert set(koji_build_handler.build_chroots) == set(build_targets)
+    assert set(koji_build_handler.tests_chroots) == set(test_targets)


### PR DESCRIPTION
Instead of hard-coding the values of targets in the tests, use the
ALIASES list from Packit and calculate values based on that.

This prevents the tests breaking when the list in Packit is updated.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>