### PR TITLE
[files/install-deps(-worker).yaml] install python3-celery & python3-redis

### DIFF
--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -15,15 +15,17 @@
           - python3-alembic
           - python3-sqlalchemy
           - python3-psycopg2
+          - python3-celery
+          - python3-redis
           - python3-lazy-object-proxy
           - python3-bugzilla # python-bugzilla (not bugzilla) on PyPI
           - python3-backoff # Bugzilla class
-          #- python3-flask-restx # https://bugzilla.redhat.com/show_bug.cgi?id=1817535
+          #- python3-flask-restx # needs Fedora 32
         state: present
     - name: Install pip deps
       pip:
         name:
           - git+https://github.com/packit-service/sandcastle.git
-          - sentry-sdk==0.14.3
+          - sentry-sdk==0.14.4
           - flask-restx
         executable: pip3

--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -23,6 +23,8 @@
           - python3-alembic
           - python3-sqlalchemy
           - python3-psycopg2
+          - python3-celery
+          - python3-redis
           - python3-lazy-object-proxy
           #- python3-flask-restx # Needs Fedora 32
           - python3-flexmock # because of the hack during the alembic upgrade
@@ -32,7 +34,7 @@
       pip:
         name:
           - persistentdict # still needed by one Alembic migration script
-          - sentry-sdk==0.14.3
-          - sentry-sdk[flask]==0.14.3
+          - sentry-sdk==0.14.4
+          - sentry-sdk[flask]==0.14.4
           - flask-restx
         executable: pip3


### PR DESCRIPTION
They'd be pip installed anyway, but better be explicit.

Fixes https://sentry.io/organizations/red-hat-0p/issues/1707007212