### PR TITLE
Count GitHub webhook calls

### DIFF
--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -13,6 +13,7 @@
           - python3-fedora # to access FAS
           - python3-requests
           - python3-alembic
+          - python3-prometheus_client
           - python3-sqlalchemy
           - python3-psycopg2
           #- python3-celery # don't, the liveness probe doesn't work

--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -22,6 +22,7 @@
           - python3-devel
           - python3-alembic
           - python3-sqlalchemy
+          - python3-prometheus_client
           - python3-psycopg2
           #- python3-celery # don't, the liveness probe doesn't work
           - python3-redis

--- a/packit_service/service/app.py
+++ b/packit_service/service/app.py
@@ -25,6 +25,8 @@ from os import getenv
 
 from flask import Flask
 from lazy_object_proxy import Proxy
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
+from prometheus_client import make_wsgi_app as prometheus_app
 from packit.utils import set_logging
 
 from packit_service.config import ServiceConfig
@@ -64,8 +66,10 @@ def get_flask_application():
     return app
 
 
-application = Proxy(get_flask_application)
+packit_as_a_service = Proxy(get_flask_application)
 
+# Make Prometheus Client serve the /metrics endpoint
+application = DispatcherMiddleware(packit_as_a_service, {"/metrics": prometheus_app()})
 
 # With the code below, you can debug ALL requests coming to flask
 # @application.before_request

--- a/packit_service/service/urls.py
+++ b/packit_service/service/urls.py
@@ -22,7 +22,7 @@
 
 from flask import url_for
 
-from packit_service.service.app import application
+from packit_service.service.app import packit_as_a_service as application
 
 
 def get_srpm_log_url_from_flask(id_: int = None,) -> str:

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -11,7 +11,7 @@ from packit_service.models import (
     GitProjectModel,
     SRPMBuildModel,
 )
-from packit_service.service.app import application
+from packit_service.service.app import packit_as_a_service as application
 from packit_service.service.urls import (
     get_copr_build_info_url_from_flask,
     get_srpm_log_url_from_flask,

--- a/tests_requre/service/conftest.py
+++ b/tests_requre/service/conftest.py
@@ -22,7 +22,7 @@
 
 import pytest
 
-from packit_service.service.app import application
+from packit_service.service.app import packit_as_a_service as application
 
 
 @pytest.fixture


### PR DESCRIPTION
Set up Prometheus Client to serve the `/metrics` endpoint, and
instrument the GitHub webhook to count the number of calls.

Use a label called 'result' to mark the different outcomes of these
calls.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>