### PR TITLE
Create Celery tasks to run handlers

### DIFF
--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -735,26 +735,16 @@ class InstallationEvent(Event):
 
     @classmethod
     def from_event_dict(cls, event: dict):
-        account_type = event.get("account_type")
-        account_login = event.get("account_login")
-        sender_login = event.get("sender_login")
-        account_id = event.get("account_id")
-        account_url = event.get("account_url")
-        sender_id = event.get("sender_id")
-        created_at = event.get("created_at")
-        installation_id = event.get("installation_id")
-        repositories = event.get("repositories")
-
         return InstallationEvent(
-            installation_id=installation_id,
-            account_login=account_login,
-            account_id=account_id,
-            account_url=account_url,
-            account_type=account_type,
-            created_at=created_at,
-            repositories=repositories,
-            sender_id=sender_id,
-            sender_login=sender_login,
+            installation_id=event.get("installation_id"),
+            account_login=event.get("account_login"),
+            account_id=event.get("account_id"),
+            account_url=event.get("account_url"),
+            account_type=event.get("account_type"),
+            created_at=event.get("created_at"),
+            repositories=event.get("repositories"),
+            sender_id=event.get("sender_id"),
+            sender_login=event.get("sender_login"),
         )
 
     def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
@@ -970,22 +960,17 @@ class KojiBuildEvent(AbstractForgeIndependentEvent):
 
     @classmethod
     def from_event_dict(cls, event: dict):
-        build_id = event.get("build_id")
-        state = KojiBuildState(event.get("state")) if event.get("state") else None
-        old_state = (
-            KojiBuildState(event.get("old_state")) if event.get("old_state") else None
-        )
-        start_time = event.get("start_time")
-        rpm_build_task_id = event.get("rpm_build_task_id")
-        completion_time = event.get("completion_time")
-
         return KojiBuildEvent(
-            build_id=build_id,
-            state=state,
-            old_state=old_state,
-            rpm_build_task_id=rpm_build_task_id,
-            start_time=start_time,
-            completion_time=completion_time,
+            build_id=event.get("build_id"),
+            state=KojiBuildState(event.get("state")) if event.get("state") else None,
+            old_state=(
+                KojiBuildState(event.get("old_state"))
+                if event.get("old_state")
+                else None
+            ),
+            rpm_build_task_id=event.get("rpm_build_task_id"),
+            start_time=event.get("start_time"),
+            completion_time=event.get("completion_time"),
         )
 
     def get_base_project(self) -> Optional[GitProject]:
@@ -1125,24 +1110,15 @@ class CoprBuildEvent(AbstractForgeIndependentEvent):
 
     @classmethod
     def from_event_dict(cls, event: dict):
-        topic = event.get("topic")
-        project_name = event.get("project_name")
-        owner = event.get("owner")
-        build_id = event.get("build_id")
-        chroot = event.get("chroot")
-        timestamp = event.get("timestamp")
-        pkg = event.get("pkg")
-        status = event.get("status")
-
         return CoprBuildEvent.from_build_id(
-            topic=topic,
-            build_id=build_id,
-            chroot=chroot,
-            status=status,
-            owner=owner,
-            project_name=project_name,
-            pkg=pkg,
-            timestamp=timestamp,
+            topic=event.get("topic"),
+            build_id=event.get("build_id"),
+            chroot=event.get("chroot"),
+            status=event.get("status"),
+            owner=event.get("owner"),
+            project_name=event.get("project_name"),
+            pkg=event.get("pkg"),
+            timestamp=event.get("timestamp"),
         )
 
     def pre_check(self):

--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -1304,10 +1304,6 @@ class PullRequestLabelPagureEvent(AddPullRequestDbTrigger, AbstractPagureEvent):
         self.commit_sha = commit_sha
         self.labels = labels
 
-    @property
-    def package_config(self):
-        return None
-
     def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
         result = super().get_dict()
         result["action"] = result["action"].value

--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -852,6 +852,7 @@ class TestingFarmResultsEvent(AbstractForgeIndependentEvent):
         result = super().get_dict()
         result["result"] = result["result"].value
         result["pr_id"] = self.pr_id
+        result.pop("_db_trigger")
         return result
 
     @property
@@ -995,6 +996,8 @@ class KojiBuildEvent(AbstractForgeIndependentEvent):
         result["pr_id"] = self.pr_id
         result["git_ref"] = self.git_ref
         result["identifier"] = self.identifier
+        result.pop("_build_model")
+        result.pop("_db_trigger")
         return result
 
     def get_koji_build_logs_url(self) -> Optional[str]:

--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -200,6 +200,12 @@ class EventData:
             event_dict=event,
         )
 
+    def get_dict(self) -> dict:
+        d = self.__dict__
+        d = copy.deepcopy(d)
+        d["trigger"] = d["trigger"].value
+        return d
+
 
 class Event:
     def __init__(
@@ -371,6 +377,14 @@ class AbstractForgeIndependentEvent(Event):
         if package_config:
             package_config.upstream_project_url = self.project_url
         return package_config
+
+    def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
+        result = super().get_dict()
+        # so that it is JSON serializable (because of Celery tasks)
+        result.pop("_project")
+        result.pop("_base_project")
+        result.pop("_package_config")
+        return result
 
 
 class AbstractGithubEvent(AbstractForgeIndependentEvent):

--- a/packit_service/utils.py
+++ b/packit_service/utils.py
@@ -21,6 +21,10 @@
 # SOFTWARE.
 import logging
 
+from packit.config import JobConfig, PackageConfig
+
+from packit.schema import PackageConfigSchema, JobConfigSchema
+
 logger = logging.getLogger(__name__)
 
 
@@ -44,3 +48,20 @@ class only_once(object):
             f"args: {args} and kwargs: {kwargs}"
         )
         return self.func(*args, **kwargs)
+
+
+# wrappers for dumping/loading of configs
+def load_package_config(package_config: PackageConfig):
+    return PackageConfigSchema().load_config(package_config) if package_config else None
+
+
+def dump_package_config(package_config: PackageConfig):
+    return PackageConfigSchema().dump_config(package_config) if package_config else None
+
+
+def load_job_config(job_config: JobConfig):
+    return JobConfigSchema().load_config(job_config) if job_config else None
+
+
+def dump_job_config(job_config: JobConfig):
+    return JobConfigSchema().dump_config(job_config) if job_config else None

--- a/packit_service/worker/build/babysit.py
+++ b/packit_service/worker/build/babysit.py
@@ -93,10 +93,10 @@ def check_copr_build(build_id: int) -> bool:
         )
 
         for job_config in job_configs:
-            event_dict = event.get_dict()
             CoprBuildEndHandler(
                 package_config=event.package_config,
                 job_config=job_config,
-                data=EventData.from_event_dict(event_dict),
+                data=EventData.from_event_dict(event.get_dict()),
+                copr_event=event,
             ).run()
     return True

--- a/packit_service/worker/build/copr_build.py
+++ b/packit_service/worker/build/copr_build.py
@@ -39,7 +39,7 @@ from packit_service.service.urls import (
     get_copr_build_info_url_from_flask,
 )
 from packit_service.worker.build.build_helper import BaseBuildJobHelper
-from packit_service.worker.result import HandlerResults
+from packit_service.worker.result import TaskResults
 
 logger = logging.getLogger(__name__)
 
@@ -149,12 +149,12 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
         """
         return get_build_targets(*self.configured_tests_targets, default=None)
 
-    def run_copr_build(self) -> HandlerResults:
+    def run_copr_build(self) -> TaskResults:
 
         if not (self.job_build or self.job_tests):
             msg = "No copr_build or tests job defined."
             # we can't report it to end-user at this stage
-            return HandlerResults(success=False, details={"msg": msg})
+            return TaskResults(success=False, details={"msg": msg})
 
         self.report_status_to_all(
             description="Building SRPM ...",
@@ -171,7 +171,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
                 description=msg,
                 url=get_srpm_log_url_from_flask(self.srpm_model.id),
             )
-            return HandlerResults(success=False, details={"msg": msg})
+            return TaskResults(success=False, details={"msg": msg})
 
         try:
             build_id, web_url = self.run_build()
@@ -183,7 +183,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
                 state=CommitStatus.error,
                 description=f"Submit of the build failed: {ex}",
             )
-            return HandlerResults(success=False, details={"error": str(ex)})
+            return TaskResults(success=False, details={"error": str(ex)})
 
         for chroot in self.build_targets:
             copr_build = CoprBuildModel.get_or_create(
@@ -212,7 +212,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
             countdown=120,  # do the first check in 120s
         )
 
-        return HandlerResults(success=True, details={})
+        return TaskResults(success=True, details={})
 
     def run_build(
         self, target: Optional[str] = None

--- a/packit_service/worker/build/koji_build.py
+++ b/packit_service/worker/build/koji_build.py
@@ -39,7 +39,8 @@ from packit_service.service.urls import (
     get_koji_build_info_url_from_flask,
 )
 from packit_service.worker.build.build_helper import BaseBuildJobHelper
-from packit_service.worker.result import HandlerResults
+from packit_service.worker.result import TaskResults
+from packit_service.service.events import EventData
 
 logger = logging.getLogger(__name__)
 
@@ -112,7 +113,7 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
             self._supported_koji_targets = get_all_koji_targets()
         return self._supported_koji_targets
 
-    def run_koji_build(self) -> HandlerResults:
+    def run_koji_build(self) -> TaskResults:
         self.report_status_to_all(
             description="Building SRPM ...", state=CommitStatus.pending
         )
@@ -125,7 +126,7 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
                 description=msg,
                 url=get_srpm_log_url_from_flask(self.srpm_model.id),
             )
-            return HandlerResults(success=False, details={"msg": msg})
+            return TaskResults(success=False, details={"msg": msg})
 
         try:
             # We need to do it manually
@@ -139,7 +140,7 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
                 description=msg,
                 url=get_srpm_log_url_from_flask(self.srpm_model.id),
             )
-            return HandlerResults(success=False, details={"msg": msg})
+            return TaskResults(success=False, details={"msg": msg})
 
         errors: Dict[str, str] = {}
         for target in self.build_targets:
@@ -188,7 +189,7 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
             )
 
         if errors:
-            return HandlerResults(
+            return TaskResults(
                 success=False,
                 details={
                     "msg": "Koji build submit was not successful for all chroots.",
@@ -205,7 +206,7 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
         )
         """
 
-        return HandlerResults(success=True, details={})
+        return TaskResults(success=True, details={})
 
     def run_build(
         self, target: Optional[str] = None

--- a/packit_service/worker/build/koji_build.py
+++ b/packit_service/worker/build/koji_build.py
@@ -33,7 +33,6 @@ from packit_service import sentry_integration
 from packit_service.config import ServiceConfig
 from packit_service.constants import MSG_RETRIGGER
 from packit_service.models import KojiBuildModel
-from packit_service.service.events import EventData
 from packit_service.service.urls import (
     get_srpm_log_url_from_flask,
     get_koji_build_info_url_from_flask,

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -215,7 +215,7 @@ class JobHandler(Handler):
     def run_job(self):
         """
         If pre-check succeeds, run the job for the specific handler.
-        :return: TaskResults
+        :return: Dict [str, TaskResults]
         """
         job_type = self.job_config.type or self.type
         logger.debug(f"Running handler {str(self)} for {job_type}")

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -23,6 +23,7 @@
 """
 This file defines generic job handler
 """
+import enum
 import logging
 import shutil
 from collections import defaultdict
@@ -92,6 +93,28 @@ def use_for(job_type: JobType):
         return kls
 
     return _add_to_mapping
+
+
+class TaskName(str, enum.Enum):
+    copr_build_start = "task.run_copr_build_start_handler"
+    copr_build_end = "task.run_copr_build_end_handler"
+    release_copr_build = "task.run_release_copr_build_handler"
+    pr_copr_build = "task.run_pr_copr_build_handler"
+    pr_comment_copr_build = "task.run_pr_comment_copr_build_handler"
+    push_copr_build = "task.run_push_copr_build_handler"
+    installation = "task.run_installation_handler"
+    testing_farm = "task.run_testing_farm_handler"
+    testing_farm_comment = "task.run_testing_farm_comment_handler"
+    testing_farm_results = "task.run_testing_farm_results_handler"
+    propose_update_comment = "task.run_propose_update_comment_handler"
+    propose_downstream = "task.run_propose_downstream_handler"
+    release_koji_build = "task.run_release_koji_build_handler"
+    pr_koji_build = "task.run_pr_koji_build_handler"
+    push_koji_build = "task.run_push_koji_build_handler"
+    distgit_commit = "task.run_distgit_commit_handler"
+    pagure_pr_comment_copr_build = "task.run_pagure_pr_comment_copr_build_handler"
+    pagure_pr_label = "task.run_pagure_pr_label_handler"
+    koji_build_report = "task.run_koji_build_report_handler"
 
 
 class Handler:
@@ -178,7 +201,7 @@ class JobHandler(Handler):
 
     type: JobType
     triggers: List[TheJobTriggerType]
-    task_name: str
+    task_name: TaskName
 
     def __init__(
         self, package_config: PackageConfig, job_config: JobConfig, data: EventData,
@@ -246,7 +269,7 @@ class JobHandler(Handler):
         """
         logger.debug(f"Getting signature of a Celery task {cls.task_name}.")
         return signature(
-            cls.task_name,
+            cls.task_name.value,
             kwargs={
                 "package_config": dump_package_config(event.package_config),
                 "job_config": dump_job_config(job),

--- a/packit_service/worker/handlers/comment_action_handler.py
+++ b/packit_service/worker/handlers/comment_action_handler.py
@@ -31,9 +31,7 @@ from typing import Dict, Type
 from packit.config import JobConfig
 from packit.config.package_config import PackageConfig
 
-from packit_service.service.events import EventData
 from packit_service.worker.handlers import JobHandler
-
 from packit_service.worker.result import TaskResults
 from packit_service.service.events import EventData
 

--- a/packit_service/worker/handlers/comment_action_handler.py
+++ b/packit_service/worker/handlers/comment_action_handler.py
@@ -33,7 +33,9 @@ from packit.config.package_config import PackageConfig
 
 from packit_service.service.events import EventData
 from packit_service.worker.handlers import JobHandler
-from packit_service.worker.result import HandlerResults
+
+from packit_service.worker.result import TaskResults
+from packit_service.service.events import EventData
 
 logger = logging.getLogger(__name__)
 
@@ -86,5 +88,5 @@ class CommentActionHandler(JobHandler):
             package_config=package_config, job_config=job_config, data=data,
         )
 
-    def run(self) -> HandlerResults:
+    def run(self) -> TaskResults:
         raise NotImplementedError("This should have been implemented.")

--- a/packit_service/worker/handlers/fedmsg_handlers.py
+++ b/packit_service/worker/handlers/fedmsg_handlers.py
@@ -66,6 +66,7 @@ from packit_service.worker.handlers.abstract import (
     JobHandler,
     use_for,
     required_by,
+    TaskName,
 )
 from packit_service.worker.result import TaskResults
 from packit_service.utils import dump_package_config, dump_job_config
@@ -105,7 +106,7 @@ class NewDistGitCommitHandler(FedmsgHandler):
 
     topic = "org.fedoraproject.prod.git.receive"
     triggers = [TheJobTriggerType.commit]
-    task_name = "task.run_distgit_commit_handler"
+    task_name = TaskName.distgit_commit
 
     def __init__(
         self, package_config: PackageConfig, job_config: JobConfig, data: EventData,
@@ -182,7 +183,7 @@ class AbstractCoprBuildReportHandler(FedmsgHandler):
 class CoprBuildEndHandler(AbstractCoprBuildReportHandler):
     topic = "org.fedoraproject.prod.copr.build.end"
     triggers = [TheJobTriggerType.copr_end]
-    task_name = "task.run_copr_build_end_handler"
+    task_name = TaskName.copr_build_end
 
     def was_last_packit_comment_with_congratulation(self):
         """
@@ -313,7 +314,7 @@ class CoprBuildEndHandler(AbstractCoprBuildReportHandler):
 class CoprBuildStartHandler(AbstractCoprBuildReportHandler):
     topic = "org.fedoraproject.prod.copr.build.start"
     triggers = [TheJobTriggerType.copr_start]
-    task_name = "task.run_copr_build_start_handler"
+    task_name = TaskName.copr_build_start
 
     def run(self):
         build_job_helper = CoprBuildJobHelper(
@@ -362,7 +363,7 @@ class CoprBuildStartHandler(AbstractCoprBuildReportHandler):
 class KojiBuildReportHandler(FedmsgHandler):
     topic = "org.fedoraproject.prod.buildsys.task.state.change"
     triggers = [TheJobTriggerType.koji_results]
-    task_name = "task.run_koji_build_report_handler"
+    task_name = TaskName.koji_build_report
 
     def __init__(
         self,

--- a/packit_service/worker/handlers/github_handlers.py
+++ b/packit_service/worker/handlers/github_handlers.py
@@ -60,7 +60,7 @@ from packit_service.worker.handlers import (
     CommentActionHandler,
     JobHandler,
 )
-from packit_service.worker.handlers.abstract import required_by, use_for
+from packit_service.worker.handlers.abstract import required_by, use_for, TaskName
 from packit_service.worker.handlers.comment_action_handler import (
     add_to_comment_action_mapping,
     add_to_comment_action_mapping_with_name,
@@ -76,7 +76,7 @@ logger = logging.getLogger(__name__)
 class GithubAppInstallationHandler(JobHandler):
     type = JobType.add_to_whitelist
     triggers = [TheJobTriggerType.installation]
-    task_name = "task.run_installation_handler"
+    task_name = TaskName.installation
 
     # https://developer.github.com/v3/activity/events/types/#events-api-payload-28
 
@@ -132,7 +132,7 @@ class GithubAppInstallationHandler(JobHandler):
 class ProposeDownstreamHandler(JobHandler):
     type = JobType.propose_downstream
     triggers = [TheJobTriggerType.release]
-    task_name = "task.run_propose_downstream_handler"
+    task_name = TaskName.propose_downstream
 
     def run(self) -> TaskResults:
         """
@@ -238,7 +238,7 @@ class ReleaseCoprBuildHandler(AbstractCoprBuildHandler):
     triggers = [
         TheJobTriggerType.release,
     ]
-    task_name = "task.run_release_copr_build_handler"
+    task_name = TaskName.release_copr_build
 
     def pre_check(self) -> bool:
         return (
@@ -255,7 +255,7 @@ class PullRequestCoprBuildHandler(AbstractCoprBuildHandler):
     triggers = [
         TheJobTriggerType.pull_request,
     ]
-    task_name = "task.run_pr_copr_build_handler"
+    task_name = TaskName.pr_copr_build
 
     def run(self) -> TaskResults:
         if self.data.event_type in (
@@ -296,7 +296,7 @@ class PushCoprBuildHandler(AbstractCoprBuildHandler):
         TheJobTriggerType.push,
         TheJobTriggerType.commit,
     ]
-    task_name = "task.run_push_copr_build_handler"
+    task_name = TaskName.push_copr_build
 
     def pre_check(self) -> bool:
         valid = (
@@ -386,7 +386,7 @@ class ReleaseGithubKojiBuildHandler(AbstractGithubKojiBuildHandler):
     triggers = [
         TheJobTriggerType.release,
     ]
-    task_name = "task.run_release_koji_build_handler"
+    task_name = TaskName.release_koji_build
 
     def pre_check(self) -> bool:
         return (
@@ -401,7 +401,7 @@ class PullRequestGithubKojiBuildHandler(AbstractGithubKojiBuildHandler):
     triggers = [
         TheJobTriggerType.pull_request,
     ]
-    task_name = "task.run_pr_koji_build_handler"
+    task_name = TaskName.pr_koji_build
 
     def run(self) -> TaskResults:
         if self.data.event_type == PullRequestGithubEvent.__name__:
@@ -432,7 +432,7 @@ class PushGithubKojiBuildHandler(AbstractGithubKojiBuildHandler):
         TheJobTriggerType.push,
         TheJobTriggerType.commit,
     ]
-    task_name = "task.run_push_koji_build_handler"
+    task_name = TaskName.push_koji_build
 
     def pre_check(self) -> bool:
         valid = (
@@ -498,7 +498,7 @@ class GitHubPullRequestCommentCoprBuildHandler(CommentActionHandler):
 
     type = CommentAction.copr_build
     triggers = [TheJobTriggerType.pr_comment]
-    task_name = "task.run_pr_comment_copr_build_handler"
+    task_name = TaskName.pr_comment_copr_build
 
     def run(self) -> TaskResults:
         user_can_merge_pr = self.project.can_merge_pr(self.data.user_login)
@@ -545,7 +545,7 @@ class GitHubIssueCommentProposeUpdateHandler(CommentActionHandler):
 
     type = CommentAction.propose_update
     triggers = [TheJobTriggerType.issue_comment]
-    task_name = "task.run_propose_update_comment_handler"
+    task_name = TaskName.propose_update_comment
 
     @property
     def dist_git_branches_to_sync(self) -> Set[str]:
@@ -627,7 +627,7 @@ class GitHubPullRequestCommentTestingFarmHandler(CommentActionHandler):
 
     type = CommentAction.test
     triggers = [TheJobTriggerType.pr_comment]
-    task_name = "task.run_testing_farm_comment_handler"
+    task_name = TaskName.testing_farm_comment
 
     def run(self) -> TaskResults:
         testing_farm_helper = TestingFarmJobHelper(

--- a/packit_service/worker/handlers/github_handlers.py
+++ b/packit_service/worker/handlers/github_handlers.py
@@ -39,7 +39,7 @@ from packit.local_project import LocalProject
 
 from packit_service import sentry_integration
 from packit_service.constants import PERMISSIONS_ERROR_WRITE_OR_ADMIN
-from packit_service.models import InstallationModel, AbstractTriggerDbType
+from packit_service.models import InstallationModel
 from packit_service.service.events import (
     TheJobTriggerType,
     ReleaseEvent,
@@ -467,17 +467,11 @@ class GithubTestingFarmHandler(JobHandler):
         job_config: JobConfig,
         data: EventData,
         chroot: str,
-        db_trigger: AbstractTriggerDbType,
     ):
         super().__init__(
             package_config=package_config, job_config=job_config, data=data,
         )
         self.chroot = chroot
-        self._db_trigger = db_trigger
-
-    @property
-    def db_trigger(self):
-        return self._db_trigger
 
     def run(self) -> TaskResults:
         # TODO: once we turn hanadlers into respective celery tasks, we should iterate

--- a/packit_service/worker/handlers/pagure_handlers.py
+++ b/packit_service/worker/handlers/pagure_handlers.py
@@ -197,5 +197,7 @@ class PagurePullRequestLabelHandler(JobHandler):
             self._attach_patch()
             self._set_status()
         else:
-            logger.debug(f"We accept only {self.service_config.pr_accepted_labels} labels/tags")
+            logger.debug(
+                f"We accept only {self.service_config.pr_accepted_labels} labels/tags"
+            )
         return TaskResults(success=True)

--- a/packit_service/worker/handlers/pagure_handlers.py
+++ b/packit_service/worker/handlers/pagure_handlers.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 import logging
-from typing import Optional
+from typing import Optional, Set
 
 from ogr.abstract import CommitStatus, PullRequest
 from packit.config import JobType, JobConfig, PackageConfig
@@ -38,7 +38,7 @@ from packit_service.worker.handlers.abstract import use_for, JobHandler
 from packit_service.worker.handlers.comment_action_handler import CommentAction
 from packit_service.worker.psbugzilla import Bugzilla
 from packit_service.worker.reporting import StatusReporter
-from packit_service.worker.result import HandlerResults
+from packit_service.worker.result import TaskResults
 
 logger = logging.getLogger(__name__)
 
@@ -50,13 +50,10 @@ class PagurePullRequestCommentCoprBuildHandler(CommentActionHandler):
 
     type = CommentAction.copr_build
     triggers = [TheJobTriggerType.pr_comment]
+    task_name = "task.run_pagure_pr_comment_copr_build_handler"
 
     def __init__(
-        self,
-        package_config: PackageConfig,
-        job_config: JobConfig,
-        data: EventData,
-        **kwargs,
+        self, package_config: PackageConfig, job_config: JobConfig, data: EventData,
     ):
         super().__init__(
             package_config=package_config, job_config=job_config, data=data,
@@ -78,25 +75,34 @@ class PagurePullRequestCommentCoprBuildHandler(CommentActionHandler):
             )
         return self._copr_build_helper
 
-    def run(self) -> HandlerResults:
+    def run(self) -> TaskResults:
         return self.copr_build_helper.run_copr_build()
 
 
 class PagurePullRequestLabelHandler(JobHandler):
     type = JobType.create_bugzilla
     triggers = [TheJobTriggerType.pr_label]
+    task_name = "task.run_pagure_pr_label_handler"
 
     def __init__(
-        self, package_config: PackageConfig, job_config: JobConfig, data: EventData,
+        self,
+        package_config: PackageConfig,
+        job_config: JobConfig,
+        data: EventData,
+        labels: Set[str],
+        action: PullRequestLabelAction,
+        base_repo_owner: str,
+        base_repo_name: str,
+        base_repo_namespace: str,
     ):
         super().__init__(
             package_config=package_config, job_config=job_config, data=data
         )
-        self.labels = data.event_dict.get("labels")
-        self.action = PullRequestLabelAction(data.event_dict.get("action"))
-        self.base_repo_owner = data.event_dict.get("base_repo_owner")
-        self.base_repo_namespace = data.event_dict.get("base_repo_namespace")
-        self.base_repo_name = data.event_dict.get("base_repo_name")
+        self.labels = labels
+        self.action = action
+        self.base_repo_owner = base_repo_owner
+        self.base_repo_name = base_repo_name
+        self.base_repo_namespace = base_repo_namespace
 
         self.pr: PullRequest = self.project.get_pr(self.data.pr_id)
         # lazy properties
@@ -179,7 +185,7 @@ class PagurePullRequestLabelHandler(JobHandler):
             url=self.bz_model.bug_url,
         )
 
-    def run(self) -> HandlerResults:
+    def run(self) -> TaskResults:
         logger.debug(
             f"Handling labels/tags {self.labels} {self.action.value} to Pagure PR "
             f"{self.base_repo_owner}/{self.base_repo_namespace}/"
@@ -191,7 +197,5 @@ class PagurePullRequestLabelHandler(JobHandler):
             self._attach_patch()
             self._set_status()
         else:
-            logger.debug(
-                f"We accept only {self.service_config.pr_accepted_labels} labels/tags"
-            )
-        return HandlerResults(success=True)
+            logger.debug(f"We accept only {self.service_config.pr_accepted_labels} labels/tags")
+        return TaskResults(success=True)

--- a/packit_service/worker/handlers/pagure_handlers.py
+++ b/packit_service/worker/handlers/pagure_handlers.py
@@ -34,7 +34,7 @@ from packit_service.service.events import (
 )
 from packit_service.worker.build import CoprBuildJobHelper
 from packit_service.worker.handlers import CommentActionHandler
-from packit_service.worker.handlers.abstract import use_for, JobHandler
+from packit_service.worker.handlers.abstract import use_for, JobHandler, TaskName
 from packit_service.worker.handlers.comment_action_handler import CommentAction
 from packit_service.worker.psbugzilla import Bugzilla
 from packit_service.worker.reporting import StatusReporter
@@ -50,7 +50,7 @@ class PagurePullRequestCommentCoprBuildHandler(CommentActionHandler):
 
     type = CommentAction.copr_build
     triggers = [TheJobTriggerType.pr_comment]
-    task_name = "task.run_pagure_pr_comment_copr_build_handler"
+    task_name = TaskName.pagure_pr_comment_copr_build
 
     def __init__(
         self, package_config: PackageConfig, job_config: JobConfig, data: EventData,
@@ -82,7 +82,7 @@ class PagurePullRequestCommentCoprBuildHandler(CommentActionHandler):
 class PagurePullRequestLabelHandler(JobHandler):
     type = JobType.create_bugzilla
     triggers = [TheJobTriggerType.pr_label]
-    task_name = "task.run_pagure_pr_label_handler"
+    task_name = TaskName.pagure_pr_label
 
     def __init__(
         self,

--- a/packit_service/worker/handlers/testing_farm_handlers.py
+++ b/packit_service/worker/handlers/testing_farm_handlers.py
@@ -38,7 +38,7 @@ from packit_service.service.events import (
     TestResult,
 )
 from packit_service.worker.handlers import JobHandler
-from packit_service.worker.handlers.abstract import use_for
+from packit_service.worker.handlers.abstract import use_for, TaskName
 from packit_service.worker.reporting import StatusReporter
 from packit_service.worker.result import TaskResults
 from packit_service.worker.testing_farm import TestingFarmJobHelper
@@ -50,7 +50,7 @@ logger = logging.getLogger(__name__)
 class TestingFarmResultsHandler(JobHandler):
     type = JobType.report_test_results
     triggers = [TheJobTriggerType.testing_farm_results]
-    task_name = "task.run_testing_farm_results_handler"
+    task_name = TaskName.testing_farm_results
 
     def __init__(
         self,

--- a/packit_service/worker/handlers/testing_farm_handlers.py
+++ b/packit_service/worker/handlers/testing_farm_handlers.py
@@ -24,7 +24,7 @@
 This file defines classes for job handlers specific for Testing farm
 """
 import logging
-from typing import Optional
+from typing import Optional, List
 
 from ogr.abstract import CommitStatus
 from packit.config import JobType, JobConfig
@@ -35,11 +35,12 @@ from packit_service.service.events import (
     TestingFarmResult,
     TheJobTriggerType,
     EventData,
+    TestResult,
 )
 from packit_service.worker.handlers import JobHandler
 from packit_service.worker.handlers.abstract import use_for
 from packit_service.worker.reporting import StatusReporter
-from packit_service.worker.result import HandlerResults
+from packit_service.worker.result import TaskResults
 from packit_service.worker.testing_farm import TestingFarmJobHelper
 
 logger = logging.getLogger(__name__)
@@ -49,24 +50,30 @@ logger = logging.getLogger(__name__)
 class TestingFarmResultsHandler(JobHandler):
     type = JobType.report_test_results
     triggers = [TheJobTriggerType.testing_farm_results]
+    task_name = "task.run_testing_farm_results_handler"
 
     def __init__(
-        self, package_config: PackageConfig, job_config: JobConfig, data: EventData,
+        self,
+        package_config: PackageConfig,
+        job_config: JobConfig,
+        data: EventData,
+        tests: List[TestResult],
+        result: TestingFarmResult,
+        pipeline_id: str,
+        log_url: str,
+        copr_chroot: str,
+        message: str,
     ):
         super().__init__(
             package_config=package_config, job_config=job_config, data=data,
         )
 
-        self.tests = data.event_dict.get("tests")
-        self.result = (
-            TestingFarmResult(data.event_dict.get("result"))
-            if data.event_dict.get("result")
-            else None
-        )
-        self.pipeline_id = data.event_dict.get("pipeline_id")
-        self.log_url = data.event_dict.get("log_url")
-        self.copr_chroot = data.event_dict.get("copr_chroot")
-        self.message = data.event_dict.get("message")
+        self.tests = tests
+        self.result = result
+        self.pipeline_id = pipeline_id
+        self.log_url = log_url
+        self.copr_chroot = copr_chroot
+        self.message = message
         self._db_trigger: Optional[AbstractTriggerDbType] = None
 
     @property
@@ -77,7 +84,7 @@ class TestingFarmResultsHandler(JobHandler):
                 self._db_trigger = run_model.job_trigger.get_trigger_object()
         return self._db_trigger
 
-    def run(self) -> HandlerResults:
+    def run(self) -> TaskResults:
 
         logger.debug(f"Received testing-farm result:\n{self.result}")
         logger.debug(f"Received testing-farm test results:\n{self.tests}")
@@ -118,4 +125,4 @@ class TestingFarmResultsHandler(JobHandler):
             check_names=TestingFarmJobHelper.get_test_check(self.copr_chroot),
         )
 
-        return HandlerResults(success=True, details={})
+        return TaskResults(success=True, details={})

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -467,7 +467,7 @@ class SteveJobs:
             success=True,
             details={
                 "event": event_object.get_dict(),
-                "package_config": None,
+                "package_config": event_object.package_config,
                 "matching_jobs": None,
             },
         )

--- a/packit_service/worker/result.py
+++ b/packit_service/worker/result.py
@@ -1,7 +1,7 @@
 from typing import Dict, Any
 
 
-class HandlerResults(dict):
+class TaskResults(dict):
     """
     Job handler results.
     Inherit from dict to be JSON serializable.

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -24,8 +24,46 @@ from typing import Optional
 
 from packit_service.celerizer import celery_app
 from packit_service.models import TaskResultModel
+from packit_service.service.events import (
+    CoprBuildEvent,
+    InstallationEvent,
+    KojiBuildEvent,
+    PullRequestLabelAction,
+    TestingFarmResult,
+    EventData,
+)
 from packit_service.worker.build.babysit import check_copr_build
 from packit_service.worker.jobs import SteveJobs
+from packit_service.worker.handlers.github_handlers import (
+    GithubAppInstallationHandler,
+    GitHubIssueCommentProposeUpdateHandler,
+    ReleaseGithubKojiBuildHandler,
+    PushGithubKojiBuildHandler,
+    PullRequestGithubKojiBuildHandler,
+    PushCoprBuildHandler,
+    ReleaseCoprBuildHandler,
+    PullRequestCoprBuildHandler,
+    ProposeDownstreamHandler,
+    GitHubPullRequestCommentTestingFarmHandler,
+)
+
+from packit_service.worker.handlers.fedmsg_handlers import (
+    CoprBuildStartHandler,
+    CoprBuildEndHandler,
+    KojiBuildReportHandler,
+    NewDistGitCommitHandler,
+)
+
+from packit_service.worker.handlers.pagure_handlers import (
+    PagurePullRequestCommentCoprBuildHandler,
+    PagurePullRequestLabelHandler,
+)
+
+from packit_service.worker.handlers.testing_farm_handlers import (
+    TestingFarmResultsHandler,
+)
+
+from packit.schema import PackageConfigSchema, JobConfigSchema
 
 logger = logging.getLogger(__name__)
 
@@ -74,3 +112,222 @@ def babysit_copr_build(self, build_id: int):
     """ check status of a copr build and update it in DB """
     if not check_copr_build(build_id=build_id):
         self.retry()
+
+
+# tasks for running the handlers
+@celery_app.task(name="task.run_copr_build_start_handler")
+def run_copr_build_start_handler(event: dict, package_config: dict, job_config: dict):
+    handler = CoprBuildStartHandler(
+        package_config=PackageConfigSchema().load_config(package_config),
+        job_config=JobConfigSchema().load_config(job_config),
+        data=EventData.from_event_dict(event),
+        copr_event=CoprBuildEvent.from_event_dict(event),
+    )
+    return handler.run_job()
+
+
+@celery_app.task(name="task.run_copr_build_end_handler")
+def run_copr_build_end_handler(event: dict, package_config: dict, job_config: dict):
+    handler = CoprBuildEndHandler(
+        package_config=PackageConfigSchema().load_config(package_config),
+        job_config=JobConfigSchema().load_config(job_config),
+        data=EventData.from_event_dict(event),
+        copr_event=CoprBuildEvent.from_event_dict(event),
+    )
+    return handler.run_job()
+
+
+@celery_app.task(name="task.run_release_copr_build_handler")
+def run_release_copr_build_handler(event: dict, package_config: dict, job_config: dict):
+    handler = ReleaseCoprBuildHandler(
+        package_config=PackageConfigSchema().load_config(package_config),
+        job_config=JobConfigSchema().load_config(job_config),
+        data=EventData.from_event_dict(event),
+    )
+    return handler.run_job()
+
+
+@celery_app.task(name="task.run_pr_copr_build_handler")
+def run_pr_copr_build_handler(event: dict, package_config: dict, job_config: dict):
+    handler = PullRequestCoprBuildHandler(
+        package_config=PackageConfigSchema().load_config(package_config),
+        job_config=JobConfigSchema().load_config(job_config),
+        data=EventData.from_event_dict(event),
+    )
+    return handler.run_job()
+
+
+@celery_app.task(name="task.run_pr_comment_copr_build_handler")
+def run_pr_comment_copr_build_handler(
+    event: dict, package_config: dict, job_config: dict
+):
+    handler = PullRequestCoprBuildHandler(
+        package_config=PackageConfigSchema().load_config(package_config),
+        job_config=JobConfigSchema().load_config(job_config),
+        data=EventData.from_event_dict(event),
+    )
+    return handler.run_job()
+
+
+@celery_app.task(name="task.run_push_copr_build_handler")
+def run_push_copr_build_handler(event: dict, package_config: dict, job_config: dict):
+    handler = PushCoprBuildHandler(
+        package_config=PackageConfigSchema().load_config(package_config),
+        job_config=JobConfigSchema().load_config(job_config),
+        data=EventData.from_event_dict(event),
+    )
+    return handler.run_job()
+
+
+@celery_app.task(name="task.run_installation_handler")
+def run_installation_handler(event: dict, package_config: dict, job_config: dict):
+    handler = GithubAppInstallationHandler(
+        package_config=PackageConfigSchema().load_config(package_config),
+        job_config=JobConfigSchema().load_config(job_config),
+        data=None,
+        installation_event=InstallationEvent.from_event_dict(event),
+    )
+    return handler.run_job()
+
+
+@celery_app.task(name="task.run_testing_farm_comment_handler")
+def run_testing_farm_comment_handler(
+    event: dict, package_config: dict, job_config: dict
+):
+    handler = GitHubPullRequestCommentTestingFarmHandler(
+        package_config=PackageConfigSchema().load_config(package_config),
+        job_config=JobConfigSchema().load_config(job_config),
+        data=EventData.from_event_dict(event),
+    )
+    return handler.run_job()
+
+
+@celery_app.task(name="task.run_testing_farm_results_handler")
+def run_testing_farm_results_handler(
+    event: dict, package_config: dict, job_config: dict
+):
+    tests = event.get("tests")
+    result = TestingFarmResult(event.get("result")) if event.get("result") else None
+    pipeline_id = event.get("pipeline_id")
+    log_url = event.get("log_url")
+    copr_chroot = event.get("copr_chroot")
+    message = event.get("message")
+
+    handler = TestingFarmResultsHandler(
+        package_config=PackageConfigSchema().load_config(package_config),
+        job_config=JobConfigSchema().load_config(job_config),
+        data=EventData.from_event_dict(event),
+        tests=tests,
+        result=result,
+        pipeline_id=pipeline_id,
+        log_url=log_url,
+        copr_chroot=copr_chroot,
+        message=message,
+    )
+    return handler.run_job()
+
+
+@celery_app.task(name="task.run_propose_update_comment_handler")
+def run_propose_update_comment_handler(
+    event: dict, package_config: dict, job_config: dict
+):
+    handler = GitHubIssueCommentProposeUpdateHandler(
+        package_config=PackageConfigSchema().load_config(package_config),
+        job_config=JobConfigSchema().load_config(job_config),
+        data=EventData.from_event_dict(event),
+    )
+    return handler.run_job()
+
+
+@celery_app.task(name="task.run_propose_downstream_handler")
+def run_propose_downstream_handler(event: dict, package_config: dict, job_config: dict):
+    handler = ProposeDownstreamHandler(
+        package_config=PackageConfigSchema().load_config(package_config),
+        job_config=JobConfigSchema().load_config(job_config),
+        data=EventData.from_event_dict(event),
+    )
+    return handler.run_job()
+
+
+@celery_app.task(name="task.run_release_koji_build_handler")
+def run_release_koji_build_handler(event: dict, package_config: dict, job_config: dict):
+    handler = ReleaseGithubKojiBuildHandler(
+        package_config=PackageConfigSchema().load_config(package_config),
+        job_config=JobConfigSchema().load_config(job_config),
+        data=EventData.from_event_dict(event),
+    )
+    return handler.run_job()
+
+
+@celery_app.task(name="task.run_pr_koji_build_handler")
+def run_pr_koji_build_handler(event: dict, package_config: dict, job_config: dict):
+    handler = PullRequestGithubKojiBuildHandler(
+        package_config=PackageConfigSchema().load_config(package_config),
+        job_config=JobConfigSchema().load_config(job_config),
+        data=EventData.from_event_dict(event),
+    )
+    return handler.run_job()
+
+
+@celery_app.task(name="task.run_push_koji_build_handler")
+def run_push_koji_build_handler(event: dict, package_config: dict, job_config: dict):
+    handler = PushGithubKojiBuildHandler(
+        package_config=PackageConfigSchema().load_config(package_config),
+        job_config=JobConfigSchema().load_config(job_config),
+        data=EventData.from_event_dict(event),
+    )
+    return handler.run_job()
+
+
+@celery_app.task(name="task.run_distgit_commit_handler")
+def run_distgit_commit_handler(event: dict, package_config: dict, job_config: dict):
+    handler = NewDistGitCommitHandler(
+        package_config=PackageConfigSchema().load_config(package_config),
+        job_config=JobConfigSchema().load_config(job_config),
+        data=EventData.from_event_dict(event),
+    )
+    return handler.run_job()
+
+
+@celery_app.task(name="task.run_pagure_pr_comment_copr_build_handler")
+def run_pagure_pr_comment_copr_build_handler(
+    event: dict, package_config: dict, job_config: dict
+):
+    handler = PagurePullRequestCommentCoprBuildHandler(
+        package_config=PackageConfigSchema().load_config(package_config),
+        job_config=JobConfigSchema().load_config(job_config),
+        data=EventData.from_event_dict(event),
+    )
+    return handler.run_job()
+
+
+@celery_app.task(name="task.run_pagure_pr_label_handler")
+def run_pagure_pr_label_handler(event: dict, package_config: dict, job_config: dict):
+    labels = event.get("labels")
+    action = PullRequestLabelAction(event.get("action"))
+    base_repo_owner = event.get("base_repo_owner")
+    base_repo_namespace = event.get("base_repo_namespace")
+    base_repo_name = event.get("base_repo_name")
+
+    handler = PagurePullRequestLabelHandler(
+        package_config=PackageConfigSchema().load_config(package_config),
+        job_config=JobConfigSchema().load_config(job_config),
+        data=EventData.from_event_dict(event),
+        labels=labels,
+        action=action,
+        base_repo_owner=base_repo_owner,
+        base_repo_name=base_repo_name,
+        base_repo_namespace=base_repo_namespace,
+    )
+    return handler.run_job()
+
+
+@celery_app.task(name="task.run_koji_build_report_handler")
+def run_koji_build_report_handler(event: dict, package_config: dict, job_config: dict):
+    handler = KojiBuildReportHandler(
+        package_config=PackageConfigSchema().load_config(package_config),
+        job_config=JobConfigSchema().load_config(job_config),
+        data=EventData.from_event_dict(event),
+        koji_event=KojiBuildEvent.from_event_dict(event),
+    )
+    return handler.run_job()

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -124,7 +124,7 @@ def run_copr_build_start_handler(event: dict, package_config: dict, job_config: 
         data=EventData.from_event_dict(event),
         copr_event=CoprBuildEvent.from_event_dict(event),
     )
-    return handler.run_job()
+    return get_handlers_task_results(handler.run_job(), event)
 
 
 @celery_app.task(name="task.run_copr_build_end_handler")
@@ -135,7 +135,7 @@ def run_copr_build_end_handler(event: dict, package_config: dict, job_config: di
         data=EventData.from_event_dict(event),
         copr_event=CoprBuildEvent.from_event_dict(event),
     )
-    return handler.run_job()
+    return get_handlers_task_results(handler.run_job(), event)
 
 
 @celery_app.task(name="task.run_release_copr_build_handler")
@@ -145,7 +145,7 @@ def run_release_copr_build_handler(event: dict, package_config: dict, job_config
         job_config=JobConfigSchema().load_config(job_config),
         data=EventData.from_event_dict(event),
     )
-    return handler.run_job()
+    return get_handlers_task_results(handler.run_job(), event)
 
 
 @celery_app.task(name="task.run_pr_copr_build_handler")
@@ -155,7 +155,7 @@ def run_pr_copr_build_handler(event: dict, package_config: dict, job_config: dic
         job_config=JobConfigSchema().load_config(job_config),
         data=EventData.from_event_dict(event),
     )
-    return handler.run_job()
+    return get_handlers_task_results(handler.run_job(), event)
 
 
 @celery_app.task(name="task.run_pr_comment_copr_build_handler")
@@ -167,7 +167,7 @@ def run_pr_comment_copr_build_handler(
         job_config=JobConfigSchema().load_config(job_config),
         data=EventData.from_event_dict(event),
     )
-    return handler.run_job()
+    return get_handlers_task_results(handler.run_job(), event)
 
 
 @celery_app.task(name="task.run_push_copr_build_handler")
@@ -177,7 +177,7 @@ def run_push_copr_build_handler(event: dict, package_config: dict, job_config: d
         job_config=JobConfigSchema().load_config(job_config),
         data=EventData.from_event_dict(event),
     )
-    return handler.run_job()
+    return get_handlers_task_results(handler.run_job(), event)
 
 
 @celery_app.task(name="task.run_installation_handler")
@@ -188,7 +188,7 @@ def run_installation_handler(event: dict, package_config: dict, job_config: dict
         data=None,
         installation_event=InstallationEvent.from_event_dict(event),
     )
-    return handler.run_job()
+    return get_handlers_task_results(handler.run_job(), event)
 
 
 @celery_app.task(name="task.run_testing_farm_comment_handler")
@@ -200,7 +200,7 @@ def run_testing_farm_comment_handler(
         job_config=JobConfigSchema().load_config(job_config),
         data=EventData.from_event_dict(event),
     )
-    return handler.run_job()
+    return get_handlers_task_results(handler.run_job(), event)
 
 
 @celery_app.task(name="task.run_testing_farm_results_handler")
@@ -225,7 +225,7 @@ def run_testing_farm_results_handler(
         copr_chroot=copr_chroot,
         message=message,
     )
-    return handler.run_job()
+    return get_handlers_task_results(handler.run_job(), event)
 
 
 @celery_app.task(name="task.run_propose_update_comment_handler")
@@ -237,7 +237,7 @@ def run_propose_update_comment_handler(
         job_config=JobConfigSchema().load_config(job_config),
         data=EventData.from_event_dict(event),
     )
-    return handler.run_job()
+    return get_handlers_task_results(handler.run_job(), event)
 
 
 @celery_app.task(name="task.run_propose_downstream_handler")
@@ -247,7 +247,7 @@ def run_propose_downstream_handler(event: dict, package_config: dict, job_config
         job_config=JobConfigSchema().load_config(job_config),
         data=EventData.from_event_dict(event),
     )
-    return handler.run_job()
+    return get_handlers_task_results(handler.run_job(), event)
 
 
 @celery_app.task(name="task.run_release_koji_build_handler")
@@ -257,7 +257,7 @@ def run_release_koji_build_handler(event: dict, package_config: dict, job_config
         job_config=JobConfigSchema().load_config(job_config),
         data=EventData.from_event_dict(event),
     )
-    return handler.run_job()
+    return get_handlers_task_results(handler.run_job(), event)
 
 
 @celery_app.task(name="task.run_pr_koji_build_handler")
@@ -267,7 +267,7 @@ def run_pr_koji_build_handler(event: dict, package_config: dict, job_config: dic
         job_config=JobConfigSchema().load_config(job_config),
         data=EventData.from_event_dict(event),
     )
-    return handler.run_job()
+    return get_handlers_task_results(handler.run_job(), event)
 
 
 @celery_app.task(name="task.run_push_koji_build_handler")
@@ -277,7 +277,7 @@ def run_push_koji_build_handler(event: dict, package_config: dict, job_config: d
         job_config=JobConfigSchema().load_config(job_config),
         data=EventData.from_event_dict(event),
     )
-    return handler.run_job()
+    return get_handlers_task_results(handler.run_job(), event)
 
 
 @celery_app.task(name="task.run_distgit_commit_handler")
@@ -287,7 +287,7 @@ def run_distgit_commit_handler(event: dict, package_config: dict, job_config: di
         job_config=JobConfigSchema().load_config(job_config),
         data=EventData.from_event_dict(event),
     )
-    return handler.run_job()
+    return get_handlers_task_results(handler.run_job(), event)
 
 
 @celery_app.task(name="task.run_pagure_pr_comment_copr_build_handler")
@@ -299,7 +299,7 @@ def run_pagure_pr_comment_copr_build_handler(
         job_config=JobConfigSchema().load_config(job_config),
         data=EventData.from_event_dict(event),
     )
-    return handler.run_job()
+    return get_handlers_task_results(handler.run_job(), event)
 
 
 @celery_app.task(name="task.run_pagure_pr_label_handler")
@@ -320,7 +320,7 @@ def run_pagure_pr_label_handler(event: dict, package_config: dict, job_config: d
         base_repo_name=base_repo_name,
         base_repo_namespace=base_repo_namespace,
     )
-    return handler.run_job()
+    return get_handlers_task_results(handler.run_job(), event)
 
 
 @celery_app.task(name="task.run_koji_build_report_handler")
@@ -331,4 +331,8 @@ def run_koji_build_report_handler(event: dict, package_config: dict, job_config:
         data=EventData.from_event_dict(event),
         koji_event=KojiBuildEvent.from_event_dict(event),
     )
-    return handler.run_job()
+    return get_handlers_task_results(handler.run_job(), event)
+
+
+def get_handlers_task_results(results: dict, event: dict):
+    return {"job": results, "event": event}

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -45,6 +45,7 @@ from packit_service.worker.handlers.github_handlers import (
     PullRequestCoprBuildHandler,
     ProposeDownstreamHandler,
     GitHubPullRequestCommentTestingFarmHandler,
+    GitHubPullRequestCommentCoprBuildHandler,
 )
 
 from packit_service.worker.handlers.fedmsg_handlers import (
@@ -161,7 +162,7 @@ def run_pr_copr_build_handler(event: dict, package_config: dict, job_config: dic
 def run_pr_comment_copr_build_handler(
     event: dict, package_config: dict, job_config: dict
 ):
-    handler = PullRequestCoprBuildHandler(
+    handler = GitHubPullRequestCommentCoprBuildHandler(
         package_config=PackageConfigSchema().load_config(package_config),
         job_config=JobConfigSchema().load_config(job_config),
         data=EventData.from_event_dict(event),

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -64,6 +64,8 @@ from packit_service.worker.handlers.pagure_handlers import (
 from packit_service.worker.handlers.testing_farm_handlers import (
     TestingFarmResultsHandler,
 )
+
+from packit_service.worker.handlers.abstract import TaskName
 from packit_service.utils import load_package_config, load_job_config
 
 logger = logging.getLogger(__name__)
@@ -116,7 +118,7 @@ def babysit_copr_build(self, build_id: int):
 
 
 # tasks for running the handlers
-@celery_app.task(name="task.run_copr_build_start_handler")
+@celery_app.task(name=TaskName.copr_build_start)
 def run_copr_build_start_handler(event: dict, package_config: dict, job_config: dict):
     handler = CoprBuildStartHandler(
         package_config=load_package_config(package_config),
@@ -127,7 +129,7 @@ def run_copr_build_start_handler(event: dict, package_config: dict, job_config: 
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(name="task.run_copr_build_end_handler")
+@celery_app.task(name=TaskName.copr_build_end)
 def run_copr_build_end_handler(event: dict, package_config: dict, job_config: dict):
     handler = CoprBuildEndHandler(
         package_config=load_package_config(package_config),
@@ -138,7 +140,7 @@ def run_copr_build_end_handler(event: dict, package_config: dict, job_config: di
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(name="task.run_release_copr_build_handler")
+@celery_app.task(name=TaskName.release_copr_build)
 def run_release_copr_build_handler(event: dict, package_config: dict, job_config: dict):
     handler = ReleaseCoprBuildHandler(
         package_config=load_package_config(package_config),
@@ -148,7 +150,7 @@ def run_release_copr_build_handler(event: dict, package_config: dict, job_config
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(name="task.run_pr_copr_build_handler")
+@celery_app.task(name=TaskName.pr_copr_build)
 def run_pr_copr_build_handler(event: dict, package_config: dict, job_config: dict):
     handler = PullRequestCoprBuildHandler(
         package_config=load_package_config(package_config),
@@ -158,7 +160,7 @@ def run_pr_copr_build_handler(event: dict, package_config: dict, job_config: dic
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(name="task.run_pr_comment_copr_build_handler")
+@celery_app.task(name=TaskName.pr_comment_copr_build)
 def run_pr_comment_copr_build_handler(
     event: dict, package_config: dict, job_config: dict
 ):
@@ -170,7 +172,7 @@ def run_pr_comment_copr_build_handler(
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(name="task.run_push_copr_build_handler")
+@celery_app.task(name=TaskName.push_copr_build)
 def run_push_copr_build_handler(event: dict, package_config: dict, job_config: dict):
     handler = PushCoprBuildHandler(
         package_config=load_package_config(package_config),
@@ -180,7 +182,7 @@ def run_push_copr_build_handler(event: dict, package_config: dict, job_config: d
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(name="task.run_installation_handler")
+@celery_app.task(name=TaskName.installation)
 def run_installation_handler(event: dict, package_config: dict, job_config: dict):
     handler = GithubAppInstallationHandler(
         package_config=None,
@@ -191,7 +193,7 @@ def run_installation_handler(event: dict, package_config: dict, job_config: dict
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(name="task.run_testing_farm_handler")
+@celery_app.task(name=TaskName.testing_farm)
 def run_testing_farm_handler(
     event: dict, package_config: dict, job_config: dict, chroot: str
 ):
@@ -204,7 +206,7 @@ def run_testing_farm_handler(
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(name="task.run_testing_farm_comment_handler")
+@celery_app.task(name=TaskName.testing_farm_comment)
 def run_testing_farm_comment_handler(
     event: dict, package_config: dict, job_config: dict
 ):
@@ -216,7 +218,7 @@ def run_testing_farm_comment_handler(
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(name="task.run_testing_farm_results_handler")
+@celery_app.task(name=TaskName.testing_farm_results)
 def run_testing_farm_results_handler(
     event: dict, package_config: dict, job_config: dict
 ):
@@ -234,7 +236,7 @@ def run_testing_farm_results_handler(
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(name="task.run_propose_update_comment_handler")
+@celery_app.task(name=TaskName.propose_update_comment)
 def run_propose_update_comment_handler(
     event: dict, package_config: dict, job_config: dict
 ):
@@ -246,7 +248,7 @@ def run_propose_update_comment_handler(
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(name="task.run_propose_downstream_handler")
+@celery_app.task(name=TaskName.propose_downstream)
 def run_propose_downstream_handler(event: dict, package_config: dict, job_config: dict):
     handler = ProposeDownstreamHandler(
         package_config=load_package_config(package_config),
@@ -256,7 +258,7 @@ def run_propose_downstream_handler(event: dict, package_config: dict, job_config
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(name="task.run_release_koji_build_handler")
+@celery_app.task(name=TaskName.release_koji_build)
 def run_release_koji_build_handler(event: dict, package_config: dict, job_config: dict):
     handler = ReleaseGithubKojiBuildHandler(
         package_config=load_package_config(package_config),
@@ -266,7 +268,7 @@ def run_release_koji_build_handler(event: dict, package_config: dict, job_config
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(name="task.run_pr_koji_build_handler")
+@celery_app.task(name=TaskName.pr_koji_build)
 def run_pr_koji_build_handler(event: dict, package_config: dict, job_config: dict):
     handler = PullRequestGithubKojiBuildHandler(
         package_config=load_package_config(package_config),
@@ -276,7 +278,7 @@ def run_pr_koji_build_handler(event: dict, package_config: dict, job_config: dic
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(name="task.run_push_koji_build_handler")
+@celery_app.task(name=TaskName.push_koji_build)
 def run_push_koji_build_handler(event: dict, package_config: dict, job_config: dict):
     handler = PushGithubKojiBuildHandler(
         package_config=load_package_config(package_config),
@@ -286,7 +288,7 @@ def run_push_koji_build_handler(event: dict, package_config: dict, job_config: d
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(name="task.run_distgit_commit_handler")
+@celery_app.task(name=TaskName.distgit_commit)
 def run_distgit_commit_handler(event: dict, package_config: dict, job_config: dict):
     handler = NewDistGitCommitHandler(
         package_config=load_package_config(package_config),
@@ -296,7 +298,7 @@ def run_distgit_commit_handler(event: dict, package_config: dict, job_config: di
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(name="task.run_pagure_pr_comment_copr_build_handler")
+@celery_app.task(name=TaskName.pagure_pr_comment_copr_build)
 def run_pagure_pr_comment_copr_build_handler(
     event: dict, package_config: dict, job_config: dict
 ):
@@ -308,7 +310,7 @@ def run_pagure_pr_comment_copr_build_handler(
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(name="task.run_pagure_pr_label_handler")
+@celery_app.task(name=TaskName.pagure_pr_label)
 def run_pagure_pr_label_handler(event: dict, package_config: dict, job_config: dict):
     handler = PagurePullRequestLabelHandler(
         package_config=load_package_config(package_config),
@@ -323,7 +325,7 @@ def run_pagure_pr_label_handler(event: dict, package_config: dict, job_config: d
     return get_handlers_task_results(handler.run_job(), event)
 
 
-@celery_app.task(name="task.run_koji_build_report_handler")
+@celery_app.task(name=TaskName.koji_build_report)
 def run_koji_build_report_handler(event: dict, package_config: dict, job_config: dict):
     handler = KojiBuildReportHandler(
         package_config=load_package_config(package_config),

--- a/packit_service/worker/tasks.py
+++ b/packit_service/worker/tasks.py
@@ -220,23 +220,16 @@ def run_testing_farm_comment_handler(
 def run_testing_farm_results_handler(
     event: dict, package_config: dict, job_config: dict
 ):
-    tests = event.get("tests")
-    result = TestingFarmResult(event.get("result")) if event.get("result") else None
-    pipeline_id = event.get("pipeline_id")
-    log_url = event.get("log_url")
-    copr_chroot = event.get("copr_chroot")
-    message = event.get("message")
-
     handler = TestingFarmResultsHandler(
         package_config=load_package_config(package_config),
         job_config=load_job_config(job_config),
         data=EventData.from_event_dict(event),
-        tests=tests,
-        result=result,
-        pipeline_id=pipeline_id,
-        log_url=log_url,
-        copr_chroot=copr_chroot,
-        message=message,
+        tests=event.get("tests"),
+        result=TestingFarmResult(event.get("result")) if event.get("result") else None,
+        pipeline_id=event.get("pipeline_id"),
+        log_url=event.get("log_url"),
+        copr_chroot=event.get("copr_chroot"),
+        message=event.get("message"),
     )
     return get_handlers_task_results(handler.run_job(), event)
 
@@ -317,21 +310,15 @@ def run_pagure_pr_comment_copr_build_handler(
 
 @celery_app.task(name="task.run_pagure_pr_label_handler")
 def run_pagure_pr_label_handler(event: dict, package_config: dict, job_config: dict):
-    labels = event.get("labels")
-    action = PullRequestLabelAction(event.get("action"))
-    base_repo_owner = event.get("base_repo_owner")
-    base_repo_namespace = event.get("base_repo_namespace")
-    base_repo_name = event.get("base_repo_name")
-
     handler = PagurePullRequestLabelHandler(
         package_config=load_package_config(package_config),
         job_config=load_job_config(job_config),
         data=EventData.from_event_dict(event),
-        labels=labels,
-        action=action,
-        base_repo_owner=base_repo_owner,
-        base_repo_name=base_repo_name,
-        base_repo_namespace=base_repo_namespace,
+        labels=event.get("labels"),
+        action=PullRequestLabelAction(event.get("action")),
+        base_repo_owner=event.get("base_repo_owner"),
+        base_repo_name=event.get("base_repo_name"),
+        base_repo_namespace=event.get("base_repo_namespace"),
     )
     return get_handlers_task_results(handler.run_job(), event)
 
@@ -347,6 +334,6 @@ def run_koji_build_report_handler(event: dict, package_config: dict, job_config:
     return get_handlers_task_results(handler.run_job(), event)
 
 
-def get_handlers_task_results(results: dict, event: dict):
+def get_handlers_task_results(results: dict, event: dict) -> dict:
     # include original event to provide more info
     return {"job": results, "event": event}

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -24,6 +24,7 @@ import json
 from datetime import datetime
 
 import pytest
+from celery import Celery
 from flexmock import flexmock
 from github import Github
 from github.GitRelease import GitRelease as PyGithubRelease
@@ -40,7 +41,8 @@ from packit_service.models import IssueModel
 from packit_service.service.events import IssueCommentEvent
 from packit_service.worker.jobs import SteveJobs
 from packit_service.worker.whitelist import Whitelist
-from tests.spellbook import DATA_DIR, first_dict_value
+from packit_service.worker.tasks import run_propose_update_comment_handler
+from tests.spellbook import DATA_DIR, first_dict_value, get_parameters_from_results
 
 
 @pytest.fixture(scope="module")
@@ -116,5 +118,13 @@ def test_issue_comment_propose_update_handler(
     flexmock(IssueModel).should_receive("get_by_id").with_args(123).and_return(
         flexmock(issue_id=12345)
     )
-    results = SteveJobs().process_message(issue_comment_propose_update_event)
-    assert first_dict_value(results["jobs"])["success"]
+    flexmock(Celery).should_receive("send_task").once()
+
+    processing_results = SteveJobs().process_message(issue_comment_propose_update_event)
+    event_dict, package_config, job = get_parameters_from_results(processing_results)
+
+    results = run_propose_update_comment_handler(
+        package_config=package_config, event=event_dict, job_config=job,
+    )
+
+    assert first_dict_value(results)["success"]

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -127,4 +127,4 @@ def test_issue_comment_propose_update_handler(
         package_config=package_config, event=event_dict, job_config=job,
     )
 
-    assert first_dict_value(results)["success"]
+    assert first_dict_value(results["job"])["success"]

--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -24,7 +24,7 @@ import json
 from datetime import datetime
 
 import pytest
-from celery import Celery
+from celery.canvas import Signature
 from flexmock import flexmock
 from github import Github
 from github.GitRelease import GitRelease as PyGithubRelease
@@ -118,7 +118,7 @@ def test_issue_comment_propose_update_handler(
     flexmock(IssueModel).should_receive("get_by_id").with_args(123).and_return(
         flexmock(issue_id=12345)
     )
-    flexmock(Celery).should_receive("send_task").once()
+    flexmock(Signature).should_receive("apply_async").once()
 
     processing_results = SteveJobs().process_message(issue_comment_propose_update_event)
     event_dict, package_config, job = get_parameters_from_results(processing_results)

--- a/tests/integration/test_listen_to_fedmsg.py
+++ b/tests/integration/test_listen_to_fedmsg.py
@@ -772,7 +772,7 @@ def test_koji_build_start(koji_build_scratch_start, pc_koji_build_pr, koji_build
         package_config=package_config, event=event_dict, job_config=job,
     )
 
-    assert first_dict_value(results)["success"]
+    assert first_dict_value(results["job"])["success"]
 
 
 def test_koji_build_start_build_not_found(koji_build_scratch_start):
@@ -823,4 +823,4 @@ def test_koji_build_end(koji_build_scratch_end, pc_koji_build_pr, koji_build_pr)
         package_config=package_config, event=event_dict, job_config=job,
     )
 
-    assert first_dict_value(results)["success"]
+    assert first_dict_value(results["job"])["success"]

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -35,7 +35,7 @@ from packit_service.models import PullRequestModel
 from packit_service.service.db_triggers import AddPullRequestDbTrigger
 from packit_service.worker.build.copr_build import CoprBuildJobHelper
 from packit_service.worker.jobs import SteveJobs
-from packit_service.worker.result import HandlerResults
+from packit_service.worker.result import TaskResults
 from packit_service.worker.whitelist import Whitelist
 from tests.spellbook import DATA_DIR
 
@@ -158,7 +158,7 @@ def test_pr_comment_copr_build_handler(
     mock_pr_comment_functionality, pr_copr_build_comment_event
 ):
     flexmock(CoprBuildJobHelper).should_receive("run_copr_build").and_return(
-        HandlerResults(success=True, details={})
+        TaskResults(success=True, details={})
     ).once()
     (
         flexmock(GithubProject)
@@ -182,7 +182,7 @@ def test_pr_comment_build_handler(
     mock_pr_comment_functionality, pr_build_comment_event
 ):
     flexmock(CoprBuildJobHelper).should_receive("run_copr_build").and_return(
-        HandlerResults(success=True, details={})
+        TaskResults(success=True, details={})
     )
     (
         flexmock(GithubProject)
@@ -237,7 +237,7 @@ def test_pr_embedded_command_handler(
 ):
     pr_embedded_command_comment_event["comment"]["body"] = comments_list
     flexmock(CoprBuildJobHelper).should_receive("run_copr_build").and_return(
-        HandlerResults(success=True, details={})
+        TaskResults(success=True, details={})
     )
     (
         flexmock(GithubProject)

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -182,7 +182,7 @@ def test_pr_comment_copr_build_handler(
     results = run_pr_comment_copr_build_handler(
         package_config=package_config, event=event_dict, job_config=job,
     )
-    assert first_dict_value(results)["success"]
+    assert first_dict_value(results["job"])["success"]
 
 
 def test_pr_comment_build_handler(
@@ -208,7 +208,7 @@ def test_pr_comment_build_handler(
     results = run_pr_comment_copr_build_handler(
         package_config=package_config, event=event_dict, job_config=job,
     )
-    assert first_dict_value(results)["success"]
+    assert first_dict_value(results["job"])["success"]
 
 
 @pytest.mark.parametrize(
@@ -270,8 +270,7 @@ def test_pr_embedded_command_handler(
         package_config=package_config, event=event_dict, job_config=job,
     )
 
-    for value in results.values():
-        assert value["success"]
+    assert first_dict_value(results["job"])["success"]
 
 
 def test_pr_comment_empty_handler(

--- a/tests/integration/test_pr_comment.py
+++ b/tests/integration/test_pr_comment.py
@@ -23,7 +23,7 @@
 import json
 
 import pytest
-from celery import Celery
+from celery.canvas import Signature
 from flexmock import flexmock
 from github import Github
 from ogr.services.github import GithubProject
@@ -174,7 +174,7 @@ def test_pr_comment_copr_build_handler(
         "https://github.com/the-namespace/the-repo"
     )
     flexmock(GithubProject).should_receive("is_private").and_return(False)
-    flexmock(Celery).should_receive("send_task").once()
+    flexmock(Signature).should_receive("apply_async").once()
 
     processing_results = SteveJobs().process_message(pr_copr_build_comment_event)
     event_dict, package_config, job = get_parameters_from_results(processing_results)
@@ -200,7 +200,7 @@ def test_pr_comment_build_handler(
     )
     flexmock(GithubProject, get_files="foo.spec")
     flexmock(GithubProject).should_receive("is_private").and_return(False)
-    flexmock(Celery).should_receive("send_task").once()
+    flexmock(Signature).should_receive("apply_async").once()
 
     processing_results = SteveJobs().process_message(pr_build_comment_event)
     event_dict, package_config, job = get_parameters_from_results(processing_results)
@@ -261,7 +261,7 @@ def test_pr_embedded_command_handler(
     )
     flexmock(GithubProject, get_files="foo.spec")
     flexmock(GithubProject).should_receive("is_private").and_return(False)
-    flexmock(Celery).should_receive("send_task").once()
+    flexmock(Signature).should_receive("apply_async").once()
 
     processing_results = SteveJobs().process_message(pr_embedded_command_comment_event)
     event_dict, package_config, job = get_parameters_from_results(processing_results)

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -61,7 +61,7 @@ def test_dist_git_push_release_handle(github_release_webhook):
     results = run_propose_downstream_handler(
         package_config=package_config, event=event_dict, job_config=job,
     )
-    assert first_dict_value(results)["success"]
+    assert first_dict_value(results["job"])["success"]
 
 
 def test_dist_git_push_release_handle_multiple_branches(
@@ -108,7 +108,7 @@ def test_dist_git_push_release_handle_multiple_branches(
     results = run_propose_downstream_handler(
         package_config=package_config, event=event_dict, job_config=job,
     )
-    assert first_dict_value(results)["success"]
+    assert first_dict_value(results["job"])["success"]
 
 
 def test_dist_git_push_release_handle_one_failed(
@@ -166,7 +166,7 @@ def test_dist_git_push_release_handle_one_failed(
     results = run_propose_downstream_handler(
         package_config=package_config, event=event_dict, job_config=job,
     )
-    assert not first_dict_value(results)["success"]
+    assert not first_dict_value(results["job"])["success"]
 
 
 def test_dist_git_push_release_handle_all_failed(
@@ -230,4 +230,4 @@ def test_dist_git_push_release_handle_all_failed(
     results = run_propose_downstream_handler(
         package_config=package_config, event=event_dict, job_config=job,
     )
-    assert not first_dict_value(results)["success"]
+    assert not first_dict_value(results["job"])["success"]

--- a/tests/integration/test_release_event.py
+++ b/tests/integration/test_release_event.py
@@ -1,5 +1,5 @@
 import pytest
-from celery import Celery
+from celery.canvas import Signature
 from flexmock import flexmock
 from github import Github
 from packit.api import PackitAPI
@@ -52,7 +52,7 @@ def test_dist_git_push_release_handle(github_release_webhook):
     flexmock(AddReleaseDbTrigger).should_receive("db_trigger").and_return(
         flexmock(job_config_trigger_type=JobConfigTriggerType.release, id=123)
     )
-    flexmock(Celery).should_receive("send_task").once()
+    flexmock(Signature).should_receive("apply_async").once()
 
     processing_results = SteveJobs().process_message(github_release_webhook)
     assert processing_results["details"]["event"]["trigger"] == "release"
@@ -99,7 +99,7 @@ def test_dist_git_push_release_handle_multiple_branches(
     flexmock(AddReleaseDbTrigger).should_receive("db_trigger").and_return(
         flexmock(job_config_trigger_type=JobConfigTriggerType.release, id=123)
     )
-    flexmock(Celery).should_receive("send_task").once()
+    flexmock(Signature).should_receive("apply_async").once()
 
     processing_results = SteveJobs().process_message(github_release_webhook)
     assert processing_results["details"]["event"]["trigger"] == "release"
@@ -158,7 +158,7 @@ def test_dist_git_push_release_handle_one_failed(
         flexmock(job_config_trigger_type=JobConfigTriggerType.release, id=123)
     )
 
-    flexmock(Celery).should_receive("send_task").once()
+    flexmock(Signature).should_receive("apply_async").once()
     processing_results = SteveJobs().process_message(github_release_webhook)
     assert processing_results["details"]["event"]["trigger"] == "release"
     event_dict, package_config, job = get_parameters_from_results(processing_results)
@@ -221,7 +221,7 @@ def test_dist_git_push_release_handle_all_failed(
     flexmock(sentry_integration).should_receive("send_to_sentry").and_return().times(
         len(fedora_branches)
     )
-    flexmock(Celery).should_receive("send_task").once()
+    flexmock(Signature).should_receive("apply_async").once()
 
     processing_results = SteveJobs().process_message(github_release_webhook)
     assert processing_results["details"]["event"]["trigger"] == "release"

--- a/tests/spellbook.py
+++ b/tests/spellbook.py
@@ -25,6 +25,7 @@ A book with our finest spells
 """
 from pathlib import Path
 from typing import Any
+from packit_service.worker.result import TaskResults
 
 TESTS_DIR = Path(__file__).parent
 DATA_DIR = TESTS_DIR / "data"
@@ -33,3 +34,10 @@ SAVED_HTTPD_REQS = DATA_DIR / "http-requests"
 
 def first_dict_value(a_dict: dict) -> Any:
     return a_dict[next(iter(a_dict))]
+
+
+def get_parameters_from_results(results: TaskResults):
+    event_dict = results["details"]["event"]
+    package_config = results["details"]["package_config"]
+    job = results["details"]["matching_jobs"][0]
+    return event_dict, package_config, job

--- a/tests/unit/test_steve.py
+++ b/tests/unit/test_steve.py
@@ -26,7 +26,7 @@ Let's test that Steve's as awesome as we think he is.
 from json import dumps
 
 import pytest
-from celery import Celery
+from celery.canvas import Signature
 from flexmock import flexmock
 from github import Github
 
@@ -87,7 +87,7 @@ def test_process_message(event):
         flexmock(job_config_trigger_type=JobConfigTriggerType.release, id=1)
     )
     flexmock(Whitelist, check_and_report=True)
-    flexmock(Celery).should_receive("send_task").once()
+    flexmock(Signature).should_receive("apply_async").once()
 
     processing_results = SteveJobs().process_message(event)
     assert processing_results["details"]["event"]["trigger"] == "release"

--- a/tests/unit/test_steve.py
+++ b/tests/unit/test_steve.py
@@ -96,5 +96,5 @@ def test_process_message(event):
     results = run_propose_downstream_handler(
         package_config=package_config, event=event_dict, job_config=job,
     )
-    assert "propose_downstream" in next(iter(results))
-    assert first_dict_value(results)["success"]
+    assert "propose_downstream" in next(iter(results["job"]))
+    assert first_dict_value(results["job"])["success"]

--- a/tests/unit/test_steve.py
+++ b/tests/unit/test_steve.py
@@ -26,6 +26,7 @@ Let's test that Steve's as awesome as we think he is.
 from json import dumps
 
 import pytest
+from celery import Celery
 from flexmock import flexmock
 from github import Github
 
@@ -38,7 +39,8 @@ from packit_service.constants import SANDCASTLE_WORK_DIR
 from packit_service.service.db_triggers import AddReleaseDbTrigger
 from packit_service.worker.jobs import SteveJobs
 from packit_service.worker.whitelist import Whitelist
-from tests.spellbook import first_dict_value
+from packit_service.worker.tasks import run_propose_downstream_handler
+from tests.spellbook import first_dict_value, get_parameters_from_results
 
 
 @pytest.mark.parametrize(
@@ -85,8 +87,14 @@ def test_process_message(event):
         flexmock(job_config_trigger_type=JobConfigTriggerType.release, id=1)
     )
     flexmock(Whitelist, check_and_report=True)
-    results = SteveJobs().process_message(event)
-    j = first_dict_value(results["jobs"])
-    assert "propose_downstream" in next(iter(results["jobs"]))
-    assert j["success"]
-    assert results["event"]["trigger"] == "release"
+    flexmock(Celery).should_receive("send_task").once()
+
+    processing_results = SteveJobs().process_message(event)
+    assert processing_results["details"]["event"]["trigger"] == "release"
+    event_dict, package_config, job = get_parameters_from_results(processing_results)
+
+    results = run_propose_downstream_handler(
+        package_config=package_config, event=event_dict, job_config=job,
+    )
+    assert "propose_downstream" in next(iter(results))
+    assert first_dict_value(results)["success"]

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -199,6 +199,12 @@ def test_testing_farm_response(
         package_config=flexmock(),
         job_config=flexmock(),
         data=EventData.from_event_dict(event_dict),
+        tests=tests_tests,
+        result=tests_result,
+        pipeline_id="id",
+        log_url="some url",
+        copr_chroot="fedora-rawhide-x86_64",
+        message=tests_message,
     )
     flexmock(StatusReporter).should_receive("report").with_args(
         state=status_status,
@@ -220,6 +226,7 @@ def test_testing_farm_response(
     )
 
     flexmock(LocalProject).should_receive("refresh_the_arguments").and_return(None)
+
     test_farm_handler.run()
 
 


### PR DESCRIPTION
- have one processing task (parses webhook to an event, makes checks - whitelist, package config presence,..) and then tasks for running handlers
- rename HandlersResults to general TaskResults (since these are results also from `process_message` task, not only handler tasks), change what is included in `details` in processing task
- create a function for each Celery task running specific handler
- get rid of event dict in `__init__` of handler classes (parse additional attributes in `run...handler` functions if there are any)
- for handlers which need original Event object move methods for parsing the event to events.py (Installation, KojiBuild, CoprBuild)
