### PR TITLE
Rename 'config' to 'service_config'

### DIFF
--- a/packit_service/worker/build/build_helper.py
+++ b/packit_service/worker/build/build_helper.py
@@ -54,14 +54,14 @@ class BaseBuildJobHelper:
 
     def __init__(
         self,
-        config: ServiceConfig,
+        service_config: ServiceConfig,
         package_config: PackageConfig,
         project: GitProject,
         metadata: EventData,
         db_trigger,
         job_config: JobConfig,
     ):
-        self.config: ServiceConfig = config
+        self.service_config: ServiceConfig = service_config
         self.job_config = job_config
         self.package_config = package_config
         self.project: GitProject = project
@@ -85,7 +85,7 @@ class BaseBuildJobHelper:
         if self._local_project is None:
             self._local_project = LocalProject(
                 git_project=self.project,
-                working_dir=self.config.command_handler_work_dir,
+                working_dir=self.service_config.command_handler_work_dir,
                 ref=self.metadata.git_ref,
                 pr_id=self.metadata.pr_id,
             )
@@ -94,14 +94,16 @@ class BaseBuildJobHelper:
     @property
     def api(self) -> PackitAPI:
         if not self._api:
-            self._api = PackitAPI(self.config, self.job_config, self.local_project)
+            self._api = PackitAPI(
+                self.service_config, self.job_config, self.local_project
+            )
         return self._api
 
     @property
     def api_url(self) -> str:
         return (
             "https://prod.packit.dev/api"
-            if self.config.deployment == Deployment.prod
+            if self.service_config.deployment == Deployment.prod
             else "https://stg.packit.dev/api"
         )
 

--- a/packit_service/worker/build/copr_build.py
+++ b/packit_service/worker/build/copr_build.py
@@ -52,7 +52,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
 
     def __init__(
         self,
-        config: ServiceConfig,
+        service_config: ServiceConfig,
         package_config: PackageConfig,
         project: GitProject,
         metadata: EventData,
@@ -60,7 +60,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
         job_config: JobConfig,
     ):
         super().__init__(
-            config=config,
+            service_config=service_config,
             package_config=package_config,
             project=project,
             metadata=metadata,
@@ -77,7 +77,7 @@ class CoprBuildJobHelper(BaseBuildJobHelper):
         """
         Project name for copr -- add `-stg` suffix for the stg app.
         """
-        stg = "-stg" if self.config.deployment == Deployment.stg else ""
+        stg = "-stg" if self.service_config.deployment == Deployment.stg else ""
         return f"{self.project.namespace}-{self.project.repo}-{self.metadata.identifier}{stg}"
 
     @property

--- a/packit_service/worker/build/koji_build.py
+++ b/packit_service/worker/build/koji_build.py
@@ -52,7 +52,7 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
 
     def __init__(
         self,
-        config: ServiceConfig,
+        service_config: ServiceConfig,
         package_config: PackageConfig,
         project: GitProject,
         metadata: EventData,
@@ -60,7 +60,7 @@ class KojiBuildJobHelper(BaseBuildJobHelper):
         job_config: JobConfig,
     ):
         super().__init__(
-            config=config,
+            service_config=service_config,
             package_config=package_config,
             project=project,
             metadata=metadata,

--- a/packit_service/worker/handlers/abstract.py
+++ b/packit_service/worker/handlers/abstract.py
@@ -93,13 +93,13 @@ class Handler:
     triggers: List[TheJobTriggerType]
     api: Optional[PackitAPI] = None
     local_project: Optional[LocalProject] = None
-    _config: Optional[ServiceConfig] = None
+    _service_config: Optional[ServiceConfig] = None
 
     @property
-    def config(self) -> ServiceConfig:
-        if not self._config:
-            self._config = ServiceConfig.get_service_config()
-        return self._config
+    def service_config(self) -> ServiceConfig:
+        if not self._service_config:
+            self._service_config = ServiceConfig.get_service_config()
+        return self._service_config
 
     def run(self) -> HandlerResults:
         raise NotImplementedError("This should have been implemented.")
@@ -131,11 +131,11 @@ class Handler:
             logger.debug("This is not a kubernetes pod, won't clean.")
             return
         logger.debug("Removing contents of the PV.")
-        p = Path(self.config.command_handler_work_dir)
+        p = Path(self.service_config.command_handler_work_dir)
         # Do not clean dir if does not exist
         if not p.is_dir():
             logger.debug(
-                f"Directory {self.config.command_handler_work_dir!r} does not exist."
+                f"Directory {self.service_config.command_handler_work_dir!r} does not exist."
             )
             return
 
@@ -207,7 +207,7 @@ class JobHandler(Handler):
     @property
     def project(self) -> Optional[GitProject]:
         if not self._project and self.data.project_url:
-            self._project = self.config.get_project(url=self.data.project_url)
+            self._project = self.service_config.get_project(url=self.data.project_url)
         return self._project
 
     def run(self) -> HandlerResults:

--- a/packit_service/worker/handlers/fedmsg_handlers.py
+++ b/packit_service/worker/handlers/fedmsg_handlers.py
@@ -114,7 +114,7 @@ class NewDistGitCommitHandler(FedmsgHandler):
 
     def run(self) -> HandlerResults:
         # self.project is dist-git, we need to get upstream
-        dg = DistGit(self.config, self.job_config)
+        dg = DistGit(self.service_config, self.job_config)
         self.job_config.upstream_project_url = dg.get_project_url_from_distgit_spec()
         if not self.job_config.upstream_project_url:
             return HandlerResults(
@@ -128,10 +128,10 @@ class NewDistGitCommitHandler(FedmsgHandler):
         n, r = get_namespace_and_repo_name(self.job_config.upstream_project_url)
         up = self.project.service.get_project(repo=r, namespace=n)
         self.local_project = LocalProject(
-            git_project=up, working_dir=self.config.command_handler_work_dir
+            git_project=up, working_dir=self.service_config.command_handler_work_dir
         )
 
-        self.api = PackitAPI(self.config, self.job_config, self.local_project)
+        self.api = PackitAPI(self.service_config, self.job_config, self.local_project)
         self.api.sync_from_downstream(
             # rev is a commit
             # we use branch on purpose so we get the latest thing
@@ -214,7 +214,7 @@ class CoprBuildEndHandler(AbstractCoprBuildReportHandler):
 
     def run(self):
         build_job_helper = CoprBuildJobHelper(
-            config=self.config,
+            service_config=self.service_config,
             package_config=self.package_config,
             project=self.project,
             metadata=self.data,
@@ -325,7 +325,7 @@ class CoprBuildStartHandler(AbstractCoprBuildReportHandler):
 
     def run(self):
         build_job_helper = CoprBuildJobHelper(
-            config=self.config,
+            service_config=self.service_config,
             package_config=self.package_config,
             project=self.project,
             metadata=self.data,
@@ -445,7 +445,7 @@ class KojiBuildReportHandler(FedmsgHandler):
 
         url = get_koji_build_info_url_from_flask(build.id)
         build_job_helper = KojiBuildJobHelper(
-            config=self.config,
+            service_config=self.service_config,
             package_config=self.package_config,
             project=self.project,
             metadata=self.data,

--- a/packit_service/worker/handlers/pagure_handlers.py
+++ b/packit_service/worker/handlers/pagure_handlers.py
@@ -69,7 +69,7 @@ class PagurePullRequestCommentCoprBuildHandler(CommentActionHandler):
     def copr_build_helper(self) -> CoprBuildJobHelper:
         if not self._copr_build_helper:
             self._copr_build_helper = CoprBuildJobHelper(
-                config=self.config,
+                service_config=self.service_config,
                 package_config=self.package_config,
                 project=self.project,
                 metadata=self.data,
@@ -119,7 +119,8 @@ class PagurePullRequestLabelHandler(JobHandler):
     def bugzilla(self) -> Bugzilla:
         if self._bugzilla is None:
             self._bugzilla = Bugzilla(
-                url=self.config.bugzilla_url, api_key=self.config.bugzilla_api_key
+                url=self.service_config.bugzilla_url,
+                api_key=self.service_config.bugzilla_api_key,
             )
         return self._bugzilla
 
@@ -184,11 +185,13 @@ class PagurePullRequestLabelHandler(JobHandler):
             f"{self.base_repo_owner}/{self.base_repo_namespace}/"
             f"{self.base_repo_name}/{self.data.identifier}"
         )
-        if self.labels.intersection(self.config.pr_accepted_labels):
+        if self.labels.intersection(self.service_config.pr_accepted_labels):
             if not self.bz_model:
                 self._create_bug()
             self._attach_patch()
             self._set_status()
         else:
-            logger.debug(f"We accept only {self.config.pr_accepted_labels} labels/tags")
+            logger.debug(
+                f"We accept only {self.service_config.pr_accepted_labels} labels/tags"
+            )
         return HandlerResults(success=True)

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -186,14 +186,14 @@ class SteveJobs:
     """
 
     def __init__(self):
-        self._config = None
+        self._service_config = None
         log_job_versions()
 
     @property
-    def config(self):
-        if self._config is None:
-            self._config = ServiceConfig.get_service_config()
-        return self._config
+    def service_config(self):
+        if self._service_config is None:
+            self._service_config = ServiceConfig.get_service_config()
+        return self._service_config
 
     def process_jobs(self, event: Event) -> Dict[str, HandlerResults]:
         """
@@ -226,10 +226,13 @@ class SteveJobs:
             # failed because of missing whitelist approval
             whitelist = Whitelist()
             user_login = getattr(event, "user_login", None)
-            if user_login and user_login in self.config.admins:
+            if user_login and user_login in self.service_config.admins:
                 logger.info(f"{user_login} is admin, you shall pass.")
             elif not whitelist.check_and_report(
-                event, event.project, config=self.config, job_configs=job_configs
+                event,
+                event.project,
+                service_config=self.service_config,
+                job_configs=job_configs,
             ):
                 for job_config in job_configs:
                     handlers_results[job_config.type.value] = HandlerResults(
@@ -342,10 +345,10 @@ class SteveJobs:
         jobs = get_config_for_handler_kls(
             handler_kls=handler_kls, event=event, package_config=event.package_config,
         )
-        if user_login and user_login in self.config.admins:
+        if user_login and user_login in self.service_config.admins:
             logger.info(f"{user_login} is admin, you shall pass.")
         elif not whitelist.check_and_report(
-            event, event.project, config=self.config, job_configs=jobs
+            event, event.project, service_config=self.service_config, job_configs=jobs
         ):
             return {
                 event.trigger.value: HandlerResults(

--- a/packit_service/worker/testing_farm.py
+++ b/packit_service/worker/testing_farm.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 class TestingFarmJobHelper(CoprBuildJobHelper):
     def __init__(
         self,
-        config: ServiceConfig,
+        service_config: ServiceConfig,
         package_config: PackageConfig,
         project: GitProject,
         metadata: EventData,
@@ -54,7 +54,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
         job_config: JobConfig,
     ):
         super().__init__(
-            config=config,
+            service_config=service_config,
             package_config=package_config,
             project=project,
             metadata=metadata,
@@ -78,7 +78,7 @@ class TestingFarmJobHelper(CoprBuildJobHelper):
 
         return {
             "pipeline": {"id": pipeline_id},
-            "api": {"token": self.config.testing_farm_secret},
+            "api": {"token": self.service_config.testing_farm_secret},
             "response-url": f"{self.api_url}/testing-farm/results",
             "artifact": {
                 "repo-name": self.project.repo,

--- a/packit_service/worker/whitelist.py
+++ b/packit_service/worker/whitelist.py
@@ -177,12 +177,12 @@ class Whitelist:
         self,
         event: Optional[Any],
         project: GitProject,
-        config: ServiceConfig,
+        service_config: ServiceConfig,
         job_configs: Iterable[JobConfig],
     ) -> bool:
         """
         Check if account is approved and report status back in case of PR
-        :param config: service config
+        :param service_config: service config
         :param event: PullRequest and Release TODO: handle more
         :param project: GitProject
         :param job_configs: iterable of jobconfigs - so we know how to update status of the PR
@@ -232,7 +232,7 @@ class Whitelist:
                 else:
                     for job_config in job_configs:
                         job_helper = CoprBuildJobHelper(
-                            config=config,
+                            service_config=service_config,
                             package_config=event.get_package_config(),
                             project=project,
                             metadata=EventData.from_event_dict((event.get_dict())),

--- a/tests/integration/test_handler.py
+++ b/tests/integration/test_handler.py
@@ -60,7 +60,7 @@ def test_handler_cleanup(tmp_path, trick_p_s_with_k8s):
         data=flexmock(trigger=TheJobTriggerType.pull_request),
     )
 
-    flexmock(j).should_receive("config").and_return(c)
+    flexmock(j).should_receive("service_config").and_return(c)
 
     j._clean_workplace()
 

--- a/tests/unit/test_build_helper.py
+++ b/tests/unit/test_build_helper.py
@@ -266,7 +266,7 @@ ONE_KOJI_TARGET_SET = {list(STABLE_KOJI_TARGETS)[0]}
 )
 def test_targets(jobs, trigger, job_config_trigger_type, build_chroots, test_chroots):
     copr_build_handler = CoprBuildJobHelper(
-        config=flexmock(),
+        service_config=flexmock(),
         package_config=PackageConfig(jobs=jobs),
         job_config=jobs[0],  # BuildHelper looks at all jobs in the end
         project=flexmock(),
@@ -337,7 +337,7 @@ def test_targets_for_koji_build(
 ):
     pr_id = 41 if trigger == TheJobTriggerType.pull_request else None
     koji_build_handler = KojiBuildJobHelper(
-        config=flexmock(),
+        service_config=flexmock(),
         package_config=PackageConfig(jobs=jobs),
         job_config=jobs[0],
         project=flexmock(),

--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -89,7 +89,7 @@ def build_helper(
 
     pkg_conf = PackageConfig(jobs=jobs, downstream_package_name="dummy")
     handler = CoprBuildJobHelper(
-        config=ServiceConfig(),
+        service_config=ServiceConfig(),
         package_config=pkg_conf,
         job_config=jobs[0],
         project=GitProject(

--- a/tests/unit/test_koji_build.py
+++ b/tests/unit/test_koji_build.py
@@ -90,7 +90,7 @@ def build_helper(
 
     pkg_conf = PackageConfig(jobs=jobs, downstream_package_name="dummy")
     handler = KojiBuildJobHelper(
-        config=ServiceConfig(),
+        service_config=ServiceConfig(),
         package_config=pkg_conf,
         job_config=pkg_conf.jobs[0],
         project=GitProject(repo=flexmock(), service=flexmock(), namespace=flexmock()),

--- a/tests/unit/test_testing_farm.py
+++ b/tests/unit/test_testing_farm.py
@@ -175,7 +175,7 @@ def test_testing_farm_response(
         )
     )
     config = flexmock(command_handler_work_dir=flexmock())
-    flexmock(TFResultsHandler).should_receive("config").and_return(config)
+    flexmock(TFResultsHandler).should_receive("service_config").and_return(config)
     flexmock(TFResultsEvent).should_receive("db_trigger").and_return(None)
     config.should_receive("get_project").with_args(
         url="https://github.com/packit-service/ogr"

--- a/tests/unit/test_whitelist.py
+++ b/tests/unit/test_whitelist.py
@@ -198,7 +198,10 @@ def test_check_and_report_calls_method(whitelist, event, method, approved):
         whitelist_mock.and_return(None)
     assert (
         whitelist.check_and_report(
-            event, gp, config=flexmock(deployment=Deployment.stg), job_configs=[]
+            event,
+            gp,
+            service_config=flexmock(deployment=Deployment.stg),
+            job_configs=[],
         )
         is approved
     )
@@ -348,7 +351,9 @@ def test_check_and_report(
             whitelist.check_and_report(
                 event,
                 git_project,
-                config=flexmock(deployment=Deployment.stg, command_handler_work_dir=""),
+                service_config=flexmock(
+                    deployment=Deployment.stg, command_handler_work_dir=""
+                ),
                 job_configs=job_configs,
             )
             is is_valid

--- a/tests_requre/openshift_integration/base.py
+++ b/tests_requre/openshift_integration/base.py
@@ -15,8 +15,8 @@ class PackitServiceTestCase(RequreTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.steve = SteveJobs()
-        self.steve.config.command_handler = RunCommandType.local
-        self.steve.config.command_handler_work_dir = "/tmp/hello-world"
+        self.steve.service_config.command_handler = RunCommandType.local
+        self.steve.service_config.command_handler_work_dir = "/tmp/hello-world"
 
     def tearDown(self):
         super().tearDown()


### PR DESCRIPTION
As we discussed in previous [PR](https://github.com/packit-service/packit-service/pull/675#discussion_r442028682), it is more readable to have `service_config`.