### PR TITLE
Do not search for comments when no pr_id

### DIFF
--- a/packit_service/worker/handlers/fedmsg_handlers.py
+++ b/packit_service/worker/handlers/fedmsg_handlers.py
@@ -149,11 +149,14 @@ class CoprBuildEndHandler(FedmsgHandler):
     triggers = [TheJobTriggerType.copr_end]
     event: CoprBuildEvent
 
-    def was_last_build_successful(self):
+    def was_last_packit_comment_with_congratulation(self):
         """
-        Check if the last copr build of the PR was successful
+        Check if the last comment by the packit app
+        was about successful build to not duplicate it.
+
         :return: bool
         """
+
         comments = self.event.project.get_pr_comments(
             pr_id=self.event.pr_id, reverse=True
         )
@@ -220,8 +223,9 @@ class CoprBuildEndHandler(FedmsgHandler):
         if (
             build_job_helper.job_build
             and build_job_helper.job_build.trigger == JobConfigTriggerType.pull_request
+            and self.event.pr_id
             and isinstance(self.event.project, GithubProject)
-            and not self.was_last_build_successful()
+            and not self.was_last_packit_comment_with_congratulation()
             and self.event.package_config.notifications.pull_request.successful_build
         ):
             msg = (

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -150,7 +150,7 @@ def test_copr_build_end(
         pc_build_pr
     )
     flexmock(CoprBuildEndHandler).should_receive(
-        "was_last_build_successful"
+        "was_last_packit_comment_with_congratulation"
     ).and_return(False)
     if pr_comment_called:
         flexmock(GithubProject).should_receive("pr_comment")
@@ -183,7 +183,7 @@ def test_copr_build_end_push(copr_build_end, pc_build_push, copr_build_branch_pu
         pc_build_push
     )
     flexmock(CoprBuildEndHandler).should_receive(
-        "was_last_build_successful"
+        "was_last_packit_comment_with_congratulation"
     ).and_return(False)
 
     # we cannot comment for branch push events
@@ -219,7 +219,7 @@ def test_copr_build_end_release(copr_build_end, pc_build_release, copr_build_rel
         pc_build_release
     )
     flexmock(CoprBuildEndHandler).should_receive(
-        "was_last_build_successful"
+        "was_last_packit_comment_with_congratulation"
     ).and_return(False)
 
     # we cannot comment for branch push events
@@ -274,7 +274,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
         "get_package_config_from_repo"
     ).and_return(config)
     flexmock(CoprBuildEndHandler).should_receive(
-        "was_last_build_successful"
+        "was_last_packit_comment_with_congratulation"
     ).and_return(False)
     flexmock(GithubProject).should_receive("pr_comment")
 
@@ -390,7 +390,7 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
         "get_package_config_from_repo"
     ).and_return(config)
     flexmock(CoprBuildEndHandler).should_receive(
-        "was_last_build_successful"
+        "was_last_packit_comment_with_congratulation"
     ).and_return(False)
     flexmock(GithubProject).should_receive("pr_comment")
 
@@ -492,7 +492,7 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
         "get_package_config_from_repo"
     ).and_return(config)
     flexmock(CoprBuildEndHandler).should_receive(
-        "was_last_build_successful"
+        "was_last_packit_comment_with_congratulation"
     ).and_return(False)
     flexmock(GithubProject).should_receive("pr_comment")
 
@@ -647,7 +647,7 @@ def test_copr_build_not_comment_on_success(copr_build_end, pc_build_pr, copr_bui
     )
 
     flexmock(CoprBuildEndHandler).should_receive(
-        "was_last_build_successful"
+        "was_last_packit_comment_with_congratulation"
     ).and_return(True)
     flexmock(GithubProject).should_receive("pr_comment").never()
 


### PR DESCRIPTION
- Rename `was_last_build_successful` and don't fail when no pr_id.
- Fixes https://github.com/packit-service/packit-service/issues/646 but probably not the real cause.