### PR TITLE
process properly multiple jobs with the same type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ check_in_container: test_image
 		-w /src-packit-service \
 		--security-opt label=disable \
 		-v $(CURDIR)/files/packit-service.yaml:/root/.config/packit-service.yaml \
-		$(TEST_IMAGE) make check
+		$(TEST_IMAGE) make check "TEST_TARGET=$(TEST_TARGET)"
 
 # This is my target so don't touch it! :) How to:
 # * No dependencies - take care of them yourself

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ check-in-container-tomas:
 		-v $(CURDIR)/tests_requre/test_data/:/tmp/test_data/ \
 		--network packit-service_default \
 		-e REDIS_SERVICE_HOST=redis \
-		$(TEST_IMAGE) make check TEST_TARGET=$(TEST_TARGET)
+		$(TEST_IMAGE) make check "TEST_TARGET=$(TEST_TARGET)"
 
 # deploy a pod with tests and run them
 check-inside-openshift: worker test_image

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -46,7 +46,7 @@ MAP_EVENT_TRIGGER_TO_HANDLERS: Dict[
     TheJobTriggerType, Set[Type["JobHandler"]]
 ] = defaultdict(set)
 
-MAP_HANDLER_TO_JOB_TYPES: Dict[Type["JobHandler"], Set[JobType]] = defaultdict(set)
+MAP_HANDLER_TO_JOB_TYPES: Dict[Type["Handler"], Set[JobType]] = defaultdict(set)
 
 
 def required_by(job_type: JobType):

--- a/packit_service/worker/handlers/comment_action_handler.py
+++ b/packit_service/worker/handlers/comment_action_handler.py
@@ -28,6 +28,8 @@ import enum
 import logging
 from typing import Dict, Type, Union
 
+from packit.config.job_config import JobConfig
+
 from packit_service.config import ServiceConfig
 from packit_service.service.events import (
     PullRequestCommentGithubEvent,
@@ -85,6 +87,7 @@ class CommentActionHandler(Handler):
             IssueCommentEvent,
             PullRequestCommentPagureEvent,
         ],
+        job: JobConfig,
     ):
         super().__init__(config)
         self.event: Union[
@@ -92,6 +95,7 @@ class CommentActionHandler(Handler):
             IssueCommentEvent,
             PullRequestCommentPagureEvent,
         ] = event
+        self.job = job
 
     def run(self) -> HandlerResults:
         raise NotImplementedError("This should have been implemented.")

--- a/packit_service/worker/handlers/fedmsg_handlers.py
+++ b/packit_service/worker/handlers/fedmsg_handlers.py
@@ -143,6 +143,7 @@ class NewDistGitCommitHandler(FedmsgHandler):
 
 @add_topic
 @use_for(job_type=JobType.copr_build)
+@use_for(job_type=JobType.build)
 @required_by(job_type=JobType.tests)
 class CoprBuildEndHandler(FedmsgHandler):
     topic = "org.fedoraproject.prod.copr.build.end"
@@ -272,6 +273,7 @@ class CoprBuildEndHandler(FedmsgHandler):
 
 @add_topic
 @use_for(job_type=JobType.copr_build)
+@use_for(job_type=JobType.build)
 @required_by(job_type=JobType.tests)
 class CoprBuildStartHandler(FedmsgHandler):
     topic = "org.fedoraproject.prod.copr.build.start"

--- a/packit_service/worker/handlers/pagure_handlers.py
+++ b/packit_service/worker/handlers/pagure_handlers.py
@@ -24,6 +24,7 @@ import logging
 from typing import Optional, Union, Any
 
 from packit.config import JobType, JobConfig
+
 from packit_service.config import ServiceConfig
 from packit_service.service.events import (
     TheJobTriggerType,
@@ -35,12 +36,15 @@ from packit_service.worker.handlers import (
     CommentActionHandler,
     AbstractGitForgeJobHandler,
 )
+from packit_service.worker.handlers.abstract import use_for
 from packit_service.worker.handlers.comment_action_handler import CommentAction
 from packit_service.worker.result import HandlerResults
 
 logger = logging.getLogger(__name__)
 
 
+@use_for(JobType.build)
+@use_for(JobType.copr_build)
 class PagurePullRequestCommentCoprBuildHandler(CommentActionHandler):
     """ Handler for PR comment `/packit copr-build` """
 
@@ -49,9 +53,12 @@ class PagurePullRequestCommentCoprBuildHandler(CommentActionHandler):
     event: PullRequestCommentPagureEvent
 
     def __init__(
-        self, config: ServiceConfig, event: PullRequestCommentPagureEvent,
+        self,
+        config: ServiceConfig,
+        event: PullRequestCommentPagureEvent,
+        job: JobConfig,
     ):
-        super().__init__(config=config, event=event)
+        super().__init__(config=config, event=event, job=job)
 
         # lazy property
         self._copr_build_helper: Optional[CoprBuildJobHelper] = None
@@ -64,6 +71,7 @@ class PagurePullRequestCommentCoprBuildHandler(CommentActionHandler):
                 package_config=self.event.package_config,
                 project=self.event.project,
                 event=self.event,
+                job=self.job,
             )
         return self._copr_build_helper
 

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -23,10 +23,14 @@
 """
 We love you, Steve Jobs.
 """
+import datetime
 import logging
-from typing import Optional, Dict, Union, Type, Set, List, Any
+from typing import Any
+from typing import Optional, Dict, Union, Type, Set, List
 
 from packit.config import JobType, PackageConfig, JobConfig
+from packit.constants import DATETIME_FORMAT
+
 from packit_service.config import ServiceConfig
 from packit_service.log_versions import log_job_versions
 from packit_service.models import PullRequestModel
@@ -110,7 +114,7 @@ def get_handlers_for_event(
 
 
 def get_config_for_handler_kls(
-    handler_kls: Type[JobHandler], event: Event, package_config: PackageConfig
+    handler_kls: Type[Handler], event: Event, package_config: PackageConfig
 ) -> List[JobConfig]:
     """
     Get a list of JobConfigs relevant to event and the handler class.
@@ -221,14 +225,16 @@ class SteveJobs:
                     )
                 return handlers_results
 
+            # we want to run handlers for all possible jobs, not just the first one
             for job_config in job_configs:
                 logger.debug(f"Running handler: {str(handler_kls)} for {job_config}")
                 handler = handler_kls(
                     config=self.config, job_config=job_config, event=event
                 )
                 if handler.pre_check():
-                    handlers_results[job_config.type.value] = handler.run_n_clean()
-            # don't break here, other handlers may react to the same event
+                    current_time = datetime.datetime.now().strftime(DATETIME_FORMAT)
+                    result_key = f"{job_config.type.value}-{current_time}"
+                    handlers_results[result_key] = handler.run_n_clean()
 
         return handlers_results
 
@@ -268,7 +274,7 @@ class SteveJobs:
             PullRequestCommentPagureEvent,
             IssueCommentEvent,
         ],
-    ) -> HandlerResults:
+    ) -> Dict[str, HandlerResults]:
 
         msg = f"comment '{event.comment}'"
         packit_command, pr_comment_error_msg = self.find_packit_command(
@@ -276,18 +282,24 @@ class SteveJobs:
         )
 
         if pr_comment_error_msg:
-            return HandlerResults(success=True, details={"msg": pr_comment_error_msg},)
+            return {
+                event.trigger.value: HandlerResults(
+                    success=True, details={"msg": pr_comment_error_msg},
+                )
+            }
 
         # packit has command `copr-build`. But PullRequestCommentAction has enum `copr_build`.
         try:
             packit_action = CommentAction[packit_command[0].replace("-", "_")]
         except KeyError:
-            return HandlerResults(
-                success=True,
-                details={
-                    "msg": f"{msg} does not contain a valid packit-service command."
-                },
-            )
+            return {
+                event.trigger.value: HandlerResults(
+                    success=True,
+                    details={
+                        "msg": f"{msg} does not contain a valid packit-service command."
+                    },
+                )
+            }
 
         if packit_action == CommentAction.test and isinstance(
             event.db_trigger, PullRequestModel
@@ -299,9 +311,12 @@ class SteveJobs:
             packit_action, None
         )
         if not handler_kls:
-            return HandlerResults(
-                success=True, details={"msg": f"{msg} is not a packit-service command."}
-            )
+            return {
+                event.trigger.value: HandlerResults(
+                    success=True,
+                    details={"msg": f"{msg} is not a packit-service command."},
+                )
+            }
 
         # check whitelist approval for every job to be able to track down which jobs
         # failed because of missing whitelist approval
@@ -310,9 +325,11 @@ class SteveJobs:
         if user_login and user_login in self.config.admins:
             logger.info(f"{user_login} is admin, you shall pass.")
         elif not whitelist.check_and_report(event, event.project, config=self.config):
-            return HandlerResults(
-                success=True, details={"msg": "Account is not whitelisted!"}
-            )
+            return {
+                event.trigger.value: HandlerResults(
+                    success=True, details={"msg": f"Account is not whitelisted!"}
+                )
+            }
 
         # VERY UGLY
         # TODO: REFACTOR !!!
@@ -321,8 +338,19 @@ class SteveJobs:
         ):
             handler_kls = PagurePullRequestCommentCoprBuildHandler
 
-        handler_instance: Handler = handler_kls(config=self.config, event=event)
-        return handler_instance.run_n_clean()
+        handlers_results: Dict[str, HandlerResults] = {}
+        jobs = get_config_for_handler_kls(
+            handler_kls=handler_kls, event=event, package_config=event.package_config,
+        )
+        for job in jobs:
+            handler_instance: Handler = handler_kls(
+                config=self.config, event=event, job=job
+            )
+            result_key = (
+                f"{job.type.value}-{datetime.datetime.now().strftime(DATETIME_FORMAT)}"
+            )
+            handlers_results[result_key] = handler_instance.run_n_clean()
+        return handlers_results
 
     def process_message(
         self, event: dict, topic: str = None, source: str = None
@@ -330,9 +358,9 @@ class SteveJobs:
         """
         Entrypoint for message processing.
 
+        :param event:  dict with webhook/fed-mes payload
         :param topic:  meant to be a topic provided by messaging subsystem (fedmsg, mqqt)
         :param source: source of message
-
         """
 
         if topic:
@@ -401,8 +429,7 @@ class SteveJobs:
                 ),
             )
         ):
-            job_type = JobType.pull_request_action.value
-            jobs_results[job_type] = self.process_comment_jobs(event_object)
+            jobs_results = self.process_comment_jobs(event_object)
         else:
             # Processing the jobs from the config.
             jobs_results = self.process_jobs(event_object)

--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -31,6 +31,7 @@ import requests
 from ogr.abstract import GitProject, CommitStatus
 from ogr.utils import RequestResponse
 from packit.config import PackageConfig
+from packit.config.job_config import JobConfig
 from packit.exceptions import PackitConfigException
 from packit_service.config import ServiceConfig
 from packit_service.constants import TESTING_FARM_TRIGGER_URL
@@ -59,8 +60,9 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             CoprBuildEvent,
             PullRequestCommentGithubEvent,
         ],
+        job: JobConfig = None,
     ):
-        super().__init__(config, package_config, project, event)
+        super().__init__(config, package_config, project, event, job=job)
         self.session = requests.session()
         adapter = requests.adapters.HTTPAdapter(max_retries=5)
         self.insecure = False

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -36,9 +36,11 @@ from packit.local_project import LocalProject
 
 from packit_service.config import ServiceConfig
 from packit_service.constants import SANDCASTLE_WORK_DIR
+from packit_service.models import ProjectReleaseModel
+from packit_service.service.events import IssueCommentEvent
 from packit_service.worker.jobs import SteveJobs
 from packit_service.worker.whitelist import Whitelist
-from tests.spellbook import DATA_DIR
+from tests.spellbook import DATA_DIR, first_dict_value
 
 
 @pytest.fixture(scope="module")
@@ -109,5 +111,6 @@ def test_issue_comment_propose_update_handler(
         get_web_url=lambda: "https://github.com/the-namespace/the-repo",
         is_private=lambda: False,
     )
+    flexmock(IssueCommentEvent, db_trigger=ProjectReleaseModel())
     results = SteveJobs().process_message(issue_comment_propose_update_event)
-    assert results["jobs"]["pull_request_action"]["success"]
+    assert first_dict_value(results["jobs"])["success"]

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -68,7 +68,7 @@ def copr_build_end():
 
 @pytest.fixture(scope="module")
 def pc_build_pr():
-    return PackageConfig(
+    pc = PackageConfig(
         jobs=[
             JobConfig(
                 type=JobType.copr_build,
@@ -77,6 +77,7 @@ def pc_build_pr():
             )
         ]
     )
+    return pc
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -13,6 +13,7 @@ from packit_service.constants import SANDCASTLE_WORK_DIR
 from packit_service.service.db_triggers import AddReleaseDbTrigger
 from packit_service.worker.jobs import SteveJobs
 from packit_service.worker.whitelist import Whitelist
+from tests.spellbook import first_dict_value
 
 
 @pytest.fixture(scope="module")
@@ -51,7 +52,7 @@ def test_dist_git_push_release_handle(github_release_webhook):
     )
 
     results = SteveJobs().process_message(github_release_webhook)
-    assert results["jobs"]["propose_downstream"]["success"]
+    assert first_dict_value(results["jobs"])["success"]
     assert results["event"]["trigger"] == "release"
 
 
@@ -92,7 +93,7 @@ def test_dist_git_push_release_handle_multiple_branches(
     )
 
     results = SteveJobs().process_message(github_release_webhook)
-    assert results["jobs"]["propose_downstream"]["success"]
+    assert first_dict_value(results["jobs"])["success"]
     assert results["event"]["trigger"] == "release"
 
 
@@ -144,7 +145,7 @@ def test_dist_git_push_release_handle_one_failed(
     )
 
     results = SteveJobs().process_message(github_release_webhook)
-    assert not results["jobs"]["propose_downstream"]["success"]
+    assert not first_dict_value(results["jobs"])["success"]
     assert results["event"]["trigger"] == "release"
 
 
@@ -202,5 +203,5 @@ def test_dist_git_push_release_handle_all_failed(
     )
 
     results = SteveJobs().process_message(github_release_webhook)
-    assert not results["jobs"]["propose_downstream"]["success"]
+    assert not first_dict_value(results["jobs"])["success"]
     assert results["event"]["trigger"] == "release"

--- a/tests/spellbook.py
+++ b/tests/spellbook.py
@@ -24,8 +24,12 @@
 A book with our finest spells
 """
 from pathlib import Path
-
+from typing import Any
 
 TESTS_DIR = Path(__file__).parent
 DATA_DIR = TESTS_DIR / "data"
 SAVED_HTTPD_REQS = DATA_DIR / "http-requests"
+
+
+def first_dict_value(a_dict: dict) -> Any:
+    return a_dict[next(iter(a_dict))]

--- a/tests/unit/test_steve.py
+++ b/tests/unit/test_steve.py
@@ -38,6 +38,7 @@ from packit_service.constants import SANDCASTLE_WORK_DIR
 from packit_service.service.db_triggers import AddReleaseDbTrigger
 from packit_service.worker.jobs import SteveJobs
 from packit_service.worker.whitelist import Whitelist
+from tests.spellbook import first_dict_value
 
 
 @pytest.mark.parametrize(
@@ -85,5 +86,7 @@ def test_process_message(event):
     )
     flexmock(Whitelist, check_and_report=True)
     results = SteveJobs().process_message(event)
-    assert "propose_downstream" in results["jobs"]
+    j = first_dict_value(results["jobs"])
+    assert "propose_downstream" in next(iter(results["jobs"]))
+    assert j["success"]
     assert results["event"]["trigger"] == "release"


### PR DESCRIPTION
This is a follow-up patch to #648 to address the problem when the
project defines multiple jobs with the same type. We address several
issues in here:

* comment jobs are processed correctly (only a first one was processed
  before)
* HandlerResults are not being overwritten with the same job type
* all build-related handlers have aliasing (build/copr-build) set up