### PR TITLE
Set job_config for babysit task

### DIFF
--- a/packit_service/worker/build/babysit.py
+++ b/packit_service/worker/build/babysit.py
@@ -1,0 +1,100 @@
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import logging
+
+from copr.v3 import Client as CoprClient
+
+from packit_service.config import ServiceConfig
+from packit_service.constants import (
+    COPR_SUCC_STATE,
+    COPR_API_SUCC_STATE,
+    COPR_API_FAIL_STATE,
+)
+from packit_service.models import CoprBuildModel
+from packit_service.service.events import CoprBuildEvent, FedmsgTopic
+from packit_service.worker.handlers import CoprBuildEndHandler
+from packit_service.worker.jobs import get_config_for_handler_kls
+
+logger = logging.getLogger(__name__)
+
+
+def check_copr_build(build_id: int) -> bool:
+    """
+    Check the copr_build with given id and refresh the status if needed.
+
+    Used in the babysit task.
+
+    :param build_id: id of the copr_build (CoprBuildModel.build.id)
+    :return: True if in case of successful run, False when we need to retry
+    """
+    logger.debug(f"Getting copr build ID {build_id} from DB.")
+    builds = CoprBuildModel.get_all_by_build_id(build_id)
+    if not builds:
+        logger.warning(f"Copr build {build_id} not in DB.")
+        return True
+
+    copr_client = CoprClient.create_from_config_file()
+    build_copr = copr_client.build_proxy.get(build_id)
+
+    if not build_copr.ended_on:
+        logger.info("The copr build is still in progress.")
+        return False
+
+    logger.info(f"The status is {build_copr.state!r}.")
+
+    for build in builds:
+        if build.status != "pending":
+            logger.info(
+                f"DB state says {build.status!r}, "
+                "things were taken care of already, skipping."
+            )
+            continue
+        chroot_build = copr_client.build_chroot_proxy.get(build_id, build.target)
+        event = CoprBuildEvent(
+            topic=FedmsgTopic.copr_build_finished.value,
+            build_id=build_id,
+            build=build,
+            chroot=build.target,
+            status=(
+                COPR_API_SUCC_STATE
+                if chroot_build.state == COPR_SUCC_STATE
+                else COPR_API_FAIL_STATE
+            ),
+            owner=build.owner,
+            project_name=build.project_name,
+            pkg=build_copr.source_package.get(
+                "name", ""
+            ),  # this seems to be the SRPM name
+            timestamp=chroot_build.ended_on,
+        )
+
+        job_configs = get_config_for_handler_kls(
+            handler_kls=CoprBuildEndHandler,
+            event=event,
+            package_config=event.get_package_config(),
+        )
+
+        for job_config in job_configs:
+            CoprBuildEndHandler(
+                ServiceConfig.get_service_config(), job_config=job_config, event=event,
+            ).run()
+    return True

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -150,6 +150,9 @@ def get_config_for_handler_kls(
     matching_job_types = MAP_HANDLER_TO_JOB_TYPES[handler_kls]
     for job in jobs_that_can_be_triggered:
         if (
+            # Check if the job matches any job supported by the handler.
+            # The function `are_job_types_same` is used
+            # because of the `build` x `copr_build` aliasing.
             any(are_job_types_same(job.type, type) for type in matching_job_types)
             and job not in matching_jobs
         ):

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -41,7 +41,10 @@ from packit_service.service.events import (
     TheJobTriggerType,
     PullRequestCommentPagureEvent,
 )
-from packit_service.trigger_mapping import is_trigger_matching_job_config
+from packit_service.trigger_mapping import (
+    is_trigger_matching_job_config,
+    are_job_types_same,
+)
 from packit_service.worker.handlers import (
     CoprBuildEndHandler,
     CoprBuildStartHandler,
@@ -146,7 +149,10 @@ def get_config_for_handler_kls(
 
     matching_job_types = MAP_HANDLER_TO_JOB_TYPES[handler_kls]
     for job in jobs_that_can_be_triggered:
-        if job.type in matching_job_types and job not in matching_jobs:
+        if (
+            any(are_job_types_same(job.type, type) for type in matching_job_types)
+            and job not in matching_jobs
+        ):
             matching_jobs.append(job)
 
     if matching_jobs:

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -22,19 +22,10 @@
 import logging
 from typing import Optional
 
-from copr.v3 import Client as CoprClient
-
 from packit_service.celerizer import celery_app
-from packit_service.config import ServiceConfig
-from packit_service.constants import (
-    COPR_SUCC_STATE,
-    COPR_API_SUCC_STATE,
-    COPR_API_FAIL_STATE,
-)
-from packit_service.models import CoprBuildModel, TaskResultModel
-from packit_service.service.events import CoprBuildEvent, FedmsgTopic
-from packit_service.worker.handlers import CoprBuildEndHandler
-from packit_service.worker.jobs import SteveJobs, get_config_for_handler_kls
+from packit_service.models import TaskResultModel
+from packit_service.worker.build.babysit import check_copr_build
+from packit_service.worker.jobs import SteveJobs
 
 logger = logging.getLogger(__name__)
 
@@ -81,54 +72,5 @@ def process_message(
 )
 def babysit_copr_build(self, build_id: int):
     """ check status of a copr build and update it in DB """
-    logger.debug(f"Getting copr build ID {build_id} from DB.")
-    builds = CoprBuildModel.get_all_by_build_id(build_id)
-    if builds:
-        copr_client = CoprClient.create_from_config_file()
-        build_copr = copr_client.build_proxy.get(build_id)
-
-        if not build_copr.ended_on:
-            logger.info("The copr build is still in progress.")
-            self.retry()
-        logger.info(f"The status is {build_copr.state!r}.")
-
-        for build in builds:
-            if build.status != "pending":
-                logger.info(
-                    f"DB state says {build.status!r}, "
-                    "things were taken care of already, skipping."
-                )
-                continue
-            chroot_build = copr_client.build_chroot_proxy.get(build_id, build.target)
-            event = CoprBuildEvent(
-                topic=FedmsgTopic.copr_build_finished.value,
-                build_id=build_id,
-                build=build,
-                chroot=build.target,
-                status=(
-                    COPR_API_SUCC_STATE
-                    if chroot_build.state == COPR_SUCC_STATE
-                    else COPR_API_FAIL_STATE
-                ),
-                owner=build.owner,
-                project_name=build.project_name,
-                pkg=build_copr.source_package.get(
-                    "name", ""
-                ),  # this seems to be the SRPM name
-                timestamp=chroot_build.ended_on,
-            )
-
-            job_configs = get_config_for_handler_kls(
-                handler_kls=CoprBuildEndHandler,
-                event=event,
-                package_config=event.get_package_config(),
-            )
-
-            for job_config in job_configs:
-                CoprBuildEndHandler(
-                    ServiceConfig.get_service_config(),
-                    job_config=job_config,
-                    event=event,
-                ).run()
-    else:
-        logger.warning(f"Copr build {build_id} not in DB.")
+    if not check_copr_build(build_id=build_id):
+        self.retry()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,7 @@ def global_service_config():
         GitlabService(token="token"),
     }
     service_config.dry_run = False
+    service_config.server_name = "localhost"
     service_config.github_requests_log_path = "/path"
     ServiceConfig.service_config = service_config
 

--- a/tests/integration/test_babysit.py
+++ b/tests/integration/test_babysit.py
@@ -1,0 +1,127 @@
+# MIT License
+#
+# Copyright (c) 2018-2019 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+from copr.v3 import Client
+from flexmock import flexmock
+
+from packit.config import PackageConfig, JobConfig, JobType, JobConfigTriggerType
+from packit_service.models import CoprBuildModel, JobTriggerModelType
+from packit_service.service.events import CoprBuildEvent
+from packit_service.worker.build.babysit import check_copr_build
+from packit_service.worker.handlers import CoprBuildEndHandler
+
+
+def test_check_copr_build_no_build():
+    flexmock(CoprBuildModel).should_receive("get_all_by_build_id").with_args(
+        1
+    ).and_return([])
+    assert check_copr_build(build_id=1)
+
+
+def test_check_copr_build_not_ended():
+    flexmock(CoprBuildModel).should_receive("get_all_by_build_id").with_args(
+        1
+    ).and_return([flexmock()])
+    flexmock(Client).should_receive("create_from_config_file").and_return(
+        flexmock(
+            build_proxy=flexmock()
+            .should_receive("get")
+            .with_args(1)
+            .and_return(flexmock(ended_on=False))
+            .mock()
+        )
+    )
+    assert not check_copr_build(build_id=1)
+
+
+def test_check_copr_build_already_successful():
+    flexmock(CoprBuildModel).should_receive("get_all_by_build_id").with_args(
+        1
+    ).and_return([flexmock(status="success")])
+    flexmock(Client).should_receive("create_from_config_file").and_return(
+        flexmock(
+            build_proxy=flexmock()
+            .should_receive("get")
+            .with_args(1)
+            .and_return(flexmock(ended_on="timestamp", state="completed"))
+            .mock()
+        )
+    )
+    assert check_copr_build(build_id=1)
+
+
+def test_check_copr_build_updated():
+    flexmock(CoprBuildModel).should_receive("get_all_by_build_id").with_args(
+        1
+    ).and_return(
+        [
+            flexmock(
+                status="pending",
+                target="the-target",
+                owner="the-owner",
+                project_name="the-project-name",
+                commit_sha="123456",
+                job_trigger=flexmock(type=JobTriggerModelType.pull_request)
+                .should_receive("get_trigger_object")
+                .and_return(
+                    flexmock(
+                        project=flexmock(
+                            repo_name="repo_name",
+                            namespace="the-namespace",
+                            project_url="https://github.com/the-namespace/repo_name",
+                        ),
+                        pr_id=5,
+                        job_config_trigger_type=JobConfigTriggerType.pull_request,
+                    )
+                )
+                .mock(),
+            )
+        ]
+    )
+    flexmock(Client).should_receive("create_from_config_file").and_return(
+        flexmock(
+            build_proxy=flexmock()
+            .should_receive("get")
+            .with_args(1)
+            .and_return(
+                flexmock(
+                    ended_on=True,
+                    state="completed",
+                    source_package={"name": "source_package_name"},
+                )
+            )
+            .mock(),
+            build_chroot_proxy=flexmock()
+            .should_receive("get")
+            .with_args(1, "the-target")
+            .and_return(flexmock(ended_on="timestamp", state="completed"))
+            .mock(),
+        )
+    )
+    flexmock(CoprBuildEvent).should_receive("get_package_config").and_return(
+        PackageConfig(
+            jobs=[
+                JobConfig(type=JobType.build, trigger=JobConfigTriggerType.pull_request)
+            ]
+        )
+    )
+    flexmock(CoprBuildEndHandler).should_receive("run").and_return().once()
+    assert check_copr_build(build_id=1)

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -22,9 +22,9 @@
 
 import pytest
 from flexmock import flexmock
+
 from packit.config import JobConfig, JobType, JobConfigTriggerType
 from packit.config.job_config import JobMetadataConfig
-
 from packit_service.service.events import TheJobTriggerType
 from packit_service.worker.handlers import (
     PullRequestCoprBuildHandler,
@@ -637,6 +637,38 @@ def test_get_handlers_for_event(trigger, db_trigger, jobs, result):
                 ),
             ],
             id="propose_downstream_multiple",
+        ),
+        pytest.param(
+            CoprBuildEndHandler,
+            flexmock(
+                trigger=TheJobTriggerType.pull_request,
+                db_trigger=flexmock(
+                    job_config_trigger_type=JobConfigTriggerType.pull_request
+                ),
+            ),
+            [
+                JobConfig(
+                    type=JobType.copr_build, trigger=JobConfigTriggerType.pull_request
+                )
+            ],
+            [
+                JobConfig(
+                    type=JobType.copr_build, trigger=JobConfigTriggerType.pull_request
+                )
+            ],
+            id="copr_build_end",
+        ),
+        pytest.param(
+            CoprBuildEndHandler,
+            flexmock(
+                trigger=TheJobTriggerType.pull_request,
+                db_trigger=flexmock(
+                    job_config_trigger_type=JobConfigTriggerType.pull_request
+                ),
+            ),
+            [JobConfig(type=JobType.build, trigger=JobConfigTriggerType.pull_request)],
+            [JobConfig(type=JobType.build, trigger=JobConfigTriggerType.pull_request)],
+            id="copr_build_end_with_build_alias",
         ),
     ],
 )

--- a/tests_requre/conftest.py
+++ b/tests_requre/conftest.py
@@ -116,6 +116,7 @@ def global_service_config():
     }
     service_config.dry_run = False
     service_config.github_requests_log_path = "/path"
+    service_config.server_name = "localhost"
     ServiceConfig.service_config = service_config
 
 


### PR DESCRIPTION
- Set the matching job_config when running babysit task for copr_build.
- Fixes the real cause of https://github.com/packit-service/packit-service/issues/646


TODO:
- [x] Tests
- [x] Check why BuildHelper does not calculate the job configs properly and if we cannot use `get_config_for_handler_kls` for that.
  - `get_config_for_handler_kls` uses `handler` => we can't use it
  - It's better to se correct values `BuildHelper` property `job_build` from outside. (The better solution cal be done after `JobType` cleanup.)