### PR TITLE
Merge chroots and do pagination (API) in SQL instead of python

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,3 +127,12 @@ services:
       - ./secrets/dev/centos-server-ca.cert:/secrets/centos-server-ca.cert:ro,Z
       - ./secrets/dev/centos.cert:/secrets/centos.cert:ro,Z
     user: "123123"
+
+  adminer:
+    image: adminer
+    container_name: adminer
+    depends_on:
+      - postgres
+    ports:
+      - 8082:8080
+    user: "123123"

--- a/tests_requre/conftest.py
+++ b/tests_requre/conftest.py
@@ -345,6 +345,59 @@ def multiple_copr_builds(pr_model, different_pr_model, srpm_build_model):
 
 
 @pytest.fixture()
+def too_many_copr_builds(pr_model, different_pr_model, srpm_build_model):
+    """Don't use for testing anything other than pagination, use multiple_copr_builds."""
+    for i in range(20):
+
+        # The following two are similar, except for target, status
+        CoprBuildModel.get_or_create(
+            build_id=SampleValues.build_id + str(i),
+            commit_sha=SampleValues.ref,
+            project_name=SampleValues.project,
+            owner=SampleValues.owner,
+            web_url=SampleValues.copr_web_url + str(i),
+            target=SampleValues.target,
+            status=SampleValues.status_success,
+            srpm_build=srpm_build_model,
+            trigger_model=pr_model,
+        )
+        CoprBuildModel.get_or_create(
+            build_id=SampleValues.build_id + str(i),
+            commit_sha=SampleValues.ref,
+            project_name=SampleValues.project,
+            owner=SampleValues.owner,
+            web_url=SampleValues.copr_web_url + str(i),
+            target=SampleValues.different_target,
+            status=SampleValues.status_pending,
+            srpm_build=srpm_build_model,
+            trigger_model=pr_model,
+        )
+        # The following two are similar, except for target, status
+        CoprBuildModel.get_or_create(
+            build_id=SampleValues.different_build_id + str(i),
+            commit_sha=SampleValues.different_commit_sha,
+            project_name=SampleValues.different_project_name,
+            owner=SampleValues.owner,
+            web_url=SampleValues.copr_web_url + str(i),
+            target=SampleValues.target,
+            status=SampleValues.status_success,
+            srpm_build=srpm_build_model,
+            trigger_model=different_pr_model,
+        )
+        CoprBuildModel.get_or_create(
+            build_id=SampleValues.different_build_id + str(i),
+            commit_sha=SampleValues.different_commit_sha,
+            project_name=SampleValues.different_project_name,
+            owner=SampleValues.owner,
+            web_url=SampleValues.copr_web_url + str(i),
+            target=SampleValues.different_target,
+            status=SampleValues.status_success,
+            srpm_build=srpm_build_model,
+            trigger_model=different_pr_model,
+        )
+
+
+@pytest.fixture()
 def copr_builds_with_different_triggers(
     pr_model, branch_model, release_model, srpm_build_model
 ):

--- a/tests_requre/database/test_models.py
+++ b/tests_requre/database/test_models.py
@@ -107,19 +107,37 @@ def test_copr_build_get_pr_id(
     assert not copr_builds_with_different_triggers[2].get_pr_id()
 
 
+def test_get_merged_chroots(clean_before_and_after, too_many_copr_builds):
+    # fetch 10 merged groups of builds
+    builds_list = CoprBuildModel.get_merged_chroots(10, 20)
+    assert len(builds_list) == 10
+    # two merged chroots so two statuses
+    assert len(builds_list[0].status) == 2
+    assert len(builds_list[0].target) == 2
+    assert builds_list[1].status[0][0] == "success"
+    assert builds_list[2].target[0][0] == "fedora-42-x86_64"
+
+
 def test_get_copr_build(clean_before_and_after, a_copr_build_for_pr):
     assert a_copr_build_for_pr.id
+
+    # pass in a build_id and a target
     b = CoprBuildModel.get_by_build_id(
         a_copr_build_for_pr.build_id, SampleValues.target
     )
     assert b.id == a_copr_build_for_pr.id
     # let's make sure passing int works as well
-    b = CoprBuildModel.get_by_build_id(
+    b2 = CoprBuildModel.get_by_build_id(
         int(a_copr_build_for_pr.build_id), SampleValues.target
     )
-    assert b.id == a_copr_build_for_pr.id
-    b2 = CoprBuildModel.get_by_id(b.id)
     assert b2.id == a_copr_build_for_pr.id
+
+    # pass in a build_id and without a target
+    b3 = CoprBuildModel.get_by_build_id(a_copr_build_for_pr.build_id, None)
+    assert b3.commit_sha == a_copr_build_for_pr.commit_sha
+
+    b4 = CoprBuildModel.get_by_id(b.id)
+    assert b4.id == a_copr_build_for_pr.id
 
 
 def test_copr_build_set_status(clean_before_and_after, a_copr_build_for_pr):

--- a/tests_requre/service/test_api.py
+++ b/tests_requre/service/test_api.py
@@ -16,17 +16,35 @@ def test_copr_builds_list(client, clean_before_and_after, multiple_copr_builds):
     response_dict = response.json
     assert response_dict[0]["project"] == SampleValues.different_project_name
     assert response_dict[1]["project"] == SampleValues.project
-    assert response_dict[1]["owner"] == SampleValues.owner
     assert response_dict[1]["build_id"] == SampleValues.build_id
     assert response_dict[1]["web_url"] == SampleValues.copr_web_url
     assert response_dict[1]["repo_namespace"] == SampleValues.repo_namespace
     assert response_dict[1]["repo_name"] == SampleValues.repo_name
-    assert len(response_dict[1]["chroots"]) == 2
+    assert response_dict[1]["pr_id"] == SampleValues.pr_id
     assert len(list(response_dict[1]["status_per_chroot"])) == 2
     assert response_dict[1]["status_per_chroot"]["fedora-42-x86_64"] == "success"
     assert response_dict[1]["status_per_chroot"]["fedora-43-x86_64"] == "pending"
     assert response_dict[1]["build_submitted_time"] is not None
     assert len(response_dict) == 2  # three builds, but two unique build ids
+
+
+#  Test Pagination
+def test_pagination(client, clean_before_and_after, too_many_copr_builds):
+    response_1 = client.get(
+        url_for("api.copr-builds_copr_builds_list") + "?page=2&per_page=20"
+    )
+    response_dict_1 = response_1.json
+    assert len(list(response_dict_1[1]["status_per_chroot"])) == 2
+    assert response_dict_1[1]["build_submitted_time"] is not None
+    assert len(response_dict_1) == 20  # three builds, but two unique build ids
+
+    response_2 = client.get(
+        url_for("api.copr-builds_copr_builds_list") + "?page=1&per_page=30"
+    )
+    response_dict_2 = response_2.json
+    assert len(list(response_dict_2[1]["status_per_chroot"])) == 2
+    assert response_dict_2[1]["build_submitted_time"] is not None
+    assert len(response_dict_2) == 30  # three builds, but two unique build ids
 
 
 # Test detailed build info


### PR DESCRIPTION
#633 
- right now, we load info about every build ever into memory and then serve info about 10 or 20 builds at a time (pagination). this repeats again when we want the next twenty builds
- we make queries to fetch "all builds" and "same build_id builds" and then merge them into one. and then we do this for every single build (above mentioned point)
- as a result /copr-builds is just timing out on the prod api

This PR replaces all of that by doing this in SQL. Now if we need the 10 latest builds with unique build_ids, we fetch that directly. Chroots are merged in SQL, not python.

- [x] Find a way to add repo_namespace and repo_name as well
- [x] Tests
