### PR TITLE
Set `__version__` to None by default

### DIFF
--- a/packit_service/__init__.py
+++ b/packit_service/__init__.py
@@ -26,4 +26,4 @@ try:
     __version__ = get_distribution(__name__).version
 except DistributionNotFound:
     # package is not installed
-    pass
+    __version__ = None


### PR DESCRIPTION
- Set `__version__` to `None` when not installed to avoid import errors.
- Usecase: Running tests via PyCharm.