### PR TITLE
Don't deploy OpenShift for the tests

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -24,10 +24,10 @@
           label: cloud-fedora-31
 
 - job:
-    name: packit-service-base
+    name: packit-service-cluster
     parent: base
     attempts: 1
-    description: Run tests of packit-service
+    description: Deploy packit-service in a cluster
     # this will clone the deployment repo to a predictable path
     required-projects:
       - github.com/packit-service/deployment
@@ -45,12 +45,18 @@
 
 - job:
     name: packit-service-tests
-    parent: packit-service-base
+    parent: base
     description: Run tests of packit-service
     run: files/zuul-tests.yaml
+    extra-vars:
+      ansible_python_interpreter: /usr/bin/python3
+    nodeset:
+      nodes:
+        - name: test-node
+          label: cloud-fedora-31
 
 - job:
     name: packit-service-tests-requre
-    parent: packit-service-base
+    parent: packit-service-cluster
     description: Run tests with requre support
     run: files/zuul-tests-requre.yaml

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -21,7 +21,7 @@
     nodeset:
       nodes:
         - name: test-node
-          label: cloud-fedora-31
+          label: cloud-fedora-32
 
 - job:
     name: packit-service-cluster
@@ -53,7 +53,7 @@
     nodeset:
       nodes:
         - name: test-node
-          label: cloud-fedora-31
+          label: cloud-fedora-32
 
 - job:
     name: packit-service-tests-requre

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ ANSIBLE_PYTHON ?= /usr/bin/python3
 AP ?= ansible-playbook -vv -c local -i localhost, -e ansible_python_interpreter=$(ANSIBLE_PYTHON)
 PATH_TO_SECRETS ?= $(CURDIR)/secrets/
 COV_REPORT ?= term-missing
+COLOR ?= yes
 
 service: files/install-deps.yaml files/recipe.yaml
 	$(CONTAINER_ENGINE) build --rm -t $(SERVICE_IMAGE) .
@@ -30,7 +31,7 @@ worker-local-push: worker
 
 check:
 	find . -name "*.pyc" -exec rm {} \;
-	PYTHONPATH=$(CURDIR) PYTHONDONTWRITEBYTECODE=1 python3 -m pytest --color=yes --verbose --showlocals --cov=packit_service --cov-report=$(COV_REPORT) $(TEST_TARGET)
+	PYTHONPATH=$(CURDIR) PYTHONDONTWRITEBYTECODE=1 python3 -m pytest --color=$(COLOR) --verbose --showlocals --cov=packit_service --cov-report=$(COV_REPORT) $(TEST_TARGET)
 
 # first run 'make worker'
 test_image: files/install-deps.yaml files/recipe-tests.yaml
@@ -39,7 +40,9 @@ test_image: files/install-deps.yaml files/recipe-tests.yaml
 check_in_container: test_image
 	@# don't use -ti here in CI, TTY is not allocated in zuul
 	$(CONTAINER_ENGINE) run --rm \
-		--env COV_REPORT --env TEST_TARGET \
+		--env COV_REPORT \
+		--env TEST_TARGET \
+		--env COLOR \
 		-v $(CURDIR):/src-packit-service \
 		-w /src-packit-service \
 		--security-opt label=disable \

--- a/files/zuul-tests.yaml
+++ b/files/zuul-tests.yaml
@@ -4,8 +4,13 @@
   hosts: all
   tasks:
     - include_tasks: tasks/zuul-project-setup.yaml
+    - name: Install podman
+      dnf:
+        name:
+          - podman
+        state: present
+      become: true
     - name: Run tests within a container
       command: "make check_in_container"
       args:
         chdir: "{{ project_dir }}"
-      become: true

--- a/files/zuul-tests.yaml
+++ b/files/zuul-tests.yaml
@@ -18,3 +18,5 @@
       command: "make check_in_container"
       args:
         chdir: "{{ project_dir }}"
+      environment:
+        COLOR: "no"

--- a/files/zuul-tests.yaml
+++ b/files/zuul-tests.yaml
@@ -10,6 +10,10 @@
           - podman
         state: present
       become: true
+    - name: Build the worker image
+      command: "make worker"
+      args:
+        chdir: "{{ project_dir }}"
     - name: Run tests within a container
       command: "make check_in_container"
       args:


### PR DESCRIPTION
In Zuul, Packit Service is required to be deployed on an OpenShift
cluster only when running the requre tests (from `tests_requre/`), but
not when running the other tests.

Restructure the Zuul config to make the above happen.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>