### PR TITLE
Fix example for 'whitelist.py waiting'

### DIFF
--- a/files/scripts/README.md
+++ b/files/scripts/README.md
@@ -19,5 +19,5 @@ $ oc exec packit-worker-0 python3 /src-packit-service/files/scripts/whitelist.py
 Show all pending requests:
 
 ```
-oc exec <packit_worker_pod_name> python3 /src/files/scripts/whitelist.py waiting
+$ oc exec packit-worker-0 python3 /src-packit-service/files/scripts/whitelist.py waiting
 ```


### PR DESCRIPTION
Path to the script was incorrect.

Use packit-worker-0 instead of a placeholder, as there is always at
least one worker available.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>