### PR TITLE
new test case: make sure spec is discovered and set

### DIFF
--- a/tests/integration/test_issue_comment.py
+++ b/tests/integration/test_issue_comment.py
@@ -53,7 +53,7 @@ def issue_comment_propose_update_event():
 @pytest.fixture(scope="module")
 def mock_issue_comment_functionality():
     packit_yaml = (
-        "{'specfile_path': '', 'synced_files': [],"
+        "{'specfile_path': 'packit.spec', 'synced_files': [],"
         "'jobs': [{'trigger': 'release', 'job': 'propose_downstream',"
         "'metadata': {'dist-git-branch': 'master'}}],"
         "'downstream_package_name': 'packit'}"


### PR DESCRIPTION
Needs https://github.com/packit-service/packit/pull/886

This is just a p-s' side of #714 in terms of testing so we're sure this
is caught both ways. Once #886 is merged, this should start passing.

TL;DR, make sure that when specfile_path is not set in packit.yaml, it's
discovered correctly and set correctly in all jobs