### PR TITLE
Allow aliases for koji builds

### DIFF
--- a/packit_service/worker/build/build_helper.py
+++ b/packit_service/worker/build/build_helper.py
@@ -245,14 +245,14 @@ class BaseBuildJobHelper:
         (Used when submitting the koji/copr build and as a part of the commit status name.)
 
         1. If the job is not defined, use the test chroots.
-        2. If the job is defined, but not the targets, use "fedora-stable" alias otherwise.
+        2. If the job is defined without targets, use "fedora-stable".
         """
         raise NotImplementedError("Use subclass instead.")
 
     @property
     def tests_targets(self) -> Set[str]:
         """
-        Return the list of targets/chroots used in the testing farm.
+        Return the list of targets/chroots used in testing farm.
         Has to be a sub-set of the `build_targets`.
 
         (Used when submitting the koji/copr build and as a part of the commit status name.)

--- a/packit_service/worker/build/build_helper.py
+++ b/packit_service/worker/build/build_helper.py
@@ -22,14 +22,13 @@
 import logging
 from io import StringIO
 from pathlib import Path
-from typing import Union, List, Optional, Tuple
+from typing import Union, List, Optional, Tuple, Set
 
 from kubernetes.client.rest import ApiException
 
 from ogr.abstract import GitProject, CommitStatus
 from packit.api import PackitAPI
 from packit.config import PackageConfig, JobType, JobConfig
-from packit.config.aliases import get_build_targets
 from packit.local_project import LocalProject
 from packit.utils import PackitFormatter
 from packit_service import sentry_integration
@@ -133,11 +132,11 @@ class BaseBuildJobHelper:
         )
 
     @property
-    def build_chroots(self) -> List[str]:
+    def configured_build_targets(self) -> Set[str]:
         """
-        Return the chroots to build.
+        Return the targets to build.
 
-        1. If the job is not defined, use the test_chroots.
+        1. If the job is not defined, use the test_targets.
         2. If the job is defined, but not the targets, use "fedora-stable" alias otherwise.
         """
         if (
@@ -145,17 +144,15 @@ class BaseBuildJobHelper:
             and self.job_tests
             and self.job_tests.metadata.targets
         ):
-            return self.tests_chroots
+            return self.configured_tests_targets
 
         if self.job_build and self.job_build.metadata.targets:
-            raw_targets = self.job_build.metadata.targets
-        else:
-            raw_targets = {"fedora-stable"}
+            return self.job_build.metadata.targets
 
-        return list(get_build_targets(*raw_targets))
+        return {"fedora-stable"}
 
     @property
-    def tests_chroots(self) -> List[str]:
+    def configured_tests_targets(self) -> Set[str]:
         """
         Return the list of chroots used in the testing farm.
         Has to be a sub-set of the `build_chroots`.
@@ -167,13 +164,12 @@ class BaseBuildJobHelper:
         2. use "fedora-stable" alias otherwise
         """
         if not self.job_tests:
-            return []
+            return set()
 
         if not self.job_tests.metadata.targets and self.job_build:
-            return self.build_chroots
+            return self.configured_build_targets
 
-        configured_targets = self.job_tests.metadata.targets or {"fedora-stable"}
-        return list(get_build_targets(*configured_targets))
+        return self.job_tests.metadata.targets or {"fedora-stable"}
 
     @property
     def job_build(self) -> Optional[JobConfig]:
@@ -242,18 +238,58 @@ class BaseBuildJobHelper:
         return self._status_reporter
 
     @property
+    def build_targets(self) -> Set[str]:
+        """
+        Return the targets/chroots to build.
+
+        (Used when submitting the koji/copr build and as a part of the commit status name.)
+
+        1. If the job is not defined, use the test chroots.
+        2. If the job is defined, but not the targets, use "fedora-stable" alias otherwise.
+        """
+        raise NotImplementedError("Use subclass instead.")
+
+    @property
+    def tests_targets(self) -> Set[str]:
+        """
+        Return the list of targets/chroots used in the testing farm.
+        Has to be a sub-set of the `build_targets`.
+
+        (Used when submitting the koji/copr build and as a part of the commit status name.)
+
+        Return an empty list if there is no job configured.
+
+        If not defined:
+        1. use the build_targets if the job si configured
+        2. use "fedora-stable" alias otherwise
+        """
+        raise NotImplementedError("Use subclass instead.")
+
+    @property
     def test_check_names(self) -> List[str]:
+        """
+        List of full names of the commit statuses.
+
+        e.g. ["packit/copr-build-fedora-rawhide-x86_64"]
+        or ["packit-stg/production-build-f31", "packit-stg/production-build-f32"]
+        """
         if not self._test_check_names:
             self._test_check_names = [
-                self.get_test_check(chroot) for chroot in self.tests_chroots
+                self.get_test_check(target) for target in self.tests_targets
             ]
         return self._test_check_names
 
     @property
     def build_check_names(self) -> List[str]:
+        """
+        List of full names of the commit statuses.
+
+        e.g. ["packit/copr-build-fedora-rawhide-x86_64"]
+        or ["packit-stg/production-build-f31", "packit-stg/production-build-f32"]
+        """
         if not self._build_check_names:
             self._build_check_names = [
-                self.get_build_check(chroot) for chroot in self.build_chroots
+                self.get_build_check(target) for target in self.build_targets
             ]
         return self._build_check_names
 
@@ -393,7 +429,7 @@ class BaseBuildJobHelper:
     def report_status_to_build_for_chroot(
         self, description, state, url: str = "", chroot: str = ""
     ) -> None:
-        if self.job_build and chroot in self.build_chroots:
+        if self.job_build and chroot in self.build_targets:
             cs = self.get_build_check(chroot)
             self._report(
                 description=description, state=state, url=url, check_names=cs,
@@ -402,7 +438,7 @@ class BaseBuildJobHelper:
     def report_status_to_test_for_chroot(
         self, description, state, url: str = "", chroot: str = ""
     ) -> None:
-        if self.job_tests and chroot in self.tests_chroots:
+        if self.job_tests and chroot in self.tests_targets:
             self._report(
                 description=description,
                 state=state,

--- a/packit_service/worker/build/copr_build.py
+++ b/packit_service/worker/build/copr_build.py
@@ -116,14 +116,14 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
         (Used when submitting the copr build and as a part of the commit status name.)
 
         1. If the job is not defined, use the test chroots.
-        2. If the job is defined, but not the targets, use "fedora-stable" alias otherwise.
+        2. If the job is defined without targets, use "fedora-stable".
         """
         return get_build_targets(*self.configured_build_targets, default=None)
 
     @property
     def tests_targets(self) -> Set[str]:
         """
-        Return the list of chroots used in the testing farm.
+        Return the list of chroots used in testing farm.
         Has to be a sub-set of the `build_targets`.
 
         (Used when submitting the copr build and as a part of the commit status name.)

--- a/packit_service/worker/build/koji_build.py
+++ b/packit_service/worker/build/koji_build.py
@@ -21,10 +21,11 @@
 # SOFTWARE.
 import logging
 from re import search
-from typing import Optional, Union, Tuple, Dict
+from typing import Optional, Union, Tuple, Dict, Set
 
 from ogr.abstract import CommitStatus, GitProject
 from packit.config import JobType, PackageConfig, JobConfig
+from packit.config.aliases import get_koji_targets, get_all_koji_targets
 from packit.exceptions import PackitCommandFailedError
 from packit_service import sentry_integration
 from packit_service.config import ServiceConfig
@@ -68,9 +69,48 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
         super().__init__(config, package_config, project, event, job)
         self.msg_retrigger: str = MSG_RETRIGGER.format(build="production-build")
 
+        # Lazy properties
+        self._supported_koji_targets = None
+
     @property
     def is_scratch(self) -> bool:
         return self.job_build and self.job_build.metadata.scratch
+
+    @property
+    def build_targets(self) -> Set[str]:
+        """
+        Return the targets/chroots to build.
+
+        (Used when submitting the koji/copr build and as a part of the commit status name.)
+
+        1. If the job is not defined, use the test chroots.
+        2. If the job is defined, but not the targets, use "fedora-stable" alias otherwise.
+        """
+        return get_koji_targets(*self.configured_build_targets)
+
+    @property
+    def tests_targets(self) -> Set[str]:
+        """
+        [not used now]
+
+        Return the list of targets/chroots used in the testing farm.
+        Has to be a sub-set of the `build_targets`.
+
+        (Used when submitting the koji/copr build and as a part of the commit status name.)
+
+        Return an empty list if there is no job configured.
+
+        If not defined:
+        1. use the build_targets if the job si configured
+        2. use "fedora-stable" alias otherwise
+        """
+        return get_koji_targets(*self.configured_tests_targets)
+
+    @property
+    def supported_koji_targets(self):
+        if self._supported_koji_targets is None:
+            self._supported_koji_targets = get_all_koji_targets()
+        return self._supported_koji_targets
 
     def run_koji_build(self) -> HandlerResults:
         self.report_status_to_all(
@@ -102,27 +142,39 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
             return HandlerResults(success=False, details={"msg": msg})
 
         errors: Dict[str, str] = {}
-        for chroot in self.build_chroots:
+        for target in self.build_targets:
+
+            if target not in self.supported_koji_targets:
+                msg = f"Target not supported: {target}"
+                self.report_status_to_all_for_chroot(
+                    state=CommitStatus.error,
+                    description=msg,
+                    url=get_srpm_log_url_from_flask(self.srpm_model.id),
+                    chroot=target,
+                )
+                errors[target] = msg
+                continue
 
             try:
-                build_id, web_url = self.run_build(target=chroot)
+                build_id, web_url = self.run_build(target=target)
             except Exception as ex:
                 sentry_integration.send_to_sentry(ex)
                 # TODO: Where can we show more info about failure?
                 # TODO: Retry
-                self.report_status_to_all(
+                self.report_status_to_all_for_chroot(
                     state=CommitStatus.error,
                     description=f"Submit of the build failed: {ex}",
                     url=get_srpm_log_url_from_flask(self.srpm_model.id),
+                    chroot=target,
                 )
-                errors[chroot] = str(ex)
+                errors[target] = str(ex)
                 continue
 
             koji_build = KojiBuildModel.get_or_create(
                 build_id=str(build_id),
                 commit_sha=self.event.commit_sha,
                 web_url=web_url,
-                target=chroot,
+                target=target,
                 status="pending",
                 srpm_build=self.srpm_model,
                 trigger_model=self.event.db_trigger,
@@ -132,7 +184,7 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
                 state=CommitStatus.pending,
                 description="Building RPM ...",
                 url=url,
-                chroot=chroot,
+                chroot=target,
             )
 
         if errors:

--- a/packit_service/worker/build/koji_build.py
+++ b/packit_service/worker/build/koji_build.py
@@ -84,7 +84,7 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
         (Used when submitting the koji/copr build and as a part of the commit status name.)
 
         1. If the job is not defined, use the test chroots.
-        2. If the job is defined, but not the targets, use "fedora-stable" alias otherwise.
+        2. If the job is defined without targets, use "fedora-stable".
         """
         return get_koji_targets(*self.configured_build_targets)
 
@@ -93,7 +93,7 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
         """
         [not used now]
 
-        Return the list of targets/chroots used in the testing farm.
+        Return the list of targets/chroots used in testing farm.
         Has to be a sub-set of the `build_targets`.
 
         (Used when submitting the koji/copr build and as a part of the commit status name.)

--- a/packit_service/worker/handlers/fedmsg_handlers.py
+++ b/packit_service/worker/handlers/fedmsg_handlers.py
@@ -251,7 +251,7 @@ class CoprBuildEndHandler(FedmsgHandler):
 
         if (
             build_job_helper.job_tests
-            and self.event.chroot in build_job_helper.tests_chroots
+            and self.event.chroot in build_job_helper.tests_targets
         ):
             testing_farm_handler = GithubTestingFarmHandler(
                 config=self.config,

--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -101,7 +101,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
 
     def run_testing_farm_on_all(self):
         failed = {}
-        for chroot in self.tests_chroots:
+        for chroot in self.tests_targets:
             result = self.run_testing_farm(chroot)
             if not result["success"]:
                 failed[chroot] = result.get("details")
@@ -117,7 +117,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         )
 
     def run_testing_farm(self, chroot: str) -> HandlerResults:
-        if chroot not in self.tests_chroots:
+        if chroot not in self.tests_targets:
             # Leaving here just to be sure that we will discover this situation if it occurs.
             # Currently not possible to trigger this situation.
             msg = f"Target '{chroot}' not defined for tests but triggered."
@@ -125,7 +125,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             send_to_sentry(PackitConfigException(msg))
             return HandlerResults(success=False, details={"msg": msg},)
 
-        if chroot not in self.build_chroots:
+        if chroot not in self.build_targets:
             self.report_missing_build_chroot(chroot)
             return HandlerResults(
                 success=False,


### PR DESCRIPTION
- Allow aliases for koji-targets in the job configuration.
- Catch the not-supported koji-target and provide error in a form of commit-status.
- Requires https://github.com/packit-service/packit/pull/839