### PR TITLE
let handlers use jobconfig only

### DIFF
--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -32,6 +32,7 @@ from typing import Optional, List, Union, Dict, Set
 from ogr.abstract import GitProject
 from ogr.services.pagure import PagureProject
 from packit.config import PackageConfig, get_package_config_from_repo
+
 from packit_service.config import (
     ServiceConfig,
     PackageConfigGetter,
@@ -365,6 +366,8 @@ class AbstractForgeIndependentEvent(Event):
             spec_file_path=spec_path,
         )
 
+        # job config change note:
+        #   this is used in sync-from-downstream which is buggy - we don't need to change this
         if package_config:
             package_config.upstream_project_url = self.project_url
         return package_config

--- a/packit_service/worker/build/copr_build.py
+++ b/packit_service/worker/build/copr_build.py
@@ -23,21 +23,23 @@ import logging
 from typing import Optional, Tuple, Set, List
 
 from ogr.abstract import GitProject, CommitStatus
-from packit.config import PackageConfig, JobType, JobConfig
+from packit.config import JobType, JobConfig
 from packit.config.aliases import get_build_targets
+from packit.config.package_config import PackageConfig
 from packit.exceptions import PackitCoprException
+
 from packit_service import sentry_integration
 from packit_service.celerizer import celery_app
 from packit_service.config import ServiceConfig, Deployment
 from packit_service.constants import MSG_RETRIGGER
 from packit_service.models import CoprBuildModel
+from packit_service.service.events import EventData
 from packit_service.service.urls import (
     get_srpm_log_url_from_flask,
     get_copr_build_info_url_from_flask,
 )
 from packit_service.worker.build.build_helper import BaseBuildJobHelper
 from packit_service.worker.result import HandlerResults
-from packit_service.service.events import EventData
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +57,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
         project: GitProject,
         metadata: EventData,
         db_trigger,
-        job: Optional[JobConfig] = None,
+        job_config: JobConfig,
     ):
         super().__init__(
             config=config,
@@ -63,7 +65,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
             project=project,
             metadata=metadata,
             db_trigger=db_trigger,
-            job=job,
+            job_config=job_config,
         )
 
         self.msg_retrigger: str = MSG_RETRIGGER.format(

--- a/packit_service/worker/build/koji_build.py
+++ b/packit_service/worker/build/koji_build.py
@@ -24,20 +24,22 @@ from re import search
 from typing import Optional, Tuple, Dict, Set
 
 from ogr.abstract import CommitStatus, GitProject
-from packit.config import JobType, PackageConfig, JobConfig
+from packit.config import JobType, JobConfig
 from packit.config.aliases import get_koji_targets, get_all_koji_targets
+from packit.config.package_config import PackageConfig
 from packit.exceptions import PackitCommandFailedError
+
 from packit_service import sentry_integration
 from packit_service.config import ServiceConfig
 from packit_service.constants import MSG_RETRIGGER
 from packit_service.models import KojiBuildModel
+from packit_service.service.events import EventData
 from packit_service.service.urls import (
     get_srpm_log_url_from_flask,
     get_koji_build_info_url_from_flask,
 )
 from packit_service.worker.build.build_helper import BaseBuildJobHelper
 from packit_service.worker.result import HandlerResults
-from packit_service.service.events import EventData
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +57,7 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
         project: GitProject,
         metadata: EventData,
         db_trigger,
-        job: Optional[JobConfig] = None,
+        job_config: JobConfig,
     ):
         super().__init__(
             config=config,
@@ -63,7 +65,7 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
             project=project,
             metadata=metadata,
             db_trigger=db_trigger,
-            job=job,
+            job_config=job_config,
         )
         self.msg_retrigger: str = MSG_RETRIGGER.format(build="production-build")
 

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -31,12 +31,12 @@ from pathlib import Path
 from typing import Dict, Optional, Type, List, Set
 
 from ogr.abstract import GitProject
-
 from packit.api import PackitAPI
-from packit.config import JobConfig, JobType, PackageConfig
+from packit.config import JobConfig, JobType
+from packit.config.package_config import PackageConfig
 from packit.local_project import LocalProject
+
 from packit_service.config import ServiceConfig
-from packit_service.sentry_integration import push_scope_to_sentry
 from packit_service.models import (
     AbstractTriggerDbType,
     PullRequestModel,
@@ -44,6 +44,7 @@ from packit_service.models import (
     ProjectReleaseModel,
     GitBranchModel,
 )
+from packit_service.sentry_integration import push_scope_to_sentry
 from packit_service.service.events import TheJobTriggerType, EventData
 from packit_service.worker.result import HandlerResults
 
@@ -174,12 +175,11 @@ class JobHandler(Handler):
     triggers: List[TheJobTriggerType]
 
     def __init__(
-        self,
-        package_config: PackageConfig,
-        job_config: Optional[JobConfig],
-        data: EventData,
+        self, package_config: PackageConfig, job_config: JobConfig, data: EventData,
     ):
+        # build helper needs package_config to resolve dependencies b/w tests and build jobs
         self.package_config = package_config
+        # always use job_config to pick up values, use package_config only for package_config.jobs
         self.job_config = job_config
         self.data = data
 

--- a/packit_service/worker/handlers/comment_action_handler.py
+++ b/packit_service/worker/handlers/comment_action_handler.py
@@ -26,13 +26,14 @@ This file defines classes for issue/pr comments which are sent by a git forge.
 
 import enum
 import logging
-
 from typing import Dict, Type
 
-from packit.config import PackageConfig, JobConfig
+from packit.config import JobConfig
+from packit.config.package_config import PackageConfig
+
+from packit_service.service.events import EventData
 from packit_service.worker.handlers import JobHandler
 from packit_service.worker.result import HandlerResults
-from packit_service.service.events import EventData
 
 logger = logging.getLogger(__name__)
 

--- a/packit_service/worker/handlers/pagure_handlers.py
+++ b/packit_service/worker/handlers/pagure_handlers.py
@@ -24,9 +24,9 @@ import logging
 from typing import Optional
 
 from ogr.abstract import CommitStatus, PullRequest
+from packit.config import JobType, JobConfig, PackageConfig
 
 from packit_service.models import BugzillaModel
-from packit.config import JobType, JobConfig, PackageConfig
 from packit_service.service.events import (
     TheJobTriggerType,
     PullRequestLabelAction,
@@ -74,7 +74,7 @@ class PagurePullRequestCommentCoprBuildHandler(CommentActionHandler):
                 project=self.project,
                 metadata=self.data,
                 db_trigger=self.db_trigger,
-                job=self.job_config,
+                job_config=self.job_config,
             )
         return self._copr_build_helper
 

--- a/packit_service/worker/handlers/testing_farm_handlers.py
+++ b/packit_service/worker/handlers/testing_farm_handlers.py
@@ -27,7 +27,9 @@ import logging
 from typing import Optional
 
 from ogr.abstract import CommitStatus
-from packit.config import JobType, JobConfig, PackageConfig
+from packit.config import JobType, JobConfig
+from packit.config.package_config import PackageConfig
+
 from packit_service.models import TFTTestRunModel, AbstractTriggerDbType
 from packit_service.service.events import (
     TestingFarmResult,

--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -24,15 +24,14 @@
 import json
 import logging
 import uuid
-from typing import Optional
 
 import requests
-
 from ogr.abstract import GitProject, CommitStatus
 from ogr.utils import RequestResponse
-from packit.config import PackageConfig
 from packit.config.job_config import JobConfig
+from packit.config.package_config import PackageConfig
 from packit.exceptions import PackitConfigException
+
 from packit_service.config import ServiceConfig
 from packit_service.constants import TESTING_FARM_TRIGGER_URL
 from packit_service.models import TFTTestRunModel, TestingFarmResult
@@ -52,7 +51,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         project: GitProject,
         metadata: EventData,
         db_trigger,
-        job: Optional[JobConfig] = None,
+        job_config: JobConfig,
     ):
         super().__init__(
             config=config,
@@ -60,7 +59,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
             project=project,
             metadata=metadata,
             db_trigger=db_trigger,
-            job=job,
+            job_config=job_config,
         )
 
         self.session = requests.session()

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -176,7 +176,7 @@ def test_copr_build_end(
 ):
     steve = SteveJobs()
     flexmock(GithubProject).should_receive("is_private").and_return(False)
-    pc_build_pr.notifications.pull_request.successful_build = pc_comment_pr_succ
+    pc_build_pr.jobs[0].notifications.pull_request.successful_build = pc_comment_pr_succ
     flexmock(CoprBuildEvent).should_receive("get_package_config").and_return(
         pc_build_pr
     )

--- a/tests/unit/test_build_helper.py
+++ b/tests/unit/test_build_helper.py
@@ -268,6 +268,7 @@ def test_targets(jobs, trigger, job_config_trigger_type, build_chroots, test_chr
     copr_build_handler = CoprBuildJobHelper(
         config=flexmock(),
         package_config=PackageConfig(jobs=jobs),
+        job_config=jobs[0],  # BuildHelper looks at all jobs in the end
         project=flexmock(),
         metadata=flexmock(trigger=trigger, pr_id=None),
         db_trigger=flexmock(job_config_trigger_type=job_config_trigger_type),
@@ -338,6 +339,7 @@ def test_targets_for_koji_build(
     koji_build_handler = KojiBuildJobHelper(
         config=flexmock(),
         package_config=PackageConfig(jobs=jobs),
+        job_config=jobs[0],
         project=flexmock(),
         metadata=flexmock(trigger=trigger, pr_id=pr_id),
         db_trigger=flexmock(job_config_trigger_type=job_config_trigger_type),

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -91,6 +91,7 @@ def build_helper(
     handler = CoprBuildJobHelper(
         config=ServiceConfig(),
         package_config=pkg_conf,
+        job_config=jobs[0],
         project=GitProject(
             repo="the-example-repo",
             service=flexmock(),

--- a/tests/unit/test_koji_build.py
+++ b/tests/unit/test_koji_build.py
@@ -92,6 +92,7 @@ def build_helper(
     handler = KojiBuildJobHelper(
         config=ServiceConfig(),
         package_config=pkg_conf,
+        job_config=pkg_conf.jobs[0],
         project=GitProject(repo=flexmock(), service=flexmock(), namespace=flexmock()),
         metadata=flexmock(
             trigger=event.trigger,

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -287,7 +287,9 @@ def test_trigger_payload(
     )
     db_trigger = flexmock()
 
-    job_helper = TFJobHelper(config, package_config, project, metadata, db_trigger)
+    job_helper = TFJobHelper(
+        config, package_config, project, metadata, db_trigger, flexmock()
+    )
     job_helper = flexmock(job_helper)
 
     job_helper.should_receive("job_owner").and_return(copr_owner)

--- a/tests/unit/test_whitelist.py
+++ b/tests/unit/test_whitelist.py
@@ -198,7 +198,7 @@ def test_check_and_report_calls_method(whitelist, event, method, approved):
         whitelist_mock.and_return(None)
     assert (
         whitelist.check_and_report(
-            event, gp, config=flexmock(deployment=Deployment.stg)
+            event, gp, config=flexmock(deployment=Deployment.stg), job_configs=[]
         )
         is approved
     )
@@ -297,16 +297,15 @@ def test_check_and_report(
         set_commit_status=lambda *args, **kwargs: None,
         issue_comment=lambda *args, **kwargs: None,
     )
-    flexmock(PullRequestGithubEvent).should_receive("get_package_config").and_return(
-        flexmock(
-            jobs=[
-                JobConfig(
-                    type=JobType.tests,
-                    trigger=JobConfigTriggerType.pull_request,
-                    metadata=JobMetadataConfig(targets=["fedora-rawhide"]),
-                )
-            ],
+    job_configs = [
+        JobConfig(
+            type=JobType.tests,
+            trigger=JobConfigTriggerType.pull_request,
+            metadata=JobMetadataConfig(targets=["fedora-rawhide"]),
         )
+    ]
+    flexmock(PullRequestGithubEvent).should_receive("get_package_config").and_return(
+        flexmock(jobs=job_configs,)
     )
 
     git_project = GithubProject("", GithubService(), "")
@@ -350,6 +349,7 @@ def test_check_and_report(
                 event,
                 git_project,
                 config=flexmock(deployment=Deployment.stg, command_handler_work_dir=""),
+                job_configs=job_configs,
             )
             is is_valid
         )


### PR DESCRIPTION
* [x] finish code
* [x] fix tests
* [x] get a beer

With this insane refactor, handlers would only use jobconfig and not
packageconfig.

Fixes #418
Fixes #393

I'm pretty sure this will conflict with #675 a lot.