### PR TITLE
Don't use 'package_config' when there is none

### DIFF
--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -427,7 +427,7 @@ class SteveJobs:
         event_dict = event_object.get_dict()
         if event_object.trigger == TheJobTriggerType.installation:
             handler = GithubAppInstallationHandler(
-                package_config=event_object.package_config,
+                package_config=None,
                 job_config=None,
                 data=EventData.from_event_dict(event_dict),
             )

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -436,7 +436,7 @@ class SteveJobs:
         # Label/Tag added event handler is run even when the job is not configured in package
         elif event_object.trigger == TheJobTriggerType.pr_label:
             handler = PagurePullRequestLabelHandler(
-                package_config=event_object.package_config,
+                package_config=None,
                 job_config=None,
                 data=EventData.from_event_dict(event_dict),
             )


### PR DESCRIPTION
'package_config' is not used in `GithubAppInstallationHandler` and `PagurePullRequestLabelHandler` objects, 
and calling 'event_object.package_config' was raising and error as installation events don't have this attribute.