### PR TITLE
WIP: Use load_config method from packit

### DIFF
--- a/packit_service/config.py
+++ b/packit_service/config.py
@@ -112,7 +112,7 @@ class ServiceConfig(Config):
         # required to avoid circular imports
         from packit_service.schema import ServiceConfigSchema
 
-        config = ServiceConfigSchema().load(raw_dict)
+        config = ServiceConfigSchema().load_config(raw_dict)
 
         config.server_name = raw_dict.get("server_name", "localhost:5000")
 


### PR DESCRIPTION
Fixes #658 
In packit-service/packit#854 I have changed the method name in MM23Schema `load` to `load_config` and I forgot that ServiceConfig inherits this method too