### PR TITLE
Change the handler classes code to have more separate attributes

### DIFF
--- a/packit_service/models.py
+++ b/packit_service/models.py
@@ -1027,23 +1027,20 @@ class InstallationModel(Base):
             return session.query(InstallationModel).all()
 
     @classmethod
-    def create(cls, event: dict):
+    def create(cls, event):
         with get_sa_session() as session:
-            account_login = event.get("account_login")
-            installation = cls.get_by_account_login(account_login)
+            installation = cls.get_by_account_login(event.account_login)
             if not installation:
                 installation = cls()
-                installation.account_login = account_login
-                installation.account_id = event.get("account_id")
-                installation.account_url = event.get("account_url")
-                installation.account_type = event.get("account_type")
-                installation.sender_login = event.get("sender_login")
-                installation.sender_id = event.get("sender_id")
-                installation.created_at = datetime.fromtimestamp(
-                    event.get("created_at")
-                )
+                installation.account_login = event.account_login
+                installation.account_id = event.account_id
+                installation.account_url = event.account_url
+                installation.account_type = event.account_type
+                installation.sender_login = event.sender_login
+                installation.sender_id = event.sender_id
+                installation.created_at = event.created_at
                 installation.repositories = [
-                    cls.get_project(repo).id for repo in event.get("repositories")
+                    cls.get_project(repo).id for repo in event.repositories
                 ]
                 session.add(installation)
             return installation

--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -870,6 +870,16 @@ class KojiBuildEvent(AbstractForgeIndependentEvent):
                 return None  # With Github app, we cannot work with fork repo
         return self.project
 
+    def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
+        result = super().get_dict()
+        result["state"] = result["state"].value
+        result["old_state"] = result["old_state"].value
+        result["commit_sha"] = self.commit_sha
+        result["pr_id"] = self.pr_id
+        result["git_ref"] = self.git_ref
+        result["identifier"] = self.identifier
+        return result
+
 
 class CoprBuildEvent(AbstractForgeIndependentEvent):
     build: Optional[CoprBuildModel]
@@ -980,25 +990,6 @@ class CoprBuildEvent(AbstractForgeIndependentEvent):
         result["topic"] = result["topic"].value
         self.build = build
         return result
-
-
-def get_koji_build_logs_url(event: KojiBuildEvent) -> Optional[str]:
-    if not event.rpm_build_task_id:
-        return None
-
-    return (
-        f"https://kojipkgs.fedoraproject.org//work/tasks/"
-        f"{event.rpm_build_task_id % 10000}/{event.rpm_build_task_id}/build.log"
-    )
-
-
-def get_koji_rpm_build_web_url(event: KojiBuildEvent) -> Optional[str]:
-    if not event.rpm_build_task_id:
-        return None
-
-    return (
-        f"https://koji.fedoraproject.org/koji/taskinfo?taskID={event.rpm_build_task_id}"
-    )
 
 
 class AbstractPagureEvent(AbstractForgeIndependentEvent):

--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -197,6 +197,9 @@ class Event:
         d["trigger"] = d["trigger"].value
         d["trigger_id"] = self.db_trigger.id if self.db_trigger else None
         d["created_at"] = int(d["created_at"].timestamp())
+        d["project_url"] = d.get("project_url") or (
+            self.db_trigger.project.project_url if self.db_trigger else None
+        )
         return d
 
     @property
@@ -629,6 +632,7 @@ class IssueCommentEvent(AddIssueDbTrigger, AbstractGithubEvent):
     def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
         result = super().get_dict()
         result["action"] = result["action"].value
+        result["tag_name"] = self.tag_name
         return result
 
 

--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -141,6 +141,62 @@ class TestResult(dict):
         )
 
 
+class EventData:
+    """
+    Class to represent the data which are common for handlers and comes from the original event
+    """
+
+    def __init__(
+        self,
+        event_type: str,
+        trigger: TheJobTriggerType,
+        user_login: str,
+        trigger_id: int,
+        project_url: str,
+        tag_name: Optional[str],
+        git_ref: Optional[str],
+        pr_id: Optional[int],
+        commit_sha: Optional[str],
+        identifier: Optional[str],
+    ):
+        self.event_type = event_type
+        self.trigger = trigger
+        self.user_login = user_login
+        self.trigger_id = trigger_id
+        self.project_url = project_url
+        self.tag_name = tag_name
+        self.git_ref = git_ref
+        self.pr_id = pr_id
+        self.commit_sha = commit_sha
+        self.identifier = identifier
+
+    @classmethod
+    def from_event_dict(cls, event: dict):
+        event_type = event.get("event_type")
+        trigger = TheJobTriggerType(event.get("trigger"))
+        user_login = event.get("user_login")
+        trigger_id = event.get("trigger_id")
+        project_url = event.get("project_url")
+        tag_name = event.get("tag_name")
+        git_ref = event.get("git_ref")
+        pr_id = event.get("pr_id")
+        commit_sha = event.get("commit_sha")
+        identifier = event.get("identifier")
+
+        return EventData(
+            event_type=event_type,
+            trigger=trigger,
+            user_login=user_login,
+            trigger_id=trigger_id,
+            project_url=project_url,
+            tag_name=tag_name,
+            git_ref=git_ref,
+            pr_id=pr_id,
+            commit_sha=commit_sha,
+            identifier=identifier,
+        )
+
+
 class Event:
     def __init__(
         self, trigger: TheJobTriggerType, created_at: Union[int, float, str] = None
@@ -1009,7 +1065,7 @@ class CoprBuildEvent(AbstractForgeIndependentEvent):
     def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
         result = super().get_dict()
         result["topic"] = result["topic"].value
-        # self.build = build
+        result.pop("build")
         return result
 
     def get_copr_build_url(self) -> str:

--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -120,9 +120,9 @@ class EventType(str, enum.Enum):
     koji_build = "KojiBuildEvent"
     tft_result = "TestingFarmResultsEvent"
     release = "ReleaseEvent"
-    push_gh = "PushGithubGHEvent"
-    pull_request_gh = "PullRequestGHEvent"
-    pull_request_comment_gh = "PullRequestCommentGHEvent"
+    push_gh = "PushGitHubEvent"
+    pull_request_gh = "PullRequestGithubEvent"
+    pull_request_comment_gh = "PullRequestCommentGithubEvent"
     issue_comment = "IssueCommentEvent"
     push_pagure = "PushPagureEvent"
     pull_request_comment_pg = "PullRequestCommentPagureEvent"
@@ -984,11 +984,9 @@ class CoprBuildEvent(AbstractForgeIndependentEvent):
         return True
 
     def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
-        d = self.__dict__
-        build = d.pop("build")
-        result = super().get_dict(d)
+        result = super().get_dict()
         result["topic"] = result["topic"].value
-        self.build = build
+        # self.build = build
         return result
 
 

--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -114,28 +114,6 @@ class TheJobTriggerType(str, enum.Enum):
     copr_end = "copr_end"
 
 
-class EventType(str, enum.Enum):
-    installation = "InstallationEvent"
-    copr_build = "CoprBuildEvent"
-    koji_build = "KojiBuildEvent"
-    tft_result = "TestingFarmResultsEvent"
-    release = "ReleaseEvent"
-    push_gh = "PushGitHubEvent"
-    pull_request_gh = "PullRequestGithubEvent"
-    pull_request_comment_gh = "PullRequestCommentGithubEvent"
-    issue_comment = "IssueCommentEvent"
-    push_pagure = "PushPagureEvent"
-    pull_request_comment_pg = "PullRequestCommentPagureEvent"
-    pull_request_pg = "PullRequestPagureEvent"
-    pull_request_label_pg = "PullRequestLabelPagureEvent"
-    dist_git_event = "DistGitEvent"
-    issue_comment_gl = "IssueCommentGitlabEvent"
-    merge_request_comment_gl = "MergeRequestCommentGitlabEvent"
-    merge_request_gl = "MergeRequestGitlabEvent"
-    push_gl = "PushGitlabEvent"
-
-
-
 class TestResult(dict):
     def __init__(self, name: str, result: TestingFarmResult, log_url: str):
         dict.__init__(self, name=name, result=result, log_url=log_url)

--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -118,7 +118,7 @@ class EventType(str, enum.Enum):
     installation = "InstallationEvent"
     copr_build = "CoprBuildEvent"
     koji_build = "KojiBuildEvent"
-    tft_result = "TestingFarmResultEvent"
+    tft_result = "TestingFarmResultsEvent"
     release = "ReleaseEvent"
     push_gh = "PushGithubGHEvent"
     pull_request_gh = "PullRequestGHEvent"
@@ -368,6 +368,11 @@ class ReleaseEvent(AddReleaseDbTrigger, AbstractGithubEvent):
         if not self._commit_sha:
             self._commit_sha = self.project.get_sha_from_tag(tag_name=self.tag_name)
         return self._commit_sha
+
+    def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
+        result = super().get_dict()
+        result["commit_sha"] = self.commit_sha
+        return result
 
 
 class PushGitHubEvent(AddBranchPushDbTrigger, AbstractGithubEvent):

--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -158,6 +158,7 @@ class EventData:
         pr_id: Optional[int],
         commit_sha: Optional[str],
         identifier: Optional[str],
+        event_dict: Optional[dict],
     ):
         self.event_type = event_type
         self.trigger = trigger
@@ -169,6 +170,7 @@ class EventData:
         self.pr_id = pr_id
         self.commit_sha = commit_sha
         self.identifier = identifier
+        self.event_dict = event_dict
 
     @classmethod
     def from_event_dict(cls, event: dict):
@@ -194,6 +196,7 @@ class EventData:
             pr_id=pr_id,
             commit_sha=commit_sha,
             identifier=identifier,
+            event_dict=event,
         )
 
 

--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -888,6 +888,21 @@ class KojiBuildEvent(AbstractForgeIndependentEvent):
         result["identifier"] = self.identifier
         return result
 
+    def get_koji_build_logs_url(self) -> Optional[str]:
+        if not self.rpm_build_task_id:
+            return None
+
+        return (
+            f"https://kojipkgs.fedoraproject.org//work/tasks/"
+            f"{self.rpm_build_task_id % 10000}/{self.rpm_build_task_id}/build.log"
+        )
+
+    def get_koji_rpm_build_web_url(self) -> Optional[str]:
+        if not self.rpm_build_task_id:
+            return None
+
+        return f"https://koji.fedoraproject.org/koji/taskinfo?taskID={self.rpm_build_task_id}"
+
 
 class CoprBuildEvent(AbstractForgeIndependentEvent):
     build: Optional[CoprBuildModel]
@@ -996,6 +1011,19 @@ class CoprBuildEvent(AbstractForgeIndependentEvent):
         result["topic"] = result["topic"].value
         # self.build = build
         return result
+
+    def get_copr_build_url(self) -> str:
+        return (
+            "https://copr.fedorainfracloud.org/coprs/"
+            f"{self.owner}/{self.project_name}/build/{self.build_id}/"
+        )
+
+    def get_copr_build_logs_url(self) -> str:
+        return (
+            f"https://copr-be.cloud.fedoraproject.org/results/{self.owner}/"
+            f"{self.project_name}/{self.chroot}/"
+            f"{self.build_id:08d}-{self.pkg}/builder-live.log.gz"
+        )
 
 
 class AbstractPagureEvent(AbstractForgeIndependentEvent):

--- a/packit_service/worker/build/__init__.py
+++ b/packit_service/worker/build/__init__.py
@@ -20,10 +20,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from packit_service.worker.build.build_helper import BaseBuildJobHelper
+from packit_service.worker.build.build_helper import (
+    BaseBuildJobHelper,
+    BuildHelperMetadata,
+)
 from packit_service.worker.build.copr_build import CoprBuildJobHelper
 
 __all__ = [
     CoprBuildJobHelper.__name__,
     BaseBuildJobHelper.__name__,
+    BuildHelperMetadata.__name__,
 ]

--- a/packit_service/worker/build/__init__.py
+++ b/packit_service/worker/build/__init__.py
@@ -5,7 +5,7 @@
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# to use, copy, modiffy, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 #
@@ -20,14 +20,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from packit_service.worker.build.build_helper import (
-    BaseBuildJobHelper,
-    BuildHelperMetadata,
-)
+from packit_service.worker.build.build_helper import BaseBuildJobHelper
 from packit_service.worker.build.copr_build import CoprBuildJobHelper
 
 __all__ = [
     CoprBuildJobHelper.__name__,
     BaseBuildJobHelper.__name__,
-    BuildHelperMetadata.__name__,
 ]

--- a/packit_service/worker/build/__init__.py
+++ b/packit_service/worker/build/__init__.py
@@ -5,7 +5,7 @@
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
-# to use, copy, modiffy, merge, publish, distribute, sublicense, and/or sell
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 #

--- a/packit_service/worker/build/babysit.py
+++ b/packit_service/worker/build/babysit.py
@@ -98,6 +98,5 @@ def check_copr_build(build_id: int) -> bool:
                 package_config=event.package_config,
                 job_config=job_config,
                 data=EventData.from_event_dict(event_dict),
-                event=event_dict,
             ).run()
     return True

--- a/packit_service/worker/build/babysit.py
+++ b/packit_service/worker/build/babysit.py
@@ -29,7 +29,7 @@ from packit_service.constants import (
     COPR_API_FAIL_STATE,
 )
 from packit_service.models import CoprBuildModel
-from packit_service.service.events import CoprBuildEvent, FedmsgTopic
+from packit_service.service.events import CoprBuildEvent, FedmsgTopic, EventData
 from packit_service.worker.handlers import CoprBuildEndHandler
 from packit_service.worker.jobs import get_config_for_handler_kls
 
@@ -93,9 +93,11 @@ def check_copr_build(build_id: int) -> bool:
         )
 
         for job_config in job_configs:
+            event_dict = event.get_dict()
             CoprBuildEndHandler(
                 package_config=event.package_config,
                 job_config=job_config,
-                event=event.get_dict(),
+                data=EventData.from_event_dict(event_dict),
+                event=event_dict,
             ).run()
     return True

--- a/packit_service/worker/build/babysit.py
+++ b/packit_service/worker/build/babysit.py
@@ -23,7 +23,6 @@ import logging
 
 from copr.v3 import Client as CoprClient
 
-from packit_service.config import ServiceConfig
 from packit_service.constants import (
     COPR_SUCC_STATE,
     COPR_API_SUCC_STATE,
@@ -95,6 +94,8 @@ def check_copr_build(build_id: int) -> bool:
 
         for job_config in job_configs:
             CoprBuildEndHandler(
-                ServiceConfig.get_service_config(), job_config=job_config, event=event,
+                package_config=event.package_config,
+                job_config=job_config,
+                event=event.get_dict(),
             ).run()
     return True

--- a/packit_service/worker/build/build_helper.py
+++ b/packit_service/worker/build/build_helper.py
@@ -68,8 +68,10 @@ class BaseBuildJobHelper:
 
         self.pr_id = event.get("pr_id")
         self.git_ref = event.get("git_ref")
-        self.commit_sha = event.get("_commit_sha")
-        self.trigger = TheJobTriggerType(event.get("trigger"))
+        self.commit_sha = event.get("commit_sha")
+        self.trigger = (
+            TheJobTriggerType(event.get("trigger")) if event.get("trigger") else None
+        )
 
         # lazy properties
         self._api = None

--- a/packit_service/worker/build/build_helper.py
+++ b/packit_service/worker/build/build_helper.py
@@ -39,48 +39,10 @@ from packit_service.trigger_mapping import (
     are_job_types_same,
 )
 from packit_service.worker.reporting import StatusReporter
-from packit_service.service.events import TheJobTriggerType
+from packit_service.service.events import EventData
 from sandcastle import SandcastleTimeoutReached
 
 logger = logging.getLogger(__name__)
-
-
-class BuildHelperMetadata:
-    """
-    Class to represent the data from event needed by BaseBuildJobHelper.
-    """
-
-    def __init__(
-        self,
-        trigger: TheJobTriggerType,
-        pr_id: Optional[int] = None,
-        git_ref: Optional[str] = None,
-        commit_sha: Optional[str] = None,
-        # identifier of the respective event (PR, release) used e.g. in copr project name
-        identifier: Optional[str] = None,
-    ):
-        self.trigger = trigger
-        self.pr_id = pr_id
-        self.git_ref = git_ref
-        self.commit_sha = commit_sha
-        self.identifier = identifier
-
-    @classmethod
-    def from_event_dict(cls, event: dict):
-        trigger = (
-            TheJobTriggerType(event.get("trigger")) if event.get("trigger") else None
-        )
-        pr_id = event.get("pr_id")
-        git_ref = event.get("git_ref")
-        commit_sha = event.get("commit_sha")
-        identifier = event.get("identifier")
-        return BuildHelperMetadata(
-            trigger=trigger,
-            pr_id=pr_id,
-            git_ref=git_ref,
-            commit_sha=commit_sha,
-            identifier=identifier,
-        )
 
 
 class BaseBuildJobHelper:
@@ -94,7 +56,7 @@ class BaseBuildJobHelper:
         config: ServiceConfig,
         package_config: PackageConfig,
         project: GitProject,
-        metadata: BuildHelperMetadata,
+        metadata: EventData,
         db_trigger,
         job: Optional[JobConfig] = None,
     ):
@@ -103,7 +65,7 @@ class BaseBuildJobHelper:
         self.project: GitProject = project
         self.db_trigger = db_trigger
         self.msg_retrigger: Optional[str] = ""
-        self.metadata: BuildHelperMetadata = metadata
+        self.metadata: EventData = metadata
 
         # lazy properties
         self._api = None

--- a/packit_service/worker/build/copr_build.py
+++ b/packit_service/worker/build/copr_build.py
@@ -57,7 +57,12 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
         job: Optional[JobConfig] = None,
     ):
         super().__init__(
-            config, package_config, project, event, db_trigger, job,
+            config=config,
+            package_config=package_config,
+            project=project,
+            event=event,
+            db_trigger=db_trigger,
+            job=job,
         )
 
         self.msg_retrigger: str = MSG_RETRIGGER.format(

--- a/packit_service/worker/build/copr_build.py
+++ b/packit_service/worker/build/copr_build.py
@@ -35,11 +35,9 @@ from packit_service.service.urls import (
     get_srpm_log_url_from_flask,
     get_copr_build_info_url_from_flask,
 )
-from packit_service.worker.build.build_helper import (
-    BaseBuildJobHelper,
-    BuildHelperMetadata,
-)
+from packit_service.worker.build.build_helper import BaseBuildJobHelper
 from packit_service.worker.result import HandlerResults
+from packit_service.service.events import EventData
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +53,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
         config: ServiceConfig,
         package_config: PackageConfig,
         project: GitProject,
-        metadata: BuildHelperMetadata,
+        metadata: EventData,
         db_trigger,
         job: Optional[JobConfig] = None,
     ):

--- a/packit_service/worker/build/koji_build.py
+++ b/packit_service/worker/build/koji_build.py
@@ -35,11 +35,9 @@ from packit_service.service.urls import (
     get_srpm_log_url_from_flask,
     get_koji_build_info_url_from_flask,
 )
-from packit_service.worker.build.build_helper import (
-    BaseBuildJobHelper,
-    BuildHelperMetadata,
-)
+from packit_service.worker.build.build_helper import BaseBuildJobHelper
 from packit_service.worker.result import HandlerResults
+from packit_service.service.events import EventData
 
 logger = logging.getLogger(__name__)
 
@@ -55,12 +53,17 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
         config: ServiceConfig,
         package_config: PackageConfig,
         project: GitProject,
-        metadata: BuildHelperMetadata,
+        metadata: EventData,
         db_trigger,
         job: Optional[JobConfig] = None,
     ):
         super().__init__(
-            config, package_config, project, metadata, db_trigger, job,
+            config=config,
+            package_config=package_config,
+            project=project,
+            metadata=metadata,
+            db_trigger=db_trigger,
+            job=job,
         )
         self.msg_retrigger: str = MSG_RETRIGGER.format(build="production-build")
 

--- a/packit_service/worker/build/koji_build.py
+++ b/packit_service/worker/build/koji_build.py
@@ -35,7 +35,10 @@ from packit_service.service.urls import (
     get_srpm_log_url_from_flask,
     get_koji_build_info_url_from_flask,
 )
-from packit_service.worker.build.build_helper import BaseBuildJobHelper
+from packit_service.worker.build.build_helper import (
+    BaseBuildJobHelper,
+    BuildHelperMetadata,
+)
 from packit_service.worker.result import HandlerResults
 
 logger = logging.getLogger(__name__)
@@ -52,12 +55,12 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
         config: ServiceConfig,
         package_config: PackageConfig,
         project: GitProject,
-        event: dict,
+        metadata: BuildHelperMetadata,
         db_trigger,
         job: Optional[JobConfig] = None,
     ):
         super().__init__(
-            config, package_config, project, event, db_trigger, job,
+            config, package_config, project, metadata, db_trigger, job,
         )
         self.msg_retrigger: str = MSG_RETRIGGER.format(build="production-build")
 
@@ -164,7 +167,7 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
 
             koji_build = KojiBuildModel.get_or_create(
                 build_id=str(build_id),
-                commit_sha=self.commit_sha,
+                commit_sha=self.metadata.commit_sha,
                 web_url=web_url,
                 target=target,
                 status="pending",

--- a/packit_service/worker/handlers/__init__.py
+++ b/packit_service/worker/handlers/__init__.py
@@ -37,7 +37,6 @@ from packit_service.worker.handlers.fedmsg_handlers import (
     NewDistGitCommitHandler,
 )
 from packit_service.worker.handlers.github_handlers import (
-    AbstractGitForgeJobHandler,
     GithubAppInstallationHandler,
     ReleaseCoprBuildHandler,
     PullRequestCoprBuildHandler,
@@ -57,7 +56,6 @@ from packit_service.worker.handlers.testing_farm_handlers import (
 )
 
 __all__ = [
-    AbstractGitForgeJobHandler.__name__,
     CommentActionHandler.__name__,
     CoprBuildEndHandler.__name__,
     CoprBuildStartHandler.__name__,

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -44,7 +44,7 @@ from packit_service.models import (
     ProjectReleaseModel,
     GitBranchModel,
 )
-from packit_service.service.events import TheJobTriggerType, EventType
+from packit_service.service.events import TheJobTriggerType
 from packit_service.worker.result import HandlerResults
 
 logger = logging.getLogger(__name__)
@@ -181,9 +181,7 @@ class JobHandler(Handler):
     ):
         self.package_config: PackageConfig = package_config
         self.job_config: Optional[JobConfig] = job_config
-        self.event_type = (
-            EventType(event.get("event_type")) if event.get("event_type") else None
-        )
+        self.event_type = event.get("event_type")
         self.trigger = (
             TheJobTriggerType(event.get("trigger")) if event.get("trigger") else None
         )

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -210,17 +210,20 @@ class JobHandler(Handler):
                 self._db_trigger = IssueModel.get_by_id(self.trigger_id)
             elif self.trigger == TheJobTriggerType.release:
                 self._db_trigger = ProjectReleaseModel.get_by_id(self.trigger_id)
-            elif self.trigger in (TheJobTriggerType.push, TheJobTriggerType.commit):
+            elif self.trigger in TheJobTriggerType.push:
                 self._db_trigger = GitBranchModel.get_by_id(self.trigger_id)
         return self._db_trigger
 
     @property
-    def project(self) -> GitProject:
+    def project(self) -> Optional[GitProject]:
         if not self._project:
             self._project = self.get_project()
         return self._project
 
-    def get_project(self) -> GitProject:
+    def get_project(self) -> Optional[GitProject]:
+        if not self.project_url:
+            return None
+
         return self.config.get_project(url=self.project_url)
 
     def run(self) -> HandlerResults:

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -181,13 +181,11 @@ class JobHandler(Handler):
     ):
         self.package_config: PackageConfig = package_config
         self.job_config: Optional[JobConfig] = job_config
-        self.event_type = event.get("event_type")
-        self.trigger = (
-            TheJobTriggerType(event.get("trigger")) if event.get("trigger") else None
-        )
-        self.user_login = event.get("user_login")
-        self.trigger_id = event.get("trigger_id")
-        self.project_url = event.get("project_url")
+        self.event_type: str = event.get("event_type")
+        self.trigger: TheJobTriggerType = TheJobTriggerType(event.get("trigger"))
+        self.user_login: str = event.get("user_login")
+        self.trigger_id: int = event.get("trigger_id")
+        self.project_url: str = event.get("project_url")
 
         self.event = event
         self._db_trigger: Optional[AbstractTriggerDbType] = None
@@ -214,15 +212,9 @@ class JobHandler(Handler):
 
     @property
     def project(self) -> Optional[GitProject]:
-        if not self._project:
-            self._project = self.get_project()
+        if not self._project and self.project_url:
+            self._project = self.config.get_project(url=self.project_url)
         return self._project
-
-    def get_project(self) -> Optional[GitProject]:
-        if not self.project_url:
-            return None
-
-        return self.config.get_project(url=self.project_url)
 
     def run(self) -> HandlerResults:
         raise NotImplementedError("This should have been implemented.")

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -181,8 +181,12 @@ class JobHandler(Handler):
     ):
         self.package_config: PackageConfig = package_config
         self.job_config: Optional[JobConfig] = job_config
-        self.event_type = EventType(event.get("event_type"))
-        self.trigger = TheJobTriggerType(event.get("trigger"))
+        self.event_type = (
+            EventType(event.get("event_type")) if event.get("event_type") else None
+        )
+        self.trigger = (
+            TheJobTriggerType(event.get("trigger")) if event.get("trigger") else None
+        )
         self.user_login = event.get("user_login")
         self.trigger_id = event.get("trigger_id")
         self.project_url = event.get("project_url")

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -178,7 +178,6 @@ class JobHandler(Handler):
         package_config: PackageConfig,
         job_config: Optional[JobConfig],
         data: EventData,
-        **kwargs,
     ):
         self.package_config = package_config
         self.job_config = job_config

--- a/packit_service/worker/handlers/comment_action_handler.py
+++ b/packit_service/worker/handlers/comment_action_handler.py
@@ -27,11 +27,12 @@ This file defines classes for issue/pr comments which are sent by a git forge.
 import enum
 import logging
 
-from typing import Dict, Type, Optional
+from typing import Dict, Type
 
 from packit.config import PackageConfig, JobConfig
 from packit_service.worker.handlers import JobHandler
 from packit_service.worker.result import HandlerResults
+from packit_service.service.events import EventData
 
 logger = logging.getLogger(__name__)
 
@@ -76,10 +77,13 @@ class CommentActionHandler(JobHandler):
     def __init__(
         self,
         package_config: PackageConfig,
-        job_config: Optional[JobConfig],
-        event: dict,
+        job_config: JobConfig,
+        data: EventData,
+        **kwargs
     ):
-        super().__init__(package_config, job_config, event)
+        super().__init__(
+            package_config=package_config, job_config=job_config, data=data,
+        )
 
     def run(self) -> HandlerResults:
         raise NotImplementedError("This should have been implemented.")

--- a/packit_service/worker/handlers/comment_action_handler.py
+++ b/packit_service/worker/handlers/comment_action_handler.py
@@ -26,19 +26,11 @@ This file defines classes for issue/pr comments which are sent by a git forge.
 
 import enum
 import logging
-from typing import Dict, Type, Union
 
-from packit.config.job_config import JobConfig
+from typing import Dict, Type, Optional
 
-from packit_service.config import ServiceConfig
-from packit_service.service.events import (
-    PullRequestCommentGithubEvent,
-    IssueCommentEvent,
-    PullRequestCommentPagureEvent,
-    MergeRequestCommentGitlabEvent,
-    IssueCommentGitlabEvent,
-)
-from packit_service.worker.handlers import Handler
+from packit.config import PackageConfig, JobConfig
+from packit_service.worker.handlers import JobHandler
 from packit_service.worker.result import HandlerResults
 
 logger = logging.getLogger(__name__)
@@ -78,30 +70,17 @@ def add_to_comment_action_mapping_with_name(name: CommentAction):
     return add_to_comment_action_mapping_with_name_inner
 
 
-class CommentActionHandler(Handler):
+class CommentActionHandler(JobHandler):
     type: CommentAction
 
     def __init__(
         self,
-        config: ServiceConfig,
-        event: Union[
-            PullRequestCommentGithubEvent,
-            IssueCommentEvent,
-            PullRequestCommentPagureEvent,
-            MergeRequestCommentGitlabEvent,
-            IssueCommentGitlabEvent,
-        ],
-        job: JobConfig,
+        package_config: PackageConfig,
+        job_config: Optional[JobConfig],
+        event: dict,
     ):
-        super().__init__(config)
-        self.event: Union[
-            PullRequestCommentGithubEvent,
-            IssueCommentEvent,
-            PullRequestCommentPagureEvent,
-            MergeRequestCommentGitlabEvent,
-            IssueCommentGitlabEvent,
-        ] = event
-        self.job = job
+        super().__init__(package_config, job_config, event)
+        self.identifier = event.get("pr_id") or event.get("issue_id")
 
     def run(self) -> HandlerResults:
         raise NotImplementedError("This should have been implemented.")

--- a/packit_service/worker/handlers/comment_action_handler.py
+++ b/packit_service/worker/handlers/comment_action_handler.py
@@ -80,7 +80,6 @@ class CommentActionHandler(JobHandler):
         event: dict,
     ):
         super().__init__(package_config, job_config, event)
-        self.identifier = event.get("pr_id") or event.get("issue_id")
 
     def run(self) -> HandlerResults:
         raise NotImplementedError("This should have been implemented.")

--- a/packit_service/worker/handlers/fedmsg_handlers.py
+++ b/packit_service/worker/handlers/fedmsg_handlers.py
@@ -26,7 +26,7 @@ This file defines classes for job handlers specific for Fedmsg events
 
 import logging
 from datetime import datetime
-from typing import Type
+from typing import Type, Optional
 
 from ogr.abstract import CommitStatus
 from ogr.services.github import GithubProject
@@ -34,13 +34,12 @@ from packit.api import PackitAPI
 from packit.config import (
     JobType,
     JobConfig,
-    get_package_config_from_repo,
     JobConfigTriggerType,
+    PackageConfig,
 )
 from packit.distgit import DistGit
 from packit.local_project import LocalProject
 from packit.utils import get_namespace_and_repo_name
-from packit_service.config import ServiceConfig
 from packit_service.constants import (
     PG_COPR_BUILD_STATUS_FAILURE,
     PG_COPR_BUILD_STATUS_SUCCESS,
@@ -61,6 +60,9 @@ from packit_service.service.urls import (
     get_copr_build_info_url_from_flask,
     get_koji_build_info_url_from_flask,
 )
+from packit_service.models import CoprBuildModel, AbstractTriggerDbType
+from packit_service.service.events import TheJobTriggerType
+from packit_service.service.urls import get_copr_build_info_url_from_flask
 from packit_service.worker.build.copr_build import CoprBuildJobHelper
 from packit_service.worker.build.koji_build import KojiBuildJobHelper
 from packit_service.worker.handlers.abstract import JobHandler, use_for, required_by
@@ -78,20 +80,17 @@ def add_topic(kls: Type["FedmsgHandler"]):
     return kls
 
 
-def get_copr_build_url(event: CoprBuildEvent) -> str:
-    return (
-        "https://copr.fedorainfracloud.org/coprs/"
-        f"{event.owner}/{event.project_name}/build/{event.build_id}/"
-    )
-
-
 class FedmsgHandler(JobHandler):
     """ Handlers for events from fedmsg """
 
     topic: str
 
-    def __init__(self, config: ServiceConfig, job_config: JobConfig, event: Event):
-        super().__init__(config=config, job_config=job_config, event=event)
+    def __init__(
+        self, package_config: PackageConfig, job_config: JobConfig, event: dict
+    ):
+        super().__init__(
+            package_config=package_config, job_config=job_config, event=event
+        )
         self._pagure_service = None
 
     def run(self) -> HandlerResults:
@@ -107,12 +106,20 @@ class NewDistGitCommitHandler(FedmsgHandler):
     triggers = [TheJobTriggerType.commit]
 
     def __init__(
-        self, config: ServiceConfig, job_config: JobConfig, event: DistGitEvent
+        self,
+        package_config: PackageConfig,
+        job_config: Optional[JobConfig],
+        event: dict,
     ):
-        super().__init__(config=config, job_config=job_config, event=event)
-        self.distgit_event = event
-        self.project = event.get_project()
-        self.package_config = get_package_config_from_repo(self.project, event.git_ref)
+        super().__init__(
+            package_config=package_config, job_config=job_config, event=event,
+        )
+        self.branch = event.get("branch")
+
+        # TODO check these, whether they can be created from the future task info
+        # self.project = event.get_project()
+        # self.package_config = get_package_config_from_repo(self.project, event.git_ref)
+
         if not self.package_config:
             raise ValueError(f"No config file found in {self.project.full_repo_name}")
 
@@ -142,20 +149,61 @@ class NewDistGitCommitHandler(FedmsgHandler):
             # rev is a commit
             # we use branch on purpose so we get the latest thing
             # TODO: check if rev is HEAD on {branch}, warn then?
-            dist_git_branch=self.distgit_event.branch,
+            dist_git_branch=self.branch,
             upstream_branch="master",  # TODO: this should be configurable
         )
         return HandlerResults(success=True, details={})
+
+
+class CoprBuildHandler(FedmsgHandler):
+    def __init__(
+        self, package_config: PackageConfig, job_config: JobConfig, event: dict,
+    ):
+        super().__init__(
+            package_config=package_config, job_config=job_config, event=event
+        )
+        self.project_name = event.get("project_name")
+        self.owner = event.get("owner")
+        self.build_id = event.get("build_id")
+        self.chroot = event.get("chroot")
+        self.pr_id = event.get("pr_id")
+        self.timestamp = event.get("timestamp")
+        self.pkg = event.get("pkg")
+        self._build = None
+
+    def get_copr_build_url(self) -> str:
+        return (
+            "https://copr.fedorainfracloud.org/coprs/"
+            f"{self.owner}/{self.project_name}/build/{self.build_id}/"
+        )
+
+    def get_copr_build_logs_url(self) -> str:
+        return (
+            f"https://copr-be.cloud.fedoraproject.org/results/{self.owner}/"
+            f"{self.project_name}/{self.chroot}/"
+            f"{self.build_id:08d}-{self.pkg}/builder-live.log.gz"
+        )
+
+    @property
+    def build(self):
+        if not self._build:
+            self._build = CoprBuildModel.get_by_build_id(
+                str(self.build_id), self.chroot
+            )
+        return self._build
+
+    @property
+    def db_trigger(self) -> Optional[AbstractTriggerDbType]:
+        return self.build.job_trigger.get_trigger_object()
 
 
 @add_topic
 @use_for(job_type=JobType.copr_build)
 @use_for(job_type=JobType.build)
 @required_by(job_type=JobType.tests)
-class CoprBuildEndHandler(FedmsgHandler):
+class CoprBuildEndHandler(CoprBuildHandler):
     topic = "org.fedoraproject.prod.copr.build.end"
     triggers = [TheJobTriggerType.copr_end]
-    event: CoprBuildEvent
 
     def was_last_packit_comment_with_congratulation(self):
         """
@@ -164,10 +212,7 @@ class CoprBuildEndHandler(FedmsgHandler):
 
         :return: bool
         """
-
-        comments = self.event.project.get_pr_comments(
-            pr_id=self.event.pr_id, reverse=True
-        )
+        comments = self.project.get_pr_comments(pr_id=self.pr_id, reverse=True)
         for comment in comments:
             if comment.author.startswith("packit-as-a-service"):
                 if "Congratulations!" in comment.comment:
@@ -179,60 +224,56 @@ class CoprBuildEndHandler(FedmsgHandler):
     def run(self):
         build_job_helper = CoprBuildJobHelper(
             config=self.config,
-            package_config=self.event.package_config,
-            project=self.event.project,
+            package_config=self.package_config,
+            project=self.project,
             event=self.event,
+            db_trigger=self.db_trigger,
+            job=self.job_config,
         )
 
-        if self.event.chroot == "srpm-builds":
+        if self.chroot == "srpm-builds":
             # we don't want to set check for this
             msg = "SRPM build in copr has finished."
             logger.debug(msg)
             return HandlerResults(success=True, details={"msg": msg})
-        build = CoprBuildModel.get_by_build_id(
-            str(self.event.build_id), self.event.chroot
-        )
-        if not build:
+
+        if not self.build:
             # TODO: how could this happen?
-            msg = f"Copr build {self.event.build_id} not in CoprBuildDB."
+            msg = f"Copr build {self.build_id} not in CoprBuildDB."
             logger.warning(msg)
             return HandlerResults(success=False, details={"msg": msg})
-        if build.status in [
+        if self.build.status in [
             PG_COPR_BUILD_STATUS_FAILURE,
             PG_COPR_BUILD_STATUS_SUCCESS,
         ]:
             msg = (
-                f"Copr build {self.event.build_id} is already"
-                f" processed (status={build.status})."
+                f"Copr build {self.build_id} is already"
+                f" processed (status={self.build.status})."
             )
             logger.info(msg)
             return HandlerResults(success=True, details={"msg": msg})
 
-        end_time = (
-            datetime.utcfromtimestamp(self.event.timestamp)
-            if self.event.timestamp
-            else None
-        )
-        build.set_end_time(end_time)
-        url = get_copr_build_info_url_from_flask(build.id)
+        end_time = datetime.utcfromtimestamp(self.timestamp) if self.timestamp else None
+        self.build.set_end_time(end_time)
+        url = get_copr_build_info_url_from_flask(self.build.id)
 
         # https://pagure.io/copr/copr/blob/master/f/common/copr_common/enums.py#_42
-        if self.event.status != COPR_API_SUCC_STATE:
+        if self.status != COPR_API_SUCC_STATE:
             failed_msg = "RPMs failed to be built."
             build_job_helper.report_status_to_all_for_chroot(
                 state=CommitStatus.failure,
                 description=failed_msg,
                 url=url,
-                chroot=self.event.chroot,
+                chroot=self.chroot,
             )
-            build.set_status(PG_COPR_BUILD_STATUS_FAILURE)
+            self.build.set_status(PG_COPR_BUILD_STATUS_FAILURE)
             return HandlerResults(success=False, details={"msg": failed_msg})
 
         if (
             build_job_helper.job_build
             and build_job_helper.job_build.trigger == JobConfigTriggerType.pull_request
             and self.event.pr_id
-            and isinstance(self.event.project, GithubProject)
+            and isinstance(self.project, GithubProject)
             and not self.was_last_packit_comment_with_congratulation()
             and self.event.package_config.notifications.pull_request.successful_build
         ):
@@ -241,35 +282,32 @@ class CoprBuildEndHandler(FedmsgHandler):
                 "You can install the built RPMs by following these steps:\n\n"
                 "* `sudo yum install -y dnf-plugins-core` on RHEL 8\n"
                 "* `sudo dnf install -y dnf-plugins-core` on Fedora\n"
-                f"* `dnf copr enable {self.event.owner}/{self.event.project_name}`\n"
+                f"* `dnf copr enable {self.owner}/{self.project_name}`\n"
                 "* And now you can install the packages.\n"
                 "\nPlease note that the RPMs should be used only in a testing environment."
             )
-            self.event.project.pr_comment(pr_id=self.event.pr_id, body=msg)
+            self.project.pr_comment(pr_id=self.pr_id, body=msg)
 
         build_job_helper.report_status_to_build_for_chroot(
             state=CommitStatus.success,
             description="RPMs were built successfully.",
             url=url,
-            chroot=self.event.chroot,
+            chroot=self.chroot,
         )
         build_job_helper.report_status_to_test_for_chroot(
             state=CommitStatus.pending,
             description="RPMs were built successfully.",
             url=url,
-            chroot=self.event.chroot,
+            chroot=self.chroot,
         )
-        build.set_status(PG_COPR_BUILD_STATUS_SUCCESS)
+        self.build.set_status(PG_COPR_BUILD_STATUS_SUCCESS)
 
-        if (
-            build_job_helper.job_tests
-            and self.event.chroot in build_job_helper.tests_targets
-        ):
+        if build_job_helper.job_tests and self.chroot in build_job_helper.tests_targets:
             testing_farm_handler = GithubTestingFarmHandler(
                 config=self.config,
                 job_config=build_job_helper.job_tests,
                 event=self.event,
-                chroot=self.event.chroot,
+                chroot=self.chroot,
             )
             testing_farm_handler.run()
         else:
@@ -282,53 +320,47 @@ class CoprBuildEndHandler(FedmsgHandler):
 @use_for(job_type=JobType.copr_build)
 @use_for(job_type=JobType.build)
 @required_by(job_type=JobType.tests)
-class CoprBuildStartHandler(FedmsgHandler):
+class CoprBuildStartHandler(CoprBuildHandler):
     topic = "org.fedoraproject.prod.copr.build.start"
     triggers = [TheJobTriggerType.copr_start]
-    event: CoprBuildEvent
 
     def run(self):
         build_job_helper = CoprBuildJobHelper(
             config=self.config,
-            package_config=self.event.package_config,
-            project=self.event.project,
+            package_config=self.package_config,
+            project=self.project,
             event=self.event,
+            db_trigger=self.db_trigger,
+            job=self.job_config,
         )
 
-        if self.event.chroot == "srpm-builds":
+        if self.chroot == "srpm-builds":
             # we don't want to set the check status for this
             msg = "SRPM build in copr has started."
             logger.debug(msg)
             return HandlerResults(success=True, details={"msg": msg})
 
-        # TODO: drop the code below once we move to PG completely; the build is present in event
-        # pg
-        build = CoprBuildModel.get_by_build_id(
-            str(self.event.build_id), self.event.chroot
-        )
-        if not build:
-            msg = f"Copr build {self.event.build_id} not in CoprBuildDB."
+        if not self.build:
+            msg = f"Copr build {self.build_id} not in CoprBuildDB."
             logger.warning(msg)
             return HandlerResults(success=False, details={"msg": msg})
 
         start_time = (
-            datetime.utcfromtimestamp(self.event.timestamp)
-            if self.event.timestamp
-            else None
+            datetime.utcfromtimestamp(self.timestamp) if self.timestamp else None
         )
-        build.set_start_time(start_time)
-        url = get_copr_build_info_url_from_flask(build.id)
-        build.set_status("pending")
-        copr_build_logs = get_copr_build_logs_url(self.event)
-        build.set_build_logs_url(copr_build_logs)
+        self.build.set_start_time(start_time)
+        url = get_copr_build_info_url_from_flask(self.build.id)
+        self.build.set_status("pending")
+        copr_build_logs = self.get_copr_build_logs_url()
+        self.build.set_build_logs_url(copr_build_logs)
 
         build_job_helper.report_status_to_all_for_chroot(
             description="RPM build is in progress...",
             state=CommitStatus.pending,
             url=url,
-            chroot=self.event.chroot,
+            chroot=self.chroot,
         )
-        msg = f"Build on {self.event.chroot} in copr has started..."
+        msg = f"Build on {self.chroot} in copr has started..."
         return HandlerResults(success=True, details={"msg": msg})
 
 

--- a/packit_service/worker/handlers/fedmsg_handlers.py
+++ b/packit_service/worker/handlers/fedmsg_handlers.py
@@ -158,6 +158,7 @@ class CoprBuildHandler(FedmsgHandler):
         self.pr_id = event.get("pr_id")
         self.timestamp = event.get("timestamp")
         self.pkg = event.get("pkg")
+        self.status = event.get("status")
         self._build = None
 
     def get_copr_build_url(self) -> str:
@@ -261,10 +262,10 @@ class CoprBuildEndHandler(CoprBuildHandler):
         if (
             build_job_helper.job_build
             and build_job_helper.job_build.trigger == JobConfigTriggerType.pull_request
-            and self.event.pr_id
+            and self.pr_id
             and isinstance(self.project, GithubProject)
             and not self.was_last_packit_comment_with_congratulation()
-            and self.event.package_config.notifications.pull_request.successful_build
+            and self.package_config.notifications.pull_request.successful_build
         ):
             msg = (
                 f"Congratulations! One of the builds has completed. :champagne:\n\n"
@@ -293,10 +294,11 @@ class CoprBuildEndHandler(CoprBuildHandler):
 
         if build_job_helper.job_tests and self.chroot in build_job_helper.tests_targets:
             testing_farm_handler = GithubTestingFarmHandler(
-                config=self.config,
+                package_config=self.package_config,
                 job_config=build_job_helper.job_tests,
                 event=self.event,
                 chroot=self.chroot,
+                db_trigger=self.db_trigger,
             )
             testing_farm_handler.run()
         else:

--- a/packit_service/worker/handlers/fedmsg_handlers.py
+++ b/packit_service/worker/handlers/fedmsg_handlers.py
@@ -160,6 +160,7 @@ class CoprBuildHandler(FedmsgHandler):
         self.pkg = event.get("pkg")
         self.status = event.get("status")
         self._build = None
+        self._db_trigger = None
 
     def get_copr_build_url(self) -> str:
         return (
@@ -184,7 +185,9 @@ class CoprBuildHandler(FedmsgHandler):
 
     @property
     def db_trigger(self) -> Optional[AbstractTriggerDbType]:
-        return self.build.job_trigger.get_trigger_object()
+        if not self._db_trigger:
+            self._db_trigger = self.build.job_trigger.get_trigger_object()
+        return self._db_trigger
 
 
 @add_topic

--- a/packit_service/worker/handlers/fedmsg_handlers.py
+++ b/packit_service/worker/handlers/fedmsg_handlers.py
@@ -84,11 +84,7 @@ class FedmsgHandler(JobHandler):
     topic: str
 
     def __init__(
-        self,
-        package_config: PackageConfig,
-        job_config: JobConfig,
-        data: EventData,
-        **kwargs,
+        self, package_config: PackageConfig, job_config: JobConfig, data: EventData,
     ):
         super().__init__(
             package_config=package_config, job_config=job_config, data=data,
@@ -108,16 +104,12 @@ class NewDistGitCommitHandler(FedmsgHandler):
     triggers = [TheJobTriggerType.commit]
 
     def __init__(
-        self,
-        package_config: PackageConfig,
-        job_config: JobConfig,
-        data: EventData,
-        event: dict,
+        self, package_config: PackageConfig, job_config: JobConfig, data: EventData,
     ):
         super().__init__(
             package_config=package_config, job_config=job_config, data=data,
         )
-        self.branch = event.get("branch")
+        self.branch = data.event_dict.get("branch")
 
     def run(self) -> HandlerResults:
         # self.project is dist-git, we need to get upstream
@@ -153,23 +145,19 @@ class NewDistGitCommitHandler(FedmsgHandler):
 
 class AbstractCoprBuildReportHandler(FedmsgHandler):
     def __init__(
-        self,
-        package_config: PackageConfig,
-        job_config: JobConfig,
-        data: EventData,
-        event: dict,
+        self, package_config: PackageConfig, job_config: JobConfig, data: EventData,
     ):
         super().__init__(
             package_config=package_config, job_config=job_config, data=data,
         )
-        topic = event.get("topic")
-        project_name = event.get("project_name")
-        owner = event.get("owner")
-        build_id = event.get("build_id")
-        chroot = event.get("chroot")
-        timestamp = event.get("timestamp")
-        pkg = event.get("pkg")
-        status = event.get("status")
+        topic = data.event_dict.get("topic")
+        project_name = data.event_dict.get("project_name")
+        owner = data.event_dict.get("owner")
+        build_id = data.event_dict.get("build_id")
+        chroot = data.event_dict.get("chroot")
+        timestamp = data.event_dict.get("timestamp")
+        pkg = data.event_dict.get("pkg")
+        status = data.event_dict.get("status")
 
         self.copr_event = CoprBuildEvent.from_build_id(
             topic=topic,
@@ -385,23 +373,25 @@ class KojiBuildReportHandler(FedmsgHandler):
     triggers = [TheJobTriggerType.koji_results]
 
     def __init__(
-        self,
-        package_config: PackageConfig,
-        job_config: JobConfig,
-        data: EventData,
-        event: dict,
+        self, package_config: PackageConfig, job_config: JobConfig, data: EventData,
     ):
         super().__init__(
             package_config=package_config, job_config=job_config, data=data,
         )
-        build_id = event.get("build_id")
-        state = KojiBuildState(event.get("state")) if event.get("state") else None
-        old_state = (
-            KojiBuildState(event.get("old_state")) if event.get("old_state") else None
+        build_id = data.event_dict.get("build_id")
+        state = (
+            KojiBuildState(data.event_dict.get("state"))
+            if data.event_dict.get("state")
+            else None
         )
-        start_time = event.get("start_time")
-        rpm_build_task_id = event.get("rpm_build_task_id")
-        completion_time = event.get("completion_time")
+        old_state = (
+            KojiBuildState(data.event_dict.get("old_state"))
+            if data.event_dict.get("old_state")
+            else None
+        )
+        start_time = data.event_dict.get("start_time")
+        rpm_build_task_id = data.event_dict.get("rpm_build_task_id")
+        completion_time = data.event_dict.get("completion_time")
 
         self.koji_event = KojiBuildEvent(
             build_id=build_id,

--- a/packit_service/worker/handlers/fedmsg_handlers.py
+++ b/packit_service/worker/handlers/fedmsg_handlers.py
@@ -105,13 +105,6 @@ class NewDistGitCommitHandler(FedmsgHandler):
         )
         self.branch = event.get("branch")
 
-        # TODO check these, whether they can be created from the future task info
-        # self.project = event.get_project()
-        # self.package_config = get_package_config_from_repo(self.project, event.git_ref)
-
-        if not self.package_config:
-            raise ValueError(f"No config file found in {self.project.full_repo_name}")
-
     def run(self) -> HandlerResults:
         # self.project is dist-git, we need to get upstream
         dg = DistGit(self.config, self.package_config)

--- a/packit_service/worker/handlers/github_handlers.py
+++ b/packit_service/worker/handlers/github_handlers.py
@@ -79,25 +79,21 @@ class GithubAppInstallationHandler(JobHandler):
     # https://developer.github.com/v3/activity/events/types/#events-api-payload-28
 
     def __init__(
-        self,
-        package_config: PackageConfig,
-        job_config: JobConfig,
-        data: EventData,
-        event: dict,
+        self, package_config: PackageConfig, job_config: JobConfig, data: EventData,
     ):
         super().__init__(
             package_config=package_config, job_config=job_config, data=data,
         )
-        self.account_type = event.get("account_type")
-        self.account_login = event.get("account_login")
-        self.sender_login = event.get("sender_login")
+        self.account_type = data.event_dict.get("account_type")
+        self.account_login = data.event_dict.get("account_login")
+        self.sender_login = data.event_dict.get("sender_login")
 
-        account_id = event.get("account_id")
-        account_url = event.get("account_url")
-        sender_id = event.get("sender_id")
-        created_at = event.get("created_at")
-        installation_id = event.get("installation_id")
-        repositories = event.get("repositories")
+        account_id = data.event_dict.get("account_id")
+        account_url = data.event_dict.get("account_url")
+        sender_id = data.event_dict.get("sender_id")
+        created_at = data.event_dict.get("created_at")
+        installation_id = data.event_dict.get("installation_id")
+        repositories = data.event_dict.get("repositories")
 
         self.installation_event = InstallationEvent(
             installation_id=installation_id,
@@ -205,11 +201,7 @@ class AbstractCoprBuildHandler(JobHandler):
     type = JobType.copr_build
 
     def __init__(
-        self,
-        package_config: PackageConfig,
-        job_config: JobConfig,
-        data: EventData,
-        **kwargs,
+        self, package_config: PackageConfig, job_config: JobConfig, data: EventData,
     ):
         super().__init__(
             package_config=package_config, job_config=job_config, data=data,
@@ -338,11 +330,7 @@ class AbstractGithubKojiBuildHandler(JobHandler):
     type = JobType.production_build
 
     def __init__(
-        self,
-        package_config: PackageConfig,
-        job_config: JobConfig,
-        data: EventData,
-        **kwargs,
+        self, package_config: PackageConfig, job_config: JobConfig, data: EventData,
     ):
         super().__init__(
             package_config=package_config, job_config=job_config, data=data,

--- a/packit_service/worker/handlers/github_handlers.py
+++ b/packit_service/worker/handlers/github_handlers.py
@@ -38,7 +38,7 @@ from packit.exceptions import PackitException
 from packit.local_project import LocalProject
 from packit_service import sentry_integration
 from packit_service.constants import PERMISSIONS_ERROR_WRITE_OR_ADMIN
-from packit_service.models import InstallationModel
+from packit_service.models import InstallationModel, AbstractTriggerDbType
 from packit_service.service.events import TheJobTriggerType, EventType
 from packit_service.worker.build import CoprBuildJobHelper
 from packit_service.worker.build.koji_build import KojiBuildJobHelper
@@ -458,11 +458,17 @@ class GithubTestingFarmHandler(JobHandler):
         job_config: JobConfig,
         event: dict,
         chroot: str,
+        db_trigger: AbstractTriggerDbType,
     ):
         super().__init__(
             package_config=package_config, job_config=job_config, event=event
         )
         self.chroot = chroot
+        self._db_trigger = db_trigger
+
+    @property
+    def db_trigger(self):
+        return self._db_trigger
 
     def run(self) -> HandlerResults:
         # TODO: once we turn hanadlers into respective celery tasks, we should iterate

--- a/packit_service/worker/handlers/github_handlers.py
+++ b/packit_service/worker/handlers/github_handlers.py
@@ -24,7 +24,7 @@
 This file defines classes for job handlers specific for Github hooks
 """
 import logging
-from typing import Union, Any, Optional, Callable, Set
+from typing import Optional, Callable, Set
 
 from ogr.abstract import GitProject, CommitStatus
 from packit.api import PackitAPI
@@ -37,25 +37,9 @@ from packit.config.aliases import get_branches
 from packit.exceptions import PackitException
 from packit.local_project import LocalProject
 from packit_service import sentry_integration
-from packit_service.config import ServiceConfig
 from packit_service.constants import PERMISSIONS_ERROR_WRITE_OR_ADMIN
 from packit_service.models import InstallationModel
-from packit_service.service.events import (
-    PullRequestGithubEvent,
-    InstallationEvent,
-    ReleaseEvent,
-    PullRequestCommentGithubEvent,
-    IssueCommentEvent,
-    CoprBuildEvent,
-    PushGitHubEvent,
-    TheJobTriggerType,
-    PullRequestPagureEvent,
-    PushPagureEvent,
-    Event,
-    PushGitlabEvent,
-    MergeRequestGitlabEvent,
-    MergeRequestCommentGitlabEvent,
-)
+from packit_service.service.events import TheJobTriggerType, EventType
 from packit_service.worker.build import CoprBuildJobHelper
 from packit_service.worker.build.koji_build import KojiBuildJobHelper
 from packit_service.worker.handlers import (
@@ -78,34 +62,24 @@ from packit_service.worker.whitelist import Whitelist
 logger = logging.getLogger(__name__)
 
 
-class AbstractGitForgeJobHandler(JobHandler):
-    def __init__(
-        self, config: ServiceConfig, job_config: Optional[JobConfig], event: Event
-    ):
-        super().__init__(config, job_config, event)
-        # lazy property
-        self._package_config: Optional[PackageConfig] = None
-
-
-class GithubAppInstallationHandler(AbstractGitForgeJobHandler):
+class GithubAppInstallationHandler(JobHandler):
     type = JobType.add_to_whitelist
     triggers = [TheJobTriggerType.installation]
-    event: InstallationEvent
 
     # https://developer.github.com/v3/activity/events/types/#events-api-payload-28
 
     def __init__(
         self,
-        config: ServiceConfig,
+        package_config: PackageConfig,
         job_config: Optional[JobConfig],
-        event: Union[InstallationEvent, Any],
+        event: dict,
     ):
-        super().__init__(config=config, job_config=job_config, event=event)
-
-        self.event = event
-        self.project = self.config.get_project(
-            url="https://github.com/packit-service/notifications"
+        super().__init__(
+            package_config=package_config, job_config=job_config, event=event,
         )
+        self.account_type = event.get("account_type")
+        self.account_login = event.get("account_login")
+        self.sender_login = event.get("sender_login")
 
     def run(self) -> HandlerResults:
         """
@@ -119,38 +93,41 @@ class GithubAppInstallationHandler(AbstractGitForgeJobHandler):
         whitelist = Whitelist(
             fas_user=self.config.fas_user, fas_password=self.config.fas_password,
         )
-        account_login = self.event.account_login
-        account_type = self.event.account_type
-        if not whitelist.add_account(self.event):
+        if not whitelist.add_account(self.account_login, self.sender_login):
             # Create an issue in our repository, so we are notified when someone install the app
             self.project.create_issue(
-                title=f"{account_type} {account_login} needs to be approved.",
+                title=f"{self.account_type} {self.account_login} needs to be approved.",
                 body=(
-                    f"Hi @{self.event.sender_login}, we need to approve you in "
+                    f"Hi @{self.sender_login}, we need to approve you in "
                     "order to start using Packit-as-a-Service. Someone from our team will "
                     "get back to you shortly.\n\n"
                     "For more info, please check out the documentation: "
                     "http://packit.dev/packit-as-a-service/"
                 ),
             )
-            msg = f"{account_type} {account_login} needs to be approved manually!"
+            msg = f"{self.account_type} {self.account_login} needs to be approved manually!"
         else:
-            msg = f"{account_type} {account_login} whitelisted!"
+            msg = f"{self.account_type} {self.account_login} whitelisted!"
 
         logger.info(msg)
         return HandlerResults(success=True, details={"msg": msg})
 
 
 @use_for(job_type=JobType.propose_downstream)
-class ProposeDownstreamHandler(AbstractGitForgeJobHandler):
+class ProposeDownstreamHandler(JobHandler):
     type = JobType.propose_downstream
     triggers = [TheJobTriggerType.release]
-    event: ReleaseEvent
 
     def __init__(
-        self, config: ServiceConfig, job_config: JobConfig, event: ReleaseEvent
+        self,
+        package_config: PackageConfig,
+        job_config: Optional[JobConfig],
+        event: dict,
     ):
-        super().__init__(config=config, job_config=job_config, event=event)
+        super().__init__(
+            package_config=package_config, job_config=job_config, event=event,
+        )
+        self.tag_name = event.get("tag_name")
 
     def run(self) -> HandlerResults:
         """
@@ -158,20 +135,17 @@ class ProposeDownstreamHandler(AbstractGitForgeJobHandler):
         """
 
         self.local_project = LocalProject(
-            git_project=self.event.project,
-            working_dir=self.config.command_handler_work_dir,
+            git_project=self.project, working_dir=self.config.command_handler_work_dir,
         )
 
-        self.api = PackitAPI(self.config, self.event.package_config, self.local_project)
+        self.api = PackitAPI(self.config, self.package_config, self.local_project)
 
         errors = {}
         for branch in get_branches(
             *self.job_config.metadata.dist_git_branches, default="master"
         ):
             try:
-                self.api.sync_release(
-                    dist_git_branch=branch, version=self.event.tag_name
-                )
+                self.api.sync_release(dist_git_branch=branch, version=self.tag_name)
             except Exception as ex:
                 sentry_integration.send_to_sentry(ex)
                 errors[branch] = str(ex)
@@ -193,8 +167,8 @@ class ProposeDownstreamHandler(AbstractGitForgeJobHandler):
                 " to the issue comment.\n"
             )
 
-            self.event.project.create_issue(
-                title=f"[packit] Propose update failed for release {self.event.tag_name}",
+            self.project.create_issue(
+                title=f"[packit] Propose update failed for release {self.tag_name}",
                 body=body_msg,
             )
 
@@ -206,45 +180,31 @@ class ProposeDownstreamHandler(AbstractGitForgeJobHandler):
         return HandlerResults(success=True, details={})
 
 
-class AbstractCoprBuildHandler(AbstractGitForgeJobHandler):
+class AbstractCoprBuildHandler(JobHandler):
     type = JobType.copr_build
-    event: Union[
-        PullRequestGithubEvent,
-        ReleaseEvent,
-        PushGitHubEvent,
-        PullRequestPagureEvent,
-        MergeRequestGitlabEvent,
-        PushGitlabEvent,
-    ]
 
     def __init__(
         self,
-        config: ServiceConfig,
-        job_config: JobConfig,
-        event: Union[
-            PullRequestGithubEvent,
-            ReleaseEvent,
-            PushGitHubEvent,
-            PullRequestPagureEvent,
-            PushPagureEvent,
-            MergeRequestGitlabEvent,
-            PushGitlabEvent,
-        ],
+        package_config: PackageConfig,
+        job_config: Optional[JobConfig],
+        event: dict,
     ):
-        super().__init__(config=config, job_config=job_config, event=event)
+        super().__init__(
+            package_config=package_config, job_config=job_config, event=event,
+        )
 
         # lazy property
         self._copr_build_helper: Optional[CoprBuildJobHelper] = None
-        self._project: Optional[GitProject] = None
 
     @property
     def copr_build_helper(self) -> CoprBuildJobHelper:
         if not self._copr_build_helper:
             self._copr_build_helper = CoprBuildJobHelper(
                 config=self.config,
-                package_config=self.event.package_config,
-                project=self.event.project,
+                package_config=self.package_config,
+                project=self.project,
                 event=self.event,
+                db_trigger=self.db_trigger,
                 job=self.job_config,
             )
         return self._copr_build_helper
@@ -258,7 +218,7 @@ class AbstractCoprBuildHandler(AbstractGitForgeJobHandler):
         ] = lambda job: job.type == JobType.copr_build
 
         if self.job_config.type == JobType.tests and any(
-            filter(is_copr_build, self.event.package_config.jobs)
+            filter(is_copr_build, self.package_config.jobs)
         ):
             logger.info(
                 "Skipping build for testing. The COPR build is defined in the config."
@@ -275,12 +235,10 @@ class ReleaseCoprBuildHandler(AbstractCoprBuildHandler):
         TheJobTriggerType.release,
     ]
 
-    event: ReleaseEvent
-
     def pre_check(self) -> bool:
         return (
-            isinstance(self.event, ReleaseEvent)
-            and self.event.trigger == TheJobTriggerType.release
+            self.event_type == EventType.release
+            and self.trigger == TheJobTriggerType.release
             and super().pre_check()
         )
 
@@ -292,12 +250,11 @@ class PullRequestCoprBuildHandler(AbstractCoprBuildHandler):
     triggers = [
         TheJobTriggerType.pull_request,
     ]
-    event: PullRequestGithubEvent
 
     def run(self) -> HandlerResults:
-        if isinstance(self.event, (PullRequestGithubEvent, MergeRequestGitlabEvent)):
-            user_can_merge_pr = self.event.project.can_merge_pr(self.event.user_login)
-            if not (user_can_merge_pr or self.event.user_login in self.config.admins):
+        if self.event_type in (EventType.pull_request_gh, EventType.merge_request_gl):
+            user_can_merge_pr = self.project.can_merge_pr(self.user_login)
+            if not (user_can_merge_pr or self.user_login in self.config.admins):
                 self.copr_build_helper.report_status_to_all(
                     description=PERMISSIONS_ERROR_WRITE_OR_ADMIN,
                     state=CommitStatus.failure,
@@ -309,15 +266,8 @@ class PullRequestCoprBuildHandler(AbstractCoprBuildHandler):
 
     def pre_check(self) -> bool:
         return (
-            isinstance(
-                self.event,
-                (
-                    PullRequestGithubEvent,
-                    PullRequestPagureEvent,
-                    MergeRequestGitlabEvent,
-                ),
-            )
-            and self.event.trigger == TheJobTriggerType.pull_request
+            self.event_type in (EventType.pull_request_gh, EventType.pull_request_pg, EventType.merge_request_gl)
+            and self.trigger == TheJobTriggerType.pull_request
             and super().pre_check()
         )
 
@@ -330,41 +280,50 @@ class PushCoprBuildHandler(AbstractCoprBuildHandler):
         TheJobTriggerType.push,
         TheJobTriggerType.commit,
     ]
-    event: PushGitHubEvent
+
+    def __init__(
+        self,
+        package_config: PackageConfig,
+        job_config: Optional[JobConfig],
+        event: dict,
+    ):
+        super().__init__(
+            package_config=package_config, job_config=job_config, event=event,
+        )
+        self.git_ref = event.get("git_ref")
 
     def pre_check(self) -> bool:
         valid = (
-            isinstance(self.event, (PushGitHubEvent, PushPagureEvent, PushGitlabEvent))
-            and self.event.trigger == TheJobTriggerType.push
+            self.event_type in (EventType.push_gh, EventType.push_pagure, EventType.push_gl)
+            and self.trigger == TheJobTriggerType.push
             and super().pre_check()
         )
         if not valid:
             return False
 
         configured_branch = self.copr_build_helper.job_build_branch
-        if self.event.git_ref != configured_branch:
+        if self.git_ref != configured_branch:
             logger.info(
-                f"Skipping build on '{self.event.git_ref}'. "
+                f"Skipping build on '{self.git_ref}'. "
                 f"Push configured only for '{configured_branch}'."
             )
             return False
         return True
 
 
-class AbstractGithubKojiBuildHandler(AbstractGitForgeJobHandler):
+class AbstractGithubKojiBuildHandler(JobHandler):
     type = JobType.production_build
-    event: Union[PullRequestGithubEvent, ReleaseEvent, PushGitHubEvent]
 
     def __init__(
-        self,
-        config: ServiceConfig,
-        job_config: JobConfig,
-        event: Union[PullRequestGithubEvent, ReleaseEvent, PushGitHubEvent],
+        self, package_config: PackageConfig, job_config: JobConfig, event: dict
     ):
-        super().__init__(config=config, job_config=job_config, event=event)
+        super().__init__(
+            package_config=package_config, job_config=job_config, event=event,
+        )
 
-        if not isinstance(
-            event, (PullRequestGithubEvent, PushGitHubEvent, ReleaseEvent)
+        if not (
+            self.event_type
+            in (EventType.pull_request_gh, EventType.push_gh, EventType.release)
         ):
             raise PackitException(
                 "Unknown event, only "
@@ -381,9 +340,10 @@ class AbstractGithubKojiBuildHandler(AbstractGitForgeJobHandler):
         if not self._koji_build_helper:
             self._koji_build_helper = KojiBuildJobHelper(
                 config=self.config,
-                package_config=self.event.package_config,
-                project=self.event.project,
+                package_config=self.package_config,
+                project=self.project,
                 event=self.event,
+                db_trigger=self.db_trigger,
                 job=self.job_config,
             )
         return self._koji_build_helper
@@ -397,7 +357,7 @@ class AbstractGithubKojiBuildHandler(AbstractGitForgeJobHandler):
         ] = lambda job: job.type == JobType.copr_build
 
         if self.job_config.type == JobType.tests and any(
-            filter(is_copr_build, self.event.package_config.jobs)
+            filter(is_copr_build, self.package_config.jobs)
         ):
             logger.info(
                 "Skipping build for testing. The COPR build is defined in the config."
@@ -412,13 +372,11 @@ class ReleaseGithubKojiBuildHandler(AbstractGithubKojiBuildHandler):
         TheJobTriggerType.release,
     ]
 
-    event: ReleaseEvent
-
     def pre_check(self) -> bool:
         return (
             super().pre_check()
-            and isinstance(self.event, ReleaseEvent)
-            and self.event.trigger == TheJobTriggerType.release
+            and self.event_type == EventType.release
+            and self.trigger == TheJobTriggerType.release
         )
 
 
@@ -427,12 +385,11 @@ class PullRequestGithubKojiBuildHandler(AbstractGithubKojiBuildHandler):
     triggers = [
         TheJobTriggerType.pull_request,
     ]
-    event: PullRequestGithubEvent
 
     def run(self) -> HandlerResults:
-        if isinstance(self.event, PullRequestGithubEvent):
-            user_can_merge_pr = self.event.project.can_merge_pr(self.event.user_login)
-            if not (user_can_merge_pr or self.event.user_login in self.config.admins):
+        if self.event_type == EventType.pull_request_gh:
+            user_can_merge_pr = self.project.can_merge_pr(self.user_login)
+            if not (user_can_merge_pr or self.user_login in self.config.admins):
                 self.koji_build_helper.report_status_to_all(
                     description=PERMISSIONS_ERROR_WRITE_OR_ADMIN,
                     state=CommitStatus.failure,
@@ -445,8 +402,8 @@ class PullRequestGithubKojiBuildHandler(AbstractGithubKojiBuildHandler):
     def pre_check(self) -> bool:
         return (
             super().pre_check()
-            and isinstance(self.event, PullRequestGithubEvent)
-            and self.event.trigger == TheJobTriggerType.pull_request
+            and self.event_type == EventType.pull_request_gh
+            and self.trigger == TheJobTriggerType.pull_request
         )
 
 
@@ -456,44 +413,55 @@ class PushGithubKojiBuildHandler(AbstractGithubKojiBuildHandler):
         TheJobTriggerType.push,
         TheJobTriggerType.commit,
     ]
-    event: PushGitHubEvent
+
+    def __init__(
+        self,
+        package_config: PackageConfig,
+        job_config: Optional[JobConfig],
+        event: dict,
+    ):
+        super().__init__(
+            package_config=package_config, job_config=job_config, event=event,
+        )
+        self.git_ref = event.get("git_ref")
 
     def pre_check(self) -> bool:
         valid = (
             super().pre_check()
-            and isinstance(self.event, PushGitHubEvent)
-            and self.event.trigger == TheJobTriggerType.push
+            and self.event_type == EventType.push_gh
+            and self.trigger == TheJobTriggerType.push
         )
         if not valid:
             return False
 
         configured_branch = self.koji_build_helper.job_build_branch
-        if self.event.git_ref != configured_branch:
+        if self.git_ref != configured_branch:
             logger.info(
-                f"Skipping build on '{self.event.git_ref}'. "
+                f"Skipping build on '{self.git_ref}'. "
                 f"Push configured only for '{configured_branch}'."
             )
             return False
         return True
 
 
-class GithubTestingFarmHandler(AbstractGitForgeJobHandler):
+class GithubTestingFarmHandler(JobHandler):
     """
     This class intentionally does not have a @add_to_mapping decorator as its
     trigger is finished copr build.
     """
 
     triggers = [TheJobTriggerType.pull_request]
-    event: Union[CoprBuildEvent, PullRequestCommentGithubEvent]
 
     def __init__(
         self,
-        config: ServiceConfig,
+        package_config: PackageConfig,
         job_config: JobConfig,
-        event: Union[CoprBuildEvent, PullRequestCommentGithubEvent],
+        event: dict,
         chroot: str,
     ):
-        super().__init__(config=config, job_config=job_config, event=event)
+        super().__init__(
+            package_config=package_config, job_config=job_config, event=event
+        )
         self.chroot = chroot
 
     def run(self) -> HandlerResults:
@@ -501,9 +469,11 @@ class GithubTestingFarmHandler(AbstractGitForgeJobHandler):
         #       here over *all* matching jobs and do them all, not just the first one
         testing_farm_helper = TestingFarmJobHelper(
             config=self.config,
-            package_config=self.event.package_config,
-            project=self.event.project,
+            package_config=self.package_config,
+            project=self.project,
             event=self.event,
+            db_trigger=self.db_trigger,
+            job=self.job_config,
         )
         logger.info("Running testing farm.")
         return testing_farm_helper.run_testing_farm(chroot=self.chroot)
@@ -519,24 +489,22 @@ class GitHubPullRequestCommentCoprBuildHandler(CommentActionHandler):
 
     type = CommentAction.copr_build
     triggers = [TheJobTriggerType.pr_comment]
-    event: PullRequestCommentGithubEvent
 
     def run(self) -> HandlerResults:
-        user_can_merge_pr = self.event.project.can_merge_pr(self.event.user_login)
-        if not (user_can_merge_pr or self.event.user_login in self.config.admins):
-            self.event.project.pr_comment(
-                self.event.pr_id, PERMISSIONS_ERROR_WRITE_OR_ADMIN
-            )
+        user_can_merge_pr = self.project.can_merge_pr(self.user_login)
+        if not (user_can_merge_pr or self.user_login in self.config.admins):
+            self.project.pr_comment(self.identifier, PERMISSIONS_ERROR_WRITE_OR_ADMIN)
             return HandlerResults(
                 success=True, details={"msg": PERMISSIONS_ERROR_WRITE_OR_ADMIN}
             )
 
         cbh = CoprBuildJobHelper(
             config=self.config,
-            package_config=self.event.package_config,
-            project=self.event.project,
+            package_config=self.package_config,
+            project=self.project,
             event=self.event,
-            job=self.job,
+            db_trigger=self.db_trigger,
+            job=self.job_config,
         )
         handler_results = cbh.run_copr_build()
 
@@ -560,7 +528,14 @@ class GitHubIssueCommentProposeUpdateHandler(CommentActionHandler):
 
     type = CommentAction.propose_update
     triggers = [TheJobTriggerType.issue_comment]
-    event: IssueCommentEvent
+
+    def __init__(
+        self, package_config: PackageConfig, job_config: JobConfig, event: dict
+    ):
+        super().__init__(
+            package_config=package_config, job_config=job_config, event=event,
+        )
+        self.tag_name = event.get("tag_name")
 
     @property
     def dist_git_branches_to_sync(self) -> Set[str]:
@@ -570,7 +545,7 @@ class GitHubIssueCommentProposeUpdateHandler(CommentActionHandler):
         :return: list of dist-git branches
         """
         configured_branches = set()
-        configured_branches.update(self.job.metadata.dist_git_branches)
+        configured_branches.update(self.job_config.metadata.dist_git_branches)
 
         if configured_branches:
             return get_branches(*configured_branches)
@@ -578,31 +553,30 @@ class GitHubIssueCommentProposeUpdateHandler(CommentActionHandler):
 
     def run(self) -> HandlerResults:
         local_project = LocalProject(
-            git_project=self.event.project,
-            working_dir=self.config.command_handler_work_dir,
+            git_project=self.project, working_dir=self.config.command_handler_work_dir,
         )
 
         api = PackitAPI(
             config=self.config,
-            package_config=self.event.package_config,
+            package_config=self.package_config,
             upstream_local_project=local_project,
         )
 
-        user_can_merge_pr = self.event.project.can_merge_pr(self.event.user_login)
-        if not (user_can_merge_pr or self.event.user_login in self.config.admins):
-            self.event.project.issue_comment(
-                self.event.issue_id, PERMISSIONS_ERROR_WRITE_OR_ADMIN
+        user_can_merge_pr = self.project.can_merge_pr(self.user_login)
+        if not (user_can_merge_pr or self.user_login in self.config.admins):
+            self.project.issue_comment(
+                self.identifier, PERMISSIONS_ERROR_WRITE_OR_ADMIN
             )
             return HandlerResults(
                 success=True, details={"msg": PERMISSIONS_ERROR_WRITE_OR_ADMIN}
             )
 
-        if not self.event.tag_name:
+        if not self.tag_name:
             msg = (
                 "There was an error while proposing a new update for the Fedora package: "
                 "no upstream release found."
             )
-            self.event.project.issue_comment(self.event.issue_id, msg)
+            self.project.issue_comment(self.identifier, msg)
             return HandlerResults(
                 success=False, details={"msg": "Propose update failed"}
             )
@@ -610,18 +584,18 @@ class GitHubIssueCommentProposeUpdateHandler(CommentActionHandler):
         sync_failed = False
         for branch in self.dist_git_branches_to_sync:
             msg = (
-                f"for the Fedora package `{self.event.package_config.downstream_package_name}`"
-                f"with the tag `{self.event.tag_name}` in the `{branch}` branch.\n"
+                f"for the Fedora package `{self.package_config.downstream_package_name}`"
+                f"with the tag `{self.tag_name}` in the `{branch}` branch.\n"
             )
             try:
                 new_pr = api.sync_release(
-                    dist_git_branch=branch, version=self.event.tag_name, create_pr=True
+                    dist_git_branch=branch, version=self.tag_name, create_pr=True
                 )
                 msg = f"Packit-as-a-Service proposed [a new update]({new_pr.url}) {msg}"
-                self.event.project.issue_comment(self.event.issue_id, msg)
+                self.project.issue_comment(self.identifier, msg)
             except PackitException as ex:
                 msg = f"There was an error while proposing a new update {msg} Traceback is: `{ex}`"
-                self.event.project.issue_comment(self.event.issue_id, msg)
+                self.project.issue_comment(self.identifier, msg)
                 logger.error(f"Error while running a build: {ex}")
                 sync_failed = True
         if sync_failed:
@@ -630,7 +604,7 @@ class GitHubIssueCommentProposeUpdateHandler(CommentActionHandler):
             )
 
         # Close issue if propose-update was successful in all branches
-        self.event.project.issue_close(self.event.issue_id)
+        self.project.issue_close(self.identifier)
 
         return HandlerResults(success=True, details={})
 
@@ -641,22 +615,20 @@ class GitHubPullRequestCommentTestingFarmHandler(CommentActionHandler):
     """ Issue handler for comment `/packit test` """
 
     type = CommentAction.test
-    event: PullRequestCommentGithubEvent
     triggers = [TheJobTriggerType.pr_comment]
 
     def run(self) -> HandlerResults:
         testing_farm_helper = TestingFarmJobHelper(
             config=self.config,
-            package_config=self.event.package_config,
-            project=self.event.project,
+            package_config=self.package_config,
+            project=self.project,
             event=self.event,
-            job=self.job,
+            db_trigger=self.db_trigger,
+            job=self.job_config,
         )
-        user_can_merge_pr = self.event.project.can_merge_pr(self.event.user_login)
-        if not (user_can_merge_pr or self.event.user_login in self.config.admins):
-            self.event.project.pr_comment(
-                self.event.pr_id, PERMISSIONS_ERROR_WRITE_OR_ADMIN
-            )
+        user_can_merge_pr = self.project.can_merge_pr(self.user_login)
+        if not (user_can_merge_pr or self.user_login in self.config.admins):
+            self.project.pr_comment(self.identifier, PERMISSIONS_ERROR_WRITE_OR_ADMIN)
             return HandlerResults(
                 success=True, details={"msg": PERMISSIONS_ERROR_WRITE_OR_ADMIN}
             )

--- a/packit_service/worker/handlers/pagure_handlers.py
+++ b/packit_service/worker/handlers/pagure_handlers.py
@@ -87,20 +87,16 @@ class PagurePullRequestLabelHandler(JobHandler):
     triggers = [TheJobTriggerType.pr_label]
 
     def __init__(
-        self,
-        package_config: PackageConfig,
-        job_config: JobConfig,
-        data: EventData,
-        event: dict,
+        self, package_config: PackageConfig, job_config: JobConfig, data: EventData,
     ):
         super().__init__(
             package_config=package_config, job_config=job_config, data=data
         )
-        self.labels = event.get("labels")
-        self.action = PullRequestLabelAction(event.get("action"))
-        self.base_repo_owner = event.get("base_repo_owner")
-        self.base_repo_name = event.get("base_repo_namespace")
-        self.base_repo_namespace = event.get("base_repo_name")
+        self.labels = data.event_dict.get("labels")
+        self.action = PullRequestLabelAction(data.event_dict.get("action"))
+        self.base_repo_owner = data.event_dict.get("base_repo_owner")
+        self.base_repo_name = data.event_dict.get("base_repo_namespace")
+        self.base_repo_namespace = data.event_dict.get("base_repo_name")
 
         self.pr: PullRequest = self.project.get_pr(self.data.pr_id)
         # lazy properties

--- a/packit_service/worker/handlers/pagure_handlers.py
+++ b/packit_service/worker/handlers/pagure_handlers.py
@@ -28,7 +28,7 @@ from ogr.abstract import CommitStatus, PullRequest
 from packit_service.models import BugzillaModel
 from packit.config import JobType, JobConfig, PackageConfig
 from packit_service.service.events import TheJobTriggerType, PullRequestLabelAction
-from packit_service.worker.build import CoprBuildJobHelper
+from packit_service.worker.build import CoprBuildJobHelper, BuildHelperMetadata
 from packit_service.worker.handlers import CommentActionHandler
 from packit_service.worker.handlers.abstract import use_for, JobHandler
 from packit_service.worker.handlers.comment_action_handler import CommentAction
@@ -54,6 +54,8 @@ class PagurePullRequestCommentCoprBuildHandler(CommentActionHandler):
             package_config=package_config, job_config=job_config, event=event,
         )
 
+        self.build_helper_metadata = BuildHelperMetadata.from_event_dict(event)
+
         # lazy property
         self._copr_build_helper: Optional[CoprBuildJobHelper] = None
 
@@ -64,7 +66,7 @@ class PagurePullRequestCommentCoprBuildHandler(CommentActionHandler):
                 config=self.config,
                 package_config=self.package_config,
                 project=self.project,
-                event=self.event,
+                metadata=self.build_helper_metadata,
                 db_trigger=self.db_trigger,
                 job=self.job_config,
             )

--- a/packit_service/worker/handlers/testing_farm_handlers.py
+++ b/packit_service/worker/handlers/testing_farm_handlers.py
@@ -32,6 +32,7 @@ from packit_service.models import TFTTestRunModel, AbstractTriggerDbType
 from packit_service.service.events import (
     TestingFarmResult,
     TheJobTriggerType,
+    EventData,
 )
 from packit_service.worker.handlers import JobHandler
 from packit_service.worker.handlers.abstract import use_for
@@ -50,11 +51,12 @@ class TestingFarmResultsHandler(JobHandler):
     def __init__(
         self,
         package_config: PackageConfig,
-        job_config: Optional[JobConfig],
+        job_config: JobConfig,
+        data: EventData,
         event: dict,
     ):
         super().__init__(
-            package_config=package_config, job_config=job_config, event=event
+            package_config=package_config, job_config=job_config, data=data,
         )
 
         self.tests = event.get("tests")
@@ -63,7 +65,6 @@ class TestingFarmResultsHandler(JobHandler):
         )
         self.pipeline_id = event.get("pipeline_id")
         self.log_url = event.get("log_url")
-        self.commit_sha = event.get("commit_sha")
         self.copr_chroot = event.get("copr_chroot")
         self.message = event.get("message")
         self._db_trigger: Optional[AbstractTriggerDbType] = None
@@ -109,7 +110,7 @@ class TestingFarmResultsHandler(JobHandler):
 
         if test_run_model:
             test_run_model.set_web_url(self.log_url)
-        status_reporter = StatusReporter(self.project, self.commit_sha)
+        status_reporter = StatusReporter(self.project, self.data.commit_sha)
         status_reporter.report(
             state=status,
             description=short_msg,

--- a/packit_service/worker/handlers/testing_farm_handlers.py
+++ b/packit_service/worker/handlers/testing_farm_handlers.py
@@ -58,7 +58,9 @@ class TestingFarmResultsHandler(JobHandler):
         )
 
         self.tests = event.get("tests")
-        self.result = event.get("result")
+        self.result = (
+            TestingFarmResult(event.get("result")) if event.get("result") else None
+        )
         self.pipeline_id = event.get("pipeline_id")
         self.log_url = event.get("log_url")
         self.commit_sha = event.get("commit_sha")

--- a/packit_service/worker/handlers/testing_farm_handlers.py
+++ b/packit_service/worker/handlers/testing_farm_handlers.py
@@ -49,24 +49,22 @@ class TestingFarmResultsHandler(JobHandler):
     triggers = [TheJobTriggerType.testing_farm_results]
 
     def __init__(
-        self,
-        package_config: PackageConfig,
-        job_config: JobConfig,
-        data: EventData,
-        event: dict,
+        self, package_config: PackageConfig, job_config: JobConfig, data: EventData,
     ):
         super().__init__(
             package_config=package_config, job_config=job_config, data=data,
         )
 
-        self.tests = event.get("tests")
+        self.tests = data.event_dict.get("tests")
         self.result = (
-            TestingFarmResult(event.get("result")) if event.get("result") else None
+            TestingFarmResult(data.event_dict.get("result"))
+            if data.event_dict.get("result")
+            else None
         )
-        self.pipeline_id = event.get("pipeline_id")
-        self.log_url = event.get("log_url")
-        self.copr_chroot = event.get("copr_chroot")
-        self.message = event.get("message")
+        self.pipeline_id = data.event_dict.get("pipeline_id")
+        self.log_url = data.event_dict.get("log_url")
+        self.copr_chroot = data.event_dict.get("copr_chroot")
+        self.message = data.event_dict.get("message")
         self._db_trigger: Optional[AbstractTriggerDbType] = None
 
     @property

--- a/packit_service/worker/handlers/testing_farm_handlers.py
+++ b/packit_service/worker/handlers/testing_farm_handlers.py
@@ -28,7 +28,7 @@ from typing import Optional
 
 from ogr.abstract import CommitStatus
 from packit.config import JobType, JobConfig, PackageConfig
-from packit_service.models import TFTTestRunModel
+from packit_service.models import TFTTestRunModel, AbstractTriggerDbType
 from packit_service.service.events import (
     TestingFarmResult,
     TheJobTriggerType,
@@ -66,6 +66,15 @@ class TestingFarmResultsHandler(JobHandler):
         self.commit_sha = event.get("commit_sha")
         self.copr_chroot = event.get("copr_chroot")
         self.message = event.get("message")
+        self._db_trigger: Optional[AbstractTriggerDbType] = None
+
+    @property
+    def db_trigger(self) -> Optional[AbstractTriggerDbType]:
+        if not self._db_trigger:
+            run_model = TFTTestRunModel.get_by_pipeline_id(pipeline_id=self.pipeline_id)
+            if run_model:
+                self._db_trigger = run_model.job_trigger.get_trigger_object()
+        return self._db_trigger
 
     def run(self) -> HandlerResults:
 

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -358,6 +358,7 @@ class SteveJobs:
             handler_kls=handler_kls, event=event, package_config=event.package_config,
         )
         for job in jobs:
+            # here will be the celery tasks created
             handler_instance: Handler = handler_kls(
                 package_config=event.package_config,
                 job_config=job,

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -240,7 +240,9 @@ class SteveJobs:
             for job_config in job_configs:
                 logger.debug(f"Running handler: {str(handler_kls)} for {job_config}")
                 handler = handler_kls(
-                    config=self.config, job_config=job_config, event=event
+                    package_config=event.package_config,
+                    job_config=job_config,
+                    event=event.get_dict(),
                 )
                 if handler.pre_check():
                     current_time = datetime.datetime.now().strftime(DATETIME_FORMAT)
@@ -357,7 +359,9 @@ class SteveJobs:
         )
         for job in jobs:
             handler_instance: Handler = handler_kls(
-                config=self.config, event=event, job=job
+                package_config=event.package_config,
+                job_config=jobs,
+                event=event.get_dict(),
             )
             result_key = (
                 f"{job.type.value}-{datetime.datetime.now().strftime(DATETIME_FORMAT)}"
@@ -418,14 +422,18 @@ class SteveJobs:
         # not repository, so package config with jobs is missing
         if event_object.trigger == TheJobTriggerType.installation:
             handler = GithubAppInstallationHandler(
-                self.config, job_config=None, event=event_object
+                package_config=event_object.package_config,
+                job_config=None,
+                event=event_object.get_dict(),
             )
             job_type = JobType.add_to_whitelist.value
             jobs_results[job_type] = handler.run_n_clean()
         # Label/Tag added event handler is run even when the job is not configured in package
         elif event_object.trigger == TheJobTriggerType.pr_label:
             handler = PagurePullRequestLabelHandler(
-                self.config, job_config=None, event=event_object
+                package_config=event_object.package_config,
+                job_config=None,
+                event=event_object.get_dict(),
             )
             job_type = JobType.create_bugzilla.value
             jobs_results[job_type] = handler.run_n_clean()

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -245,7 +245,6 @@ class SteveJobs:
                     package_config=event.package_config,
                     job_config=job_config,
                     data=EventData.from_event_dict(event_dict),
-                    event=event_dict,
                 )
                 if handler.pre_check():
                     current_time = datetime.datetime.now().strftime(DATETIME_FORMAT)
@@ -367,7 +366,6 @@ class SteveJobs:
                 package_config=event.package_config,
                 job_config=job,
                 data=EventData.from_event_dict(event_dict),
-                event=event_dict,
             )
             result_key = (
                 f"{job.type.value}-{datetime.datetime.now().strftime(DATETIME_FORMAT)}"
@@ -432,7 +430,6 @@ class SteveJobs:
                 package_config=event_object.package_config,
                 job_config=None,
                 data=EventData.from_event_dict(event_dict),
-                event=event_dict,
             )
             job_type = JobType.add_to_whitelist.value
             jobs_results[job_type] = handler.run_n_clean()
@@ -442,7 +439,6 @@ class SteveJobs:
                 package_config=event_object.package_config,
                 job_config=None,
                 data=EventData.from_event_dict(event_dict),
-                event=event_dict,
             )
             job_type = JobType.create_bugzilla.value
             jobs_results[job_type] = handler.run_n_clean()

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -360,7 +360,7 @@ class SteveJobs:
         for job in jobs:
             handler_instance: Handler = handler_kls(
                 package_config=event.package_config,
-                job_config=jobs,
+                job_config=job,
                 event=event.get_dict(),
             )
             result_key = (

--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -53,7 +53,12 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         job: JobConfig = None,
     ):
         super().__init__(
-            config, package_config, project, event, db_trigger, job,
+            config=config,
+            package_config=package_config,
+            project=project,
+            event=event,
+            db_trigger=db_trigger,
+            job=job,
         )
         self.project_url = event.get("project_url")
 

--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -37,7 +37,8 @@ from packit_service.config import ServiceConfig
 from packit_service.constants import TESTING_FARM_TRIGGER_URL
 from packit_service.models import TFTTestRunModel, TestingFarmResult
 from packit_service.sentry_integration import send_to_sentry
-from packit_service.worker.build import CoprBuildJobHelper, BuildHelperMetadata
+from packit_service.service.events import EventData
+from packit_service.worker.build import CoprBuildJobHelper
 from packit_service.worker.result import HandlerResults
 
 logger = logging.getLogger(__name__)
@@ -49,9 +50,8 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         config: ServiceConfig,
         package_config: PackageConfig,
         project: GitProject,
-        metadata: BuildHelperMetadata,
+        metadata: EventData,
         db_trigger,
-        project_url: Optional[str] = None,
         job: Optional[JobConfig] = None,
     ):
         super().__init__(
@@ -62,7 +62,6 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             db_trigger=db_trigger,
             job=job,
         )
-        self.project_url = project_url
 
         self.session = requests.session()
         adapter = requests.adapters.HTTPAdapter(max_retries=5)
@@ -74,7 +73,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         """Produce payload that can be used to trigger tests in Testing
            Farm using the Copr chroot given.
         """
-        git_url = self.project_url
+        git_url = self.metadata.project_url
         if not git_url.endswith(".git"):
             git_url = f"{git_url}.git"
 

--- a/packit_service/worker/whitelist.py
+++ b/packit_service/worker/whitelist.py
@@ -46,7 +46,7 @@ from packit_service.service.events import (
     PullRequestCommentPagureEvent,
     KojiBuildEvent,
 )
-from packit_service.worker.build import CoprBuildJobHelper
+from packit_service.worker.build import CoprBuildJobHelper, BuildHelperMetadata
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +92,8 @@ class Whitelist:
         Add account to whitelist.
         Status is set to 'waiting' or to 'approved_automatically'
         if the account is a packager in Fedora.
-        :param event: Github app installation info
+        :param sender_login: login of the user who installed the app into 'account'
+        :param account_login: login of the account into which the app was installed
         :return: was the account (auto/already)-whitelisted?
         """
         if WhitelistModel.get_account(account_login):
@@ -226,7 +227,13 @@ class Whitelist:
                         config=config,
                         package_config=event.get_package_config(),
                         project=project,
-                        event=event.get_dict(),
+                        metadata=BuildHelperMetadata(
+                            pr_id=event.pr_id,
+                            git_ref=event.git_ref,
+                            commit_sha=event.commit_sha,
+                            trigger=event.trigger,
+                            identifier=event.identifier,
+                        ),
                         db_trigger=event.db_trigger,
                     )
                     msg = "Account is not whitelisted!"  # needs to be shorter

--- a/packit_service/worker/whitelist.py
+++ b/packit_service/worker/whitelist.py
@@ -45,8 +45,9 @@ from packit_service.service.events import (
     PullRequestPagureEvent,
     PullRequestCommentPagureEvent,
     KojiBuildEvent,
+    EventData,
 )
-from packit_service.worker.build import CoprBuildJobHelper, BuildHelperMetadata
+from packit_service.worker.build import CoprBuildJobHelper
 
 logger = logging.getLogger(__name__)
 
@@ -227,13 +228,7 @@ class Whitelist:
                         config=config,
                         package_config=event.get_package_config(),
                         project=project,
-                        metadata=BuildHelperMetadata(
-                            pr_id=event.pr_id,
-                            git_ref=event.git_ref,
-                            commit_sha=event.commit_sha,
-                            trigger=event.trigger,
-                            identifier=event.identifier,
-                        ),
+                        metadata=EventData.from_event_dict((event.get_dict())),
                         db_trigger=event.db_trigger,
                     )
                     msg = "Account is not whitelisted!"  # needs to be shorter

--- a/tests/integration/test_babysit.py
+++ b/tests/integration/test_babysit.py
@@ -69,6 +69,7 @@ def test_check_copr_build_already_successful():
 
 
 def test_check_copr_build_updated():
+    flexmock(CoprBuildModel).should_receive("get_by_build_id").and_return()
     flexmock(CoprBuildModel).should_receive("get_all_by_build_id").with_args(
         1
     ).and_return(

--- a/tests/integration/test_babysit.py
+++ b/tests/integration/test_babysit.py
@@ -90,6 +90,7 @@ def test_check_copr_build_updated():
                         ),
                         pr_id=5,
                         job_config_trigger_type=JobConfigTriggerType.pull_request,
+                        id=123,
                     )
                 )
                 .mock(),

--- a/tests/integration/test_handler.py
+++ b/tests/integration/test_handler.py
@@ -52,12 +52,15 @@ def test_handler_cleanup(tmpdir, trick_p_s_with_k8s):
     t.joinpath(".h").symlink_to(".g", target_is_directory=False)
 
     c = ServiceConfig()
+    pc = flexmock(PackageConfig)
     c.command_handler_work_dir = t
     jc = JobConfig(
         type=JobType.copr_build, trigger=JobConfigTriggerType.pull_request, metadata={}
     )
     j = JobHandler(
-        config=c, job_config=jc, event=Event(trigger=TheJobTriggerType.pull_request)
+        package_config=pc,
+        job_config=jc,
+        event=Event(trigger=TheJobTriggerType.pull_request).get_dict(),
     )
 
     j._clean_workplace()
@@ -81,11 +84,11 @@ def test_precheck(github_pr_event):
         )
     )
     copr_build_handler = AbstractCoprBuildHandler(
-        config=flexmock(),
+        package_config=flexmock(),
         job_config=JobConfig(
             type=JobType.copr_build, trigger=JobConfigTriggerType.pull_request,
         ),
-        event=github_pr_event,
+        event=github_pr_event.get_dict(),
     )
     assert copr_build_handler.pre_check()
 
@@ -109,10 +112,10 @@ def test_precheck_skip_tests_when_build_defined(github_pr_event):
         "https://github.com/the-namespace/the-repo"
     )
     copr_build_handler = AbstractCoprBuildHandler(
-        config=flexmock(),
+        package_config=flexmock(),
         job_config=JobConfig(
             type=JobType.tests, trigger=JobConfigTriggerType.pull_request,
         ),
-        event=github_pr_event,
+        event=github_pr_event.get_dict(),
     )
     assert not copr_build_handler.pre_check()

--- a/tests/integration/test_handler.py
+++ b/tests/integration/test_handler.py
@@ -27,6 +27,7 @@ from flexmock import flexmock
 
 from packit.config import JobConfig, JobType, JobConfigTriggerType, PackageConfig
 from packit_service.config import ServiceConfig
+from packit_service.service.events import TheJobTriggerType, EventData
 from packit_service.worker.handlers import JobHandler
 from packit_service.worker.handlers.github_handlers import AbstractCoprBuildHandler
 
@@ -55,7 +56,11 @@ def test_handler_cleanup(tmpdir, trick_p_s_with_k8s):
     jc = JobConfig(
         type=JobType.copr_build, trigger=JobConfigTriggerType.pull_request, metadata={}
     )
-    j = JobHandler(package_config=pc, job_config=jc, event={"trigger": "pull_request"},)
+    j = JobHandler(
+        package_config=pc,
+        job_config=jc,
+        data=flexmock(trigger=TheJobTriggerType.pull_request),
+    )
 
     flexmock(j).should_receive("config").and_return(c)
 
@@ -79,7 +84,7 @@ def test_precheck(github_pr_event):
         job_config=JobConfig(
             type=JobType.copr_build, trigger=JobConfigTriggerType.pull_request,
         ),
-        event=github_pr_event.get_dict(),
+        data=EventData.from_event_dict(github_pr_event.get_dict()),
     )
     assert copr_build_handler.pre_check()
 
@@ -99,6 +104,6 @@ def test_precheck_skip_tests_when_build_defined(github_pr_event):
         job_config=JobConfig(
             type=JobType.tests, trigger=JobConfigTriggerType.pull_request,
         ),
-        event=github_pr_event.get_dict(),
+        data=EventData.from_event_dict(github_pr_event.get_dict()),
     )
     assert not copr_build_handler.pre_check()

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -111,6 +111,10 @@ def test_issue_comment_propose_update_handler(
         get_web_url=lambda: "https://github.com/the-namespace/the-repo",
         is_private=lambda: False,
     )
-    flexmock(IssueCommentEvent, db_trigger=IssueModel())
+
+    flexmock(IssueCommentEvent, db_trigger=IssueModel(id=123))
+    flexmock(IssueModel).should_receive("get_by_id").with_args(123).and_return(
+        flexmock(issue_id=12345)
+    )
     results = SteveJobs().process_message(issue_comment_propose_update_event)
     assert first_dict_value(results["jobs"])["success"]

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -351,6 +351,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
     trigger = flexmock(
         job_config_trigger_type=JobConfigTriggerType.pull_request,
         job_trigger_model_type=JobTriggerModelType.pull_request,
+        id=1,
     )
     flexmock(CoprBuildEvent).should_receive("db_trigger").and_return(trigger)
 

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -348,12 +348,6 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
             "git-ref": "0011223344",
         },
     }
-    trigger = flexmock(
-        job_config_trigger_type=JobConfigTriggerType.pull_request,
-        job_trigger_model_type=JobTriggerModelType.pull_request,
-        id=1,
-    )
-    flexmock(CoprBuildEvent).should_receive("db_trigger").and_return(trigger)
 
     tft_test_run_model = flexmock()
     tft_test_run_model.should_receive("set_status").with_args(
@@ -364,7 +358,7 @@ def test_copr_build_end_testing_farm(copr_build_end, copr_build_pr):
         commit_sha="0011223344",
         status=TestingFarmResult.new,
         target="fedora-rawhide-x86_64",
-        trigger_model=trigger,
+        trigger_model=copr_build_pr.job_trigger.get_trigger_object(),
         web_url=None,
     ).and_return(tft_test_run_model)
 
@@ -473,12 +467,6 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
         url="",
     ).once()
 
-    trigger = flexmock(
-        job_config_trigger_type=JobConfigTriggerType.pull_request,
-        job_trigger_model_type=JobTriggerModelType.pull_request,
-    )
-    flexmock(CoprBuildEvent).should_receive("db_trigger").and_return(trigger)
-
     tft_test_run_model = flexmock()
     tft_test_run_model.should_receive("set_status").with_args(
         TestingFarmResult.error
@@ -490,7 +478,7 @@ def test_copr_build_end_failed_testing_farm(copr_build_end, copr_build_pr):
         commit_sha="0011223344",
         status=TestingFarmResult.new,
         target="fedora-rawhide-x86_64",
-        trigger_model=trigger,
+        trigger_model=copr_build_pr.job_trigger.get_trigger_object(),
         web_url=None,
     ).and_return(tft_test_run_model)
 
@@ -577,12 +565,6 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
         url="",
     ).once()
 
-    trigger = flexmock(
-        job_config_trigger_type=JobConfigTriggerType.pull_request,
-        job_trigger_model_type=JobTriggerModelType.pull_request,
-    )
-    flexmock(CoprBuildEvent).should_receive("db_trigger").and_return(trigger)
-
     tft_test_run_model = flexmock()
     tft_test_run_model.should_receive("set_status").with_args(
         TestingFarmResult.error
@@ -594,7 +576,7 @@ def test_copr_build_end_failed_testing_farm_no_json(copr_build_end, copr_build_p
         commit_sha="0011223344",
         status=TestingFarmResult.new,
         target="fedora-rawhide-x86_64",
-        trigger_model=trigger,
+        trigger_model=copr_build_pr.job_trigger.get_trigger_object(),
         web_url=None,
     ).and_return(tft_test_run_model)
 

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -31,6 +31,7 @@ from packit.local_project import LocalProject
 
 from packit_service.config import ServiceConfig
 from packit_service.constants import SANDCASTLE_WORK_DIR
+from packit_service.models import PullRequestModel
 from packit_service.service.db_triggers import AddPullRequestDbTrigger
 from packit_service.worker.build.copr_build import CoprBuildJobHelper
 from packit_service.worker.jobs import SteveJobs
@@ -133,8 +134,12 @@ def mock_pr_comment_functionality(request):
     config = ServiceConfig()
     config.command_handler_work_dir = SANDCASTLE_WORK_DIR
     flexmock(ServiceConfig).should_receive("get_service_config").and_return(config)
-    flexmock(AddPullRequestDbTrigger).should_receive("db_trigger").and_return(
-        flexmock(job_config_trigger_type=JobConfigTriggerType.pull_request)
+    trigger = flexmock(
+        job_config_trigger_type=JobConfigTriggerType.pull_request, id=123
+    )
+    flexmock(AddPullRequestDbTrigger).should_receive("db_trigger").and_return(trigger)
+    flexmock(PullRequestModel).should_receive("get_by_id").with_args(123).and_return(
+        trigger
     )
     flexmock(LocalProject, refresh_the_arguments=lambda: None)
     flexmock(Whitelist, check_and_report=True)

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -48,7 +48,7 @@ def test_dist_git_push_release_handle(github_release_webhook):
     ).once()
 
     flexmock(AddReleaseDbTrigger).should_receive("db_trigger").and_return(
-        flexmock(job_config_trigger_type=JobConfigTriggerType.release)
+        flexmock(job_config_trigger_type=JobConfigTriggerType.release, id=123)
     )
 
     results = SteveJobs().process_message(github_release_webhook)
@@ -89,7 +89,7 @@ def test_dist_git_push_release_handle_multiple_branches(
     flexmock(FedPKG).should_receive("clone").and_return(None)
 
     flexmock(AddReleaseDbTrigger).should_receive("db_trigger").and_return(
-        flexmock(job_config_trigger_type=JobConfigTriggerType.release)
+        flexmock(job_config_trigger_type=JobConfigTriggerType.release, id=123)
     )
 
     results = SteveJobs().process_message(github_release_webhook)
@@ -141,7 +141,7 @@ def test_dist_git_push_release_handle_one_failed(
 
     flexmock(sentry_integration).should_receive("send_to_sentry").and_return().once()
     flexmock(AddReleaseDbTrigger).should_receive("db_trigger").and_return(
-        flexmock(job_config_trigger_type=JobConfigTriggerType.release)
+        flexmock(job_config_trigger_type=JobConfigTriggerType.release, id=123)
     )
 
     results = SteveJobs().process_message(github_release_webhook)
@@ -195,7 +195,7 @@ def test_dist_git_push_release_handle_all_failed(
         Exception, "Failed"
     ).times(len(fedora_branches))
     flexmock(AddReleaseDbTrigger).should_receive("db_trigger").and_return(
-        flexmock(job_config_trigger_type=JobConfigTriggerType.release)
+        flexmock(job_config_trigger_type=JobConfigTriggerType.release, id=123)
     )
 
     flexmock(sentry_integration).should_receive("send_to_sentry").and_return().times(

--- a/tests/unit/test_build_helper.py
+++ b/tests/unit/test_build_helper.py
@@ -5,6 +5,7 @@ from packit.config import PackageConfig, JobConfig, JobType, JobConfigTriggerTyp
 from packit.config.aliases import ALIASES
 from packit.config.job_config import JobMetadataConfig
 from packit_service.service.events import TheJobTriggerType
+from packit_service.worker.build import BuildHelperMetadata
 from packit_service.worker.build.copr_build import CoprBuildJobHelper
 from packit_service.worker.build.koji_build import KojiBuildJobHelper
 
@@ -269,7 +270,7 @@ def test_targets(jobs, trigger, job_config_trigger_type, build_chroots, test_chr
         config=flexmock(),
         package_config=PackageConfig(jobs=jobs),
         project=flexmock(),
-        event={"trigger": trigger, "pr_id": None},
+        metadata=BuildHelperMetadata(trigger=trigger, pr_id=None),
         db_trigger=flexmock(job_config_trigger_type=job_config_trigger_type),
     )
 
@@ -339,7 +340,7 @@ def test_targets_for_koji_build(
         config=flexmock(),
         package_config=PackageConfig(jobs=jobs),
         project=flexmock(),
-        event={"trigger": trigger, "pr_id": pr_id},
+        metadata=BuildHelperMetadata(trigger=trigger, pr_id=pr_id),
         db_trigger=flexmock(job_config_trigger_type=job_config_trigger_type),
     )
 

--- a/tests/unit/test_build_helper.py
+++ b/tests/unit/test_build_helper.py
@@ -5,7 +5,6 @@ from packit.config import PackageConfig, JobConfig, JobType, JobConfigTriggerTyp
 from packit.config.aliases import ALIASES
 from packit.config.job_config import JobMetadataConfig
 from packit_service.service.events import TheJobTriggerType
-from packit_service.worker.build import BuildHelperMetadata
 from packit_service.worker.build.copr_build import CoprBuildJobHelper
 from packit_service.worker.build.koji_build import KojiBuildJobHelper
 
@@ -270,7 +269,7 @@ def test_targets(jobs, trigger, job_config_trigger_type, build_chroots, test_chr
         config=flexmock(),
         package_config=PackageConfig(jobs=jobs),
         project=flexmock(),
-        metadata=BuildHelperMetadata(trigger=trigger, pr_id=None),
+        metadata=flexmock(trigger=trigger, pr_id=None),
         db_trigger=flexmock(job_config_trigger_type=job_config_trigger_type),
     )
 
@@ -340,7 +339,7 @@ def test_targets_for_koji_build(
         config=flexmock(),
         package_config=PackageConfig(jobs=jobs),
         project=flexmock(),
-        metadata=BuildHelperMetadata(trigger=trigger, pr_id=pr_id),
+        metadata=flexmock(trigger=trigger, pr_id=pr_id),
         db_trigger=flexmock(job_config_trigger_type=job_config_trigger_type),
     )
 

--- a/tests/unit/test_build_helper.py
+++ b/tests/unit/test_build_helper.py
@@ -269,11 +269,8 @@ def test_targets(jobs, trigger, job_config_trigger_type, build_chroots, test_chr
         config=flexmock(),
         package_config=PackageConfig(jobs=jobs),
         project=flexmock(),
-        event=flexmock(
-            trigger=trigger,
-            db_trigger=flexmock(job_config_trigger_type=job_config_trigger_type),
-            pr_id=None,
-        ),
+        event={"trigger": trigger, "pr_id": None},
+        db_trigger=flexmock(job_config_trigger_type=job_config_trigger_type),
     )
 
     assert copr_build_handler.package_config.jobs
@@ -337,15 +334,13 @@ def test_targets(jobs, trigger, job_config_trigger_type, build_chroots, test_chr
 def test_targets_for_koji_build(
     jobs, trigger, job_config_trigger_type, build_targets, koji_targets
 ):
+    pr_id = 41 if trigger == TheJobTriggerType.pull_request else None
     koji_build_handler = KojiBuildJobHelper(
         config=flexmock(),
         package_config=PackageConfig(jobs=jobs),
         project=flexmock(),
-        event=flexmock(
-            trigger=trigger,
-            db_trigger=flexmock(job_config_trigger_type=job_config_trigger_type),
-            pr_id=41 if trigger == TheJobTriggerType.pull_request else None,
-        ),
+        event={"trigger": trigger, "pr_id": pr_id},
+        db_trigger=flexmock(job_config_trigger_type=job_config_trigger_type),
     )
 
     assert koji_build_handler.package_config.jobs

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -69,8 +69,6 @@ from packit_service.service.events import (
     MergeRequestGitlabEvent,
     GitlabEventAction,
     KojiBuildEvent,
-    get_koji_build_logs_url,
-    get_koji_rpm_build_web_url,
     IssueCommentGitlabEvent,
     MergeRequestCommentGitlabEvent,
     PushGitlabEvent,
@@ -1286,37 +1284,3 @@ class TestCentOSEventParser:
             "https://git.stg.centos.org/source-git/packit-hello-world"
         )
         assert event_object.package_config
-
-
-@pytest.mark.parametrize(
-    "event,result",
-    [
-        (
-            flexmock(rpm_build_task_id=45270227),
-            "https://kojipkgs.fedoraproject.org//work/tasks/227/45270227/build.log",
-        ),
-        (
-            flexmock(rpm_build_task_id=45452270),
-            "https://kojipkgs.fedoraproject.org//work/tasks/2270/45452270/build.log",
-        ),
-    ],
-)
-def test_get_koji_build_logs_url(event, result):
-    assert get_koji_build_logs_url(event) == result
-
-
-@pytest.mark.parametrize(
-    "event,result",
-    [
-        (
-            flexmock(rpm_build_task_id=45270227),
-            "https://koji.fedoraproject.org/koji/taskinfo?taskID=45270227",
-        ),
-        (
-            flexmock(rpm_build_task_id=45452270),
-            "https://koji.fedoraproject.org/koji/taskinfo?taskID=45452270",
-        ),
-    ],
-)
-def test_get_koji_rpm_build_web_url(event, result):
-    assert get_koji_rpm_build_web_url(event) == result

--- a/tests/unit/test_koji_build.py
+++ b/tests/unit/test_koji_build.py
@@ -65,6 +65,7 @@ def build_helper(
     metadata=None,
     trigger=None,
     jobs=None,
+    db_trigger=None,
 ):
     if not metadata:
         metadata = JobMetadataConfig(
@@ -90,7 +91,8 @@ def build_helper(
         config=ServiceConfig(),
         package_config=pkg_conf,
         project=GitProject(repo=flexmock(), service=flexmock(), namespace=flexmock()),
-        event=event,
+        event=event.get_dict(),
+        db_trigger=db_trigger,
     )
     handler._api = PackitAPI(config=ServiceConfig(), package_config=pkg_conf)
     return handler

--- a/tests/unit/test_koji_build.py
+++ b/tests/unit/test_koji_build.py
@@ -52,7 +52,7 @@ from packit_service.service.urls import (
     get_koji_build_info_url_from_flask,
     get_srpm_log_url_from_flask,
 )
-from packit_service.worker.build import koji_build, BuildHelperMetadata
+from packit_service.worker.build import koji_build
 from packit_service.worker.build.koji_build import KojiBuildJobHelper
 from packit_service.worker.reporting import StatusReporter
 
@@ -93,7 +93,7 @@ def build_helper(
         config=ServiceConfig(),
         package_config=pkg_conf,
         project=GitProject(repo=flexmock(), service=flexmock(), namespace=flexmock()),
-        metadata=BuildHelperMetadata(
+        metadata=flexmock(
             trigger=event.trigger,
             pr_id=event.pr_id,
             git_ref=event.git_ref,

--- a/tests/unit/test_koji_build.py
+++ b/tests/unit/test_koji_build.py
@@ -101,11 +101,12 @@ def build_helper(
 
 
 def test_koji_build_check_names(github_pr_event):
-    flexmock(AddPullRequestDbTrigger).should_receive("db_trigger").and_return(
-        flexmock(job_config_trigger_type=JobConfigTriggerType.release)
-    )
+    trigger = flexmock(job_config_trigger_type=JobConfigTriggerType.release, id=123)
+    flexmock(AddPullRequestDbTrigger).should_receive("db_trigger").and_return(trigger)
     helper = build_helper(
-        event=github_pr_event, metadata=JobMetadataConfig(targets=["bright-future"]),
+        event=github_pr_event,
+        metadata=JobMetadataConfig(targets=["bright-future"]),
+        db_trigger=trigger,
     )
     flexmock(koji_build).should_receive("get_all_koji_targets").and_return(
         ["dark-past", "bright-future"]
@@ -149,11 +150,12 @@ def test_koji_build_check_names(github_pr_event):
 
 
 def test_koji_build_failed_kerberos(github_pr_event):
-    flexmock(AddPullRequestDbTrigger).should_receive("db_trigger").and_return(
-        flexmock(job_config_trigger_type=JobConfigTriggerType.release)
-    )
+    trigger = flexmock(job_config_trigger_type=JobConfigTriggerType.release, id=123)
+    flexmock(AddPullRequestDbTrigger).should_receive("db_trigger").and_return(trigger)
     helper = build_helper(
-        event=github_pr_event, metadata=JobMetadataConfig(targets=["bright-future"]),
+        event=github_pr_event,
+        metadata=JobMetadataConfig(targets=["bright-future"]),
+        db_trigger=trigger,
     )
     flexmock(koji_build).should_receive("get_all_koji_targets").and_return(
         ["dark-past", "bright-future"]
@@ -197,12 +199,12 @@ def test_koji_build_failed_kerberos(github_pr_event):
 
 
 def test_koji_build_target_not_supported(github_pr_event):
-    flexmock(AddPullRequestDbTrigger).should_receive("db_trigger").and_return(
-        flexmock(job_config_trigger_type=JobConfigTriggerType.release)
-    )
+    trigger = flexmock(job_config_trigger_type=JobConfigTriggerType.release, id=123)
+    flexmock(AddPullRequestDbTrigger).should_receive("db_trigger").and_return(trigger)
     helper = build_helper(
         event=github_pr_event,
         metadata=JobMetadataConfig(targets=["nonexisting-target"]),
+        db_trigger=trigger,
     )
     flexmock(koji_build).should_receive("get_all_koji_targets").and_return(
         ["dark-past", "bright-future"]
@@ -239,12 +241,12 @@ def test_koji_build_target_not_supported(github_pr_event):
 
 
 def test_koji_build_with_multiple_targets(github_pr_event):
-    flexmock(AddPullRequestDbTrigger).should_receive("db_trigger").and_return(
-        flexmock(job_config_trigger_type=JobConfigTriggerType.release)
-    )
+    trigger = flexmock(job_config_trigger_type=JobConfigTriggerType.release, id=123)
+    flexmock(AddPullRequestDbTrigger).should_receive("db_trigger").and_return(trigger)
     helper = build_helper(
         event=github_pr_event,
         metadata=JobMetadataConfig(targets=["bright-future", "dark-past"]),
+        db_trigger=trigger,
     )
     flexmock(koji_build).should_receive("get_all_koji_targets").and_return(
         ["dark-past", "bright-future"]
@@ -281,11 +283,12 @@ def test_koji_build_with_multiple_targets(github_pr_event):
 
 
 def test_koji_build_failed(github_pr_event):
-    flexmock(AddPullRequestDbTrigger).should_receive("db_trigger").and_return(
-        flexmock(job_config_trigger_type=JobConfigTriggerType.release)
-    )
+    trigger = flexmock(job_config_trigger_type=JobConfigTriggerType.release, id=123)
+    flexmock(AddPullRequestDbTrigger).should_receive("db_trigger").and_return(trigger)
     helper = build_helper(
-        event=github_pr_event, metadata=JobMetadataConfig(targets=["bright-future"]),
+        event=github_pr_event,
+        metadata=JobMetadataConfig(targets=["bright-future"]),
+        db_trigger=trigger,
     )
     flexmock(koji_build).should_receive("get_all_koji_targets").and_return(
         ["dark-past", "bright-future"]
@@ -326,11 +329,12 @@ def test_koji_build_failed(github_pr_event):
 
 
 def test_koji_build_failed_srpm(github_pr_event):
-    flexmock(AddPullRequestDbTrigger).should_receive("db_trigger").and_return(
-        flexmock(job_config_trigger_type=JobConfigTriggerType.release)
-    )
+    trigger = flexmock(job_config_trigger_type=JobConfigTriggerType.release, id=123)
+    flexmock(AddPullRequestDbTrigger).should_receive("db_trigger").and_return(trigger)
     helper = build_helper(
-        event=github_pr_event, metadata=JobMetadataConfig(targets=["bright-future"]),
+        event=github_pr_event,
+        metadata=JobMetadataConfig(targets=["bright-future"]),
+        db_trigger=trigger,
     )
     srpm_build_url = get_srpm_log_url_from_flask(2)
     flexmock(StatusReporter).should_receive("set_status").with_args(

--- a/tests/unit/test_steve.py
+++ b/tests/unit/test_steve.py
@@ -82,7 +82,7 @@ def test_process_message(event):
         dist_git_branch="master", version="1.2.3"
     ).once()
     flexmock(AddReleaseDbTrigger).should_receive("db_trigger").and_return(
-        flexmock(job_config_trigger_type=JobConfigTriggerType.release)
+        flexmock(job_config_trigger_type=JobConfigTriggerType.release, id=1)
     )
     flexmock(Whitelist, check_and_report=True)
     results = SteveJobs().process_message(event)

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -199,7 +199,6 @@ def test_testing_farm_response(
         package_config=flexmock(),
         job_config=flexmock(),
         data=EventData.from_event_dict(event_dict),
-        event=event_dict,
     )
     flexmock(StatusReporter).should_receive("report").with_args(
         state=status_status,

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -39,6 +39,7 @@ from packit_service.service.events import (
 from packit_service.worker.handlers import TestingFarmResultsHandler as TFResultsHandler
 from packit_service.worker.reporting import StatusReporter
 from packit_service.worker.testing_farm import TestingFarmJobHelper as TFJobHelper
+from packit_service.worker.build import BuildHelperMetadata
 
 
 @pytest.mark.parametrize(
@@ -277,15 +278,14 @@ def test_trigger_payload(
         service="GitHub",
         get_git_urls=lambda: {"git": f"{project_url}.git"},
     )
-    event = {
-        "commit_sha": commit_sha,
-        "project_url": project_url,
-        "git_ref": git_ref,
-        "pr_id": None,
-    }
+    metadata = BuildHelperMetadata(
+        trigger=flexmock(), commit_sha=commit_sha, git_ref=git_ref,
+    )
     db_trigger = flexmock()
 
-    job_helper = TFJobHelper(config, package_config, project, event, db_trigger)
+    job_helper = TFJobHelper(
+        config, package_config, project, metadata, db_trigger, project_url
+    )
     job_helper = flexmock(job_helper)
 
     job_helper.should_receive("job_owner").and_return(copr_owner)

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -173,8 +173,14 @@ def test_testing_farm_response(
             ],
         )
     )
+    config = flexmock(command_handler_work_dir=flexmock())
+    flexmock(TFResultsHandler).should_receive("config").and_return(config)
+    flexmock(TFResultsEvent).should_receive("db_trigger").and_return(None)
+    config.should_receive("get_project").with_args(
+        url="https://github.com/packit-service/ogr"
+    ).and_return()
     test_farm_handler = TFResultsHandler(
-        config=flexmock(command_handler_work_dir=flexmock()),
+        package_config=flexmock(),
         job_config=flexmock(),
         event=TFResultsEvent(
             pipeline_id="id",
@@ -190,7 +196,7 @@ def test_testing_farm_response(
             git_ref=flexmock(),
             project_url="https://github.com/packit-service/ogr",
             commit_sha=flexmock(),
-        ),
+        ).get_dict(),
     )
     flexmock(StatusReporter).should_receive("report").with_args(
         state=status_status,
@@ -271,11 +277,15 @@ def test_trigger_payload(
         service="GitHub",
         get_git_urls=lambda: {"git": f"{project_url}.git"},
     )
-    event = flexmock(
-        commit_sha=commit_sha, project_url=project_url, git_ref=git_ref, pr_id=None
-    )
+    event = {
+        "commit_sha": commit_sha,
+        "project_url": project_url,
+        "git_ref": git_ref,
+        "pr_id": None,
+    }
+    db_trigger = flexmock()
 
-    job_helper = TFJobHelper(config, package_config, project, event)
+    job_helper = TFJobHelper(config, package_config, project, event, db_trigger)
     job_helper = flexmock(job_helper)
 
     job_helper.should_receive("job_owner").and_return(copr_owner)

--- a/tests/unit/test_whitelist.py
+++ b/tests/unit/test_whitelist.py
@@ -313,6 +313,7 @@ def test_check_and_report(
     for event, is_valid in events:
         if isinstance(event, PullRequestGithubEvent) and not is_valid:
             # Report the status
+            flexmock(event).should_receive("db_trigger").and_return(None)
             flexmock(CoprHelper).should_receive("get_copr_client").and_return(
                 Client(
                     config={

--- a/tests/unit/test_whitelist.py
+++ b/tests/unit/test_whitelist.py
@@ -232,7 +232,7 @@ def events(request) -> List[Tuple[AbstractGithubEvent, bool]]:
                     base_repo_name="",
                     target_repo_namespace=namespace,
                     target_repo_name="",
-                    https_url="",
+                    https_url="example-url",
                     commit_sha="",
                     user_login=login,
                     base_ref="",
@@ -313,7 +313,6 @@ def test_check_and_report(
     for event, is_valid in events:
         if isinstance(event, PullRequestGithubEvent) and not is_valid:
             # Report the status
-            flexmock(event).should_receive("db_trigger").and_return(None)
             flexmock(CoprHelper).should_receive("get_copr_client").and_return(
                 Client(
                     config={

--- a/tests_requre/conftest.py
+++ b/tests_requre/conftest.py
@@ -719,7 +719,7 @@ def installation_events():
             repositories=[],
             sender_id=5409,
             sender_login="teg",
-        ),
+        ).get_dict(),
         InstallationEvent(
             installation_id=6813698,
             account_login="Pac23",
@@ -730,7 +730,7 @@ def installation_events():
             repositories=["Pac23/awesome-piracy"],
             sender_id=11048203,
             sender_login="Pac23",
-        ),
+        ).get_dict(),
     ]
 
 

--- a/tests_requre/conftest.py
+++ b/tests_requre/conftest.py
@@ -719,7 +719,7 @@ def installation_events():
             repositories=[],
             sender_id=5409,
             sender_login="teg",
-        ).get_dict(),
+        ),
         InstallationEvent(
             installation_id=6813698,
             account_login="Pac23",
@@ -730,7 +730,7 @@ def installation_events():
             repositories=["Pac23/awesome-piracy"],
             sender_id=11048203,
             sender_login="Pac23",
-        ).get_dict(),
+        ),
     ]
 
 


### PR DESCRIPTION
This PR prepares the code to be able to create Celery tasks - handlers accept the events as dicts and don't use event as object, have separate attribute for project, package config

**TODO:**

- [ ]  make sure no info is lost, all attributes are accessed correctly
- [x] make sure each handler has valid `db_trigger`
- [x] make sure that each event dict contains `project_url` if it was present in event (to get the project in handler)
- [x] fix the tests
- [ ] reduce attributes if possible
- [x] change newly added code (for now handler for KojiBuild)