### PR TITLE
Add CORS Headers to the API

### DIFF
--- a/packit_service/service/api/copr_builds.py
+++ b/packit_service/service/api/copr_builds.py
@@ -76,6 +76,7 @@ class CoprBuildsList(Resource):
         resp = make_response(dumps(result), HTTPStatus.PARTIAL_CONTENT)
         resp.headers["Content-Range"] = f"copr-builds {first + 1}-{last}/*"
         resp.headers["Content-Type"] = "application/json"
+        resp.headers["Access-Control-Allow-Origin"] = "*"
 
         return resp
 
@@ -128,6 +129,7 @@ class InstallationItem(Resource):
 
             build = make_response(dumps(build_dict))
             build.headers["Content-Type"] = "application/json"
+            build.headers["Access-Control-Allow-Origin"] = "*"
             return build if build else ("", HTTPStatus.NO_CONTENT)
 
         else:

--- a/packit_service/service/api/koji_builds.py
+++ b/packit_service/service/api/koji_builds.py
@@ -54,6 +54,7 @@ class KojiBuildsList(Resource):
         resp = make_response(dumps(result), HTTPStatus.PARTIAL_CONTENT)
         resp.headers["Content-Range"] = f"koji-builds {first + 1}-{last}/{len(result)}"
         resp.headers["Content-Type"] = "application/json"
+        resp.headers["Access-Control-Allow-Origin"] = "*"
 
         return resp
 
@@ -77,6 +78,7 @@ class KojiBuildItem(Resource):
             )
             build = make_response(dumps(build_dict))
             build.headers["Content-Type"] = "application/json"
+            build.headers["Access-Control-Allow-Origin"] = "*"
             return build if build else ("", HTTPStatus.NO_CONTENT)
 
         else:

--- a/packit_service/service/api/testing_farm.py
+++ b/packit_service/service/api/testing_farm.py
@@ -168,5 +168,6 @@ class TestingFarmResults(Resource):
         resp = make_response(dumps(result), HTTPStatus.PARTIAL_CONTENT)
         resp.headers["Content-Range"] = f"test-results {first + 1}-{last}/*"
         resp.headers["Content-Type"] = "application/json"
+        resp.headers["Access-Control-Allow-Origin"] = "*"
 
         return resp


### PR DESCRIPTION
Right now we dont have CORS headers so essentially we do not allow API requests from other websites. This doesnt affect curl/requests/etc since they ignore them. However browsers do respect them so theyre blocking requests from javascript.

According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSMissingAllowOrigin), its okay for public APIs to wildcard allow API requests from anywhere.

