### PR TITLE
Patch copr to avoid maximum recursion depth errors

### DIFF
--- a/Dockerfile.worker.prod
+++ b/Dockerfile.worker.prod
@@ -16,7 +16,7 @@ RUN cd $PS_PATH/ \
     && ansible-playbook -vv -c local -i localhost, files/install-deps-worker.yaml \
     && dnf clean all
 
-COPY setup.py setup.cfg files/recipe-worker.yaml files/tasks/common.yaml files/run_worker.sh files/gitconfig .git_archival.txt .gitattributes $PS_PATH/
+COPY setup.py setup.cfg files/recipe-worker.yaml files/tasks/common.yaml files/run_worker.sh files/gitconfig files/copr.patch .git_archival.txt .gitattributes $PS_PATH/
 # setuptools-scm
 COPY .git $PS_PATH/.git
 COPY packit_service/ $PS_PATH/packit_service/
@@ -25,6 +25,8 @@ RUN cd $PS_PATH \
     && git rev-parse HEAD >/.packit-service.git.commit.hash \
     && git show --quiet --format=%B HEAD >/.packit-service.git.commit.message \
     && ansible-playbook -vv -c local -i localhost, recipe-worker.yaml
+
+RUN patch /usr/lib/python3.7/site-packages/copr/v3/helpers.py $PS_PATH/copr.patch
 
 COPY . $PS_PATH
 

--- a/files/copr.patch
+++ b/files/copr.patch
@@ -1,0 +1,4 @@
+48c48
+<     for attr in cls.__dict__:
+---
+>     for attr in list(cls.__dict__):


### PR DESCRIPTION
@packit-service/the-packit-team Currently `usercont/packit-service-worker:prod` is patched with this change. This was recommended by @praiskup and discussed on #fedora-buildsys.

Please have a look and let me know if this could be done any better.

We might want to carry this patch for a while before asking Copr to merge it, to see if it works on the long term. It fixed the issues right now, but without a reproducer, it's hard to tell, if this was due to this patch or just the change itself.