### PR TITLE
Match handler for propose update comment

### DIFF
--- a/packit_service/trigger_mapping.py
+++ b/packit_service/trigger_mapping.py
@@ -38,6 +38,7 @@ MAP_JOB_TRIGGER_TO_JOB_CONFIG_TRIGGER_TYPE: Dict[
     TheJobTriggerType.copr_start: JobConfigTriggerType.pull_request,
     TheJobTriggerType.copr_end: JobConfigTriggerType.pull_request,
     TheJobTriggerType.testing_farm_results: JobConfigTriggerType.pull_request,
+    TheJobTriggerType.issue_comment: JobConfigTriggerType.release,
 }
 
 

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -27,16 +27,16 @@ import pytest
 from flexmock import flexmock
 from github import Github
 from github.GitRelease import GitRelease as PyGithubRelease
+
 from ogr.abstract import GitTag
 from ogr.abstract import PullRequest, PRStatus
 from ogr.services.github import GithubProject
 from ogr.services.github import GithubRelease
 from packit.api import PackitAPI
 from packit.local_project import LocalProject
-
 from packit_service.config import ServiceConfig
 from packit_service.constants import SANDCASTLE_WORK_DIR
-from packit_service.models import ProjectReleaseModel
+from packit_service.models import IssueModel
 from packit_service.service.events import IssueCommentEvent
 from packit_service.worker.jobs import SteveJobs
 from packit_service.worker.whitelist import Whitelist
@@ -111,6 +111,6 @@ def test_issue_comment_propose_update_handler(
         get_web_url=lambda: "https://github.com/the-namespace/the-repo",
         is_private=lambda: False,
     )
-    flexmock(IssueCommentEvent, db_trigger=ProjectReleaseModel())
+    flexmock(IssueCommentEvent, db_trigger=IssueModel())
     results = SteveJobs().process_message(issue_comment_propose_update_event)
     assert first_dict_value(results["jobs"])["success"]

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -40,6 +40,7 @@ from packit_service.worker.handlers.github_handlers import (
     PushCoprBuildHandler,
     ReleaseGithubKojiBuildHandler,
     GitHubPullRequestCommentCoprBuildHandler,
+    GitHubIssueCommentProposeUpdateHandler,
 )
 from packit_service.worker.jobs import (
     get_handlers_for_event,
@@ -340,6 +341,18 @@ from packit_service.worker.jobs import (
             ],
             {KojiBuildReportHandler},
             id="config=production_build_and_copr_build@trigger=koji_results",
+        ),
+        pytest.param(
+            TheJobTriggerType.issue_comment,
+            flexmock(job_config_trigger_type=None),
+            [
+                JobConfig(
+                    type=JobType.propose_downstream,
+                    trigger=JobConfigTriggerType.release,
+                ),
+            ],
+            {GitHubIssueCommentProposeUpdateHandler},
+            id="config=propose_downstream@trigger=issue_comment",
         ),
     ],
 )
@@ -881,6 +894,26 @@ def test_get_handlers_for_event(trigger, db_trigger, jobs, result):
             [JobConfig(type=JobType.tests, trigger=JobConfigTriggerType.pull_request)],
             [JobConfig(type=JobType.tests, trigger=JobConfigTriggerType.pull_request)],
             id="pr_comment_when_test_defined",
+        ),
+        pytest.param(
+            ProposeDownstreamHandler,
+            flexmock(
+                trigger=TheJobTriggerType.release,
+                db_trigger=flexmock(job_config_trigger_type=None),
+            ),
+            [
+                JobConfig(
+                    type=JobType.propose_downstream,
+                    trigger=JobConfigTriggerType.release,
+                )
+            ],
+            [
+                JobConfig(
+                    type=JobType.propose_downstream,
+                    trigger=JobConfigTriggerType.release,
+                )
+            ],
+            id="issue_comment_when_propose_downstream_defined",
         ),
     ],
 )


### PR DESCRIPTION
- Use old way for matching propose-downstream comment handler.
- [future] We need to save the run to the database to be able to:
  - not need to use manual matching
  - support multiple triggers
  - I'll create an issue for that. Here it is: https://github.com/packit-service/packit-service/issues/688
- Fixes: #685