### PR TITLE
Add projects endpoint to the API

### DIFF
--- a/packit_service/service/api/__init__.py
+++ b/packit_service/service/api/__init__.py
@@ -29,6 +29,7 @@ except ModuleNotFoundError:
     from flask_restplus import Api
 
 from packit_service.service.api.copr_builds import ns as copr_builds_ns
+from packit_service.service.api.projects import ns as projects_ns
 from packit_service.service.api.healthz import ns as healthz_ns
 from packit_service.service.api.installations import ns as installations_ns
 from packit_service.service.api.tasks import ns as tasks_ns
@@ -46,6 +47,7 @@ api = Api(
 )
 
 api.add_namespace(copr_builds_ns)
+api.add_namespace(projects_ns)
 api.add_namespace(healthz_ns)
 api.add_namespace(installations_ns)
 api.add_namespace(tasks_ns)

--- a/packit_service/service/api/projects.py
+++ b/packit_service/service/api/projects.py
@@ -1,0 +1,154 @@
+from http import HTTPStatus
+from logging import getLogger
+from flask import make_response
+from json import dumps
+
+try:
+    from flask_restx import Namespace, Resource
+except ModuleNotFoundError:
+    from flask_restplus import Namespace, Resource
+
+from packit_service.service.api.parsers import indices, pagination_arguments
+from packit_service.models import GitProjectModel
+
+logger = getLogger("packit_service")
+
+ns = Namespace(
+    "projects", description="Repositories which have Packit Service enabled."
+)
+
+
+@ns.route("")
+class ProjectsList(Resource):
+    @ns.expect(pagination_arguments)
+    @ns.response(HTTPStatus.PARTIAL_CONTENT, "Projects list follows")
+    @ns.response(HTTPStatus.OK, "OK")
+    def get(self):
+        """List all GitProjects"""
+
+        result = []
+        first, last = indices()
+
+        projects_list = GitProjectModel.get_projects(first, last)
+        if not projects_list:
+            return ([], HTTPStatus.OK)
+        for project in projects_list:
+            project_info = {
+                "namespace": project.namespace,
+                "repo_name": project.repo_name,
+                "project_url": project.project_url,
+                "prs_handled": len(project.pull_requests),
+                "branches_handled": len(project.branches),
+                "releases_handled": len(project.releases),
+                "issues_handled": len(project.issues),
+            }
+            result.append(project_info)
+
+        resp = make_response(dumps(result), HTTPStatus.PARTIAL_CONTENT)
+        resp.headers["Content-Range"] = f"git-projects {first + 1}-{last}/*"
+        resp.headers["Content-Type"] = "application/json"
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+        return resp
+
+
+@ns.route("/<forge>/<namespace>/<repo_name>/prs")
+@ns.param("forge", "Git Forge")
+@ns.param("namespace", "Namespace")
+@ns.param("repo_name", "Repo Name")
+class ProjectsPRs(Resource):
+    @ns.expect(pagination_arguments)
+    @ns.response(
+        HTTPStatus.PARTIAL_CONTENT, "Project PRs handled by Packit Service follow"
+    )
+    @ns.response(HTTPStatus.OK, "OK")
+    def get(self, forge, namespace, repo_name):
+        """List PRs"""
+
+        result = []
+        first, last = indices()
+
+        pr_list = GitProjectModel.get_project_prs(
+            first, last, forge, namespace, repo_name
+        )
+        if not pr_list:
+            return ([], HTTPStatus.OK)
+        for pr in pr_list:
+            pr_info = {
+                "pr_id": pr.pr_id,
+                "builds": [],
+                "tests": [],
+            }
+            copr_builds = []
+            test_runs = []
+            for build in pr.get_copr_builds():
+                build_info = {
+                    "build_id": build.build_id,
+                    "chroot": build.target,
+                    "status": build.status,
+                    "web_url": build.web_url,
+                }
+                copr_builds.append(build_info)
+            pr_info["builds"] = copr_builds
+            for test_run in pr.get_test_runs():
+                test_info = {
+                    "pipeline_id": test_run.pipeline_id,
+                    "chroot": test_run.target,
+                    "status": str(test_run.status),
+                    "web_url": test_run.web_url,
+                }
+                test_runs.append(test_info)
+            pr_info["tests"] = test_runs
+
+            result.append(pr_info)
+
+        resp = make_response(dumps(result), HTTPStatus.PARTIAL_CONTENT)
+        resp.headers["Content-Range"] = f"git-project-prs {first + 1}-{last}/*"
+        resp.headers["Content-Type"] = "application/json"
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+        return resp
+
+
+@ns.route("/<forge>/<namespace>/<repo_name>/issues")
+@ns.param("forge", "Git Forge")
+@ns.param("namespace", "Namespace")
+@ns.param("repo_name", "Repo Name")
+class ProjectIssues(Resource):
+    @ns.response(HTTPStatus.OK, "OK, project issues handled by Packit Service follow")
+    def get(self, forge, namespace, repo_name):
+        """Project issues"""
+        issues_list = GitProjectModel.get_project_issues(forge, namespace, repo_name)
+        if not issues_list:
+            return ([], HTTPStatus.OK)
+        result = {"issues": []}
+        for issue in issues_list:
+            result["issues"].append(issue.issue_id)
+        resp = make_response(dumps(result))
+        resp.headers["Content-Type"] = "application/json"
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+        return resp
+
+
+@ns.route("/<forge>/<namespace>/<repo_name>/releases")
+@ns.param("forge", "Git Forge")
+@ns.param("namespace", "Namespace")
+@ns.param("repo_name", "Repo Name")
+class ProjectReleases(Resource):
+    @ns.response(HTTPStatus.OK, "OK, project releases handled by Packit Service follow")
+    def get(self, forge, namespace, repo_name):
+        """Project releases"""
+        releases_list = GitProjectModel.get_project_releases(
+            forge, namespace, repo_name
+        )
+        if not releases_list:
+            return ([], HTTPStatus.OK)
+        result = []
+        for release in releases_list:
+            release_info = {
+                "tag_name": release.tag_name,
+                "commit_hash": release.commit_hash,
+            }
+            result.append(release_info)
+        resp = make_response(dumps(result))
+        resp.headers["Content-Type"] = "application/json"
+        resp.headers["Access-Control-Allow-Origin"] = "*"
+        return resp

--- a/tests_requre/conftest.py
+++ b/tests_requre/conftest.py
@@ -112,6 +112,9 @@ class SampleValues:
     bug_id = 123456
     bug_url = f"https://partner-bugzilla.redhat.com/show_bug.cgi?id={bug_id}"
 
+    # Issues
+    issue_id = 2020
+
 
 @pytest.fixture(scope="session", autouse=True)
 def global_service_config():
@@ -279,6 +282,16 @@ def bugzilla_model():
 
 
 @pytest.fixture()
+def an_issue_model():
+    yield IssueModel.get_or_create(
+        issue_id=SampleValues.issue_id,
+        namespace=SampleValues.repo_namespace,
+        repo_name=SampleValues.repo_name,
+        project_url=SampleValues.project_url,
+    )
+
+
+@pytest.fixture()
 def a_copr_build_for_pr(pr_model, srpm_build_model):
     model = CoprBuildModel.get_or_create(
         build_id=SampleValues.build_id,
@@ -377,54 +390,57 @@ def multiple_copr_builds(pr_model, different_pr_model, srpm_build_model):
 @pytest.fixture()
 def too_many_copr_builds(pr_model, different_pr_model, srpm_build_model):
     """Don't use for testing anything other than pagination, use multiple_copr_builds."""
+    builds_list = []
     for i in range(20):
-
-        # The following two are similar, except for target, status
-        CoprBuildModel.get_or_create(
-            build_id=SampleValues.build_id + str(i),
-            commit_sha=SampleValues.ref,
-            project_name=SampleValues.project,
-            owner=SampleValues.owner,
-            web_url=SampleValues.copr_web_url + str(i),
-            target=SampleValues.target,
-            status=SampleValues.status_success,
-            srpm_build=srpm_build_model,
-            trigger_model=pr_model,
-        )
-        CoprBuildModel.get_or_create(
-            build_id=SampleValues.build_id + str(i),
-            commit_sha=SampleValues.ref,
-            project_name=SampleValues.project,
-            owner=SampleValues.owner,
-            web_url=SampleValues.copr_web_url + str(i),
-            target=SampleValues.different_target,
-            status=SampleValues.status_pending,
-            srpm_build=srpm_build_model,
-            trigger_model=pr_model,
-        )
-        # The following two are similar, except for target, status
-        CoprBuildModel.get_or_create(
-            build_id=SampleValues.different_build_id + str(i),
-            commit_sha=SampleValues.different_commit_sha,
-            project_name=SampleValues.different_project_name,
-            owner=SampleValues.owner,
-            web_url=SampleValues.copr_web_url + str(i),
-            target=SampleValues.target,
-            status=SampleValues.status_success,
-            srpm_build=srpm_build_model,
-            trigger_model=different_pr_model,
-        )
-        CoprBuildModel.get_or_create(
-            build_id=SampleValues.different_build_id + str(i),
-            commit_sha=SampleValues.different_commit_sha,
-            project_name=SampleValues.different_project_name,
-            owner=SampleValues.owner,
-            web_url=SampleValues.copr_web_url + str(i),
-            target=SampleValues.different_target,
-            status=SampleValues.status_success,
-            srpm_build=srpm_build_model,
-            trigger_model=different_pr_model,
-        )
+        builds_list += [
+            # The following two are similar, except for target, status
+            CoprBuildModel.get_or_create(
+                build_id=SampleValues.build_id + str(i),
+                commit_sha=SampleValues.ref,
+                project_name=SampleValues.project,
+                owner=SampleValues.owner,
+                web_url=SampleValues.copr_web_url + str(i),
+                target=SampleValues.target,
+                status=SampleValues.status_success,
+                srpm_build=srpm_build_model,
+                trigger_model=pr_model,
+            ),
+            CoprBuildModel.get_or_create(
+                build_id=SampleValues.build_id + str(i),
+                commit_sha=SampleValues.ref,
+                project_name=SampleValues.project,
+                owner=SampleValues.owner,
+                web_url=SampleValues.copr_web_url + str(i),
+                target=SampleValues.different_target,
+                status=SampleValues.status_pending,
+                srpm_build=srpm_build_model,
+                trigger_model=pr_model,
+            ),
+            # The following two are similar, except for target, status
+            CoprBuildModel.get_or_create(
+                build_id=SampleValues.different_build_id + str(i),
+                commit_sha=SampleValues.different_commit_sha,
+                project_name=SampleValues.different_project_name,
+                owner=SampleValues.owner,
+                web_url=SampleValues.copr_web_url + str(i),
+                target=SampleValues.target,
+                status=SampleValues.status_success,
+                srpm_build=srpm_build_model,
+                trigger_model=different_pr_model,
+            ),
+            CoprBuildModel.get_or_create(
+                build_id=SampleValues.different_build_id + str(i),
+                commit_sha=SampleValues.different_commit_sha,
+                project_name=SampleValues.different_project_name,
+                owner=SampleValues.owner,
+                web_url=SampleValues.copr_web_url + str(i),
+                target=SampleValues.different_target,
+                status=SampleValues.status_success,
+                srpm_build=srpm_build_model,
+                trigger_model=different_pr_model,
+            ),
+        ]
+    yield builds_list
 
 
 @pytest.fixture()

--- a/tests_requre/database/test_models.py
+++ b/tests_requre/database/test_models.py
@@ -513,6 +513,48 @@ def test_project_property_for_copr_build(a_copr_build_for_pr):
     assert project.repo_name == "the-repo-name"
 
 
+def test_get_projects(clean_before_and_after, a_copr_build_for_pr):
+    projects = GitProjectModel.get_projects(0, 10)
+    assert isinstance(projects[0], GitProjectModel)
+    assert projects[0].namespace == "the-namespace"
+    assert projects[0].repo_name == "the-repo-name"
+    assert projects[0].project_url == "https://github.com/the-namespace/the-repo-name"
+
+
+def test_get_project_prs(clean_before_and_after, a_copr_build_for_pr):
+    prs_a = GitProjectModel.get_project_prs(
+        0, 10, "github.com", "the-namespace", "the-repo-name"
+    )
+    assert prs_a is not None
+    assert len(prs_a) == 1
+    assert prs_a[0].id is not None  # cant explicitly check because its random like
+    prs_b = GitProjectModel.get_project_prs(
+        0, 10, "gitlab.com", "the-namespace", "the-repo-name"
+    )
+    assert prs_b is None
+    prs_c = GitProjectModel.get_project_prs(
+        0, 10, "github", "the-namespace", "the-repo-name"
+    )
+    assert prs_c is None
+
+
+def test_get_project_issues(clean_before_and_after, an_issue_model):
+    issues_list = GitProjectModel.get_project_issues(
+        "github.com", "the-namespace", "the-repo-name"
+    )
+    assert len(issues_list) == 1
+    assert issues_list[0].issue_id == 2020
+
+
+def test_get_project_releases(clean_before_and_after, release_model):
+    releases = GitProjectModel.get_project_releases(
+        "github.com", "the-namespace", "the-repo-name"
+    )
+    assert releases[0].tag_name == "v1.0.2"
+    assert releases[0].commit_hash == "80201a74d96c"
+    assert len(releases) == 1
+
+
 def test_project_property_for_koji_build(a_koji_build_for_pr):
     project = a_koji_build_for_pr.get_project()
     assert isinstance(project, GitProjectModel)

--- a/tests_requre/service/test_api.py
+++ b/tests_requre/service/test_api.py
@@ -140,8 +140,8 @@ def test_detailed_koji_build_info_for_release(
     assert response_dict["release"] == SampleValues.tag_name
 
 
-# Test Whitelist API (all)
 def test_whitelist_all(client, clean_before_and_after, new_whitelist_entry):
+    """Test Whitelist API (all)"""
     response = client.get(url_for("api.whitelist_white_list"))
     response_dict = response.json
     assert response_dict[0]["account"] == "Rayquaza"
@@ -149,8 +149,8 @@ def test_whitelist_all(client, clean_before_and_after, new_whitelist_entry):
     assert len(list(response_dict)) == 1
 
 
-# Test Whitelist API (specific user)
 def test_whitelist_specific(client, clean_before_and_after, new_whitelist_entry):
+    """Test Whitelist API (specific user)"""
     user_1 = client.get(url_for("api.whitelist_white_list_item", login="Rayquaza"))
     assert user_1.json["account"] == "Rayquaza"
     assert user_1.json["status"] == "approved_manually"
@@ -159,10 +159,10 @@ def test_whitelist_specific(client, clean_before_and_after, new_whitelist_entry)
     assert user_2.status_code == 204  # No content when not in whitelist
 
 
-#  Test Get Testing Farm Results
 def test_get_testing_farm_results(
     client, clean_before_and_after, multiple_new_test_runs
 ):
+    """Test Get Testing Farm Results"""
     response = client.get(url_for("api.testing-farm_testing_farm_results"))
     response_dict = response.json
     assert len(response_dict) == 3
@@ -182,3 +182,61 @@ def test_get_testing_farm_results(
     assert response_dict[1]["status"] == "new"
 
     assert response_dict[2]["target"] == SampleValues.chroots[1]
+
+
+def test_get_projects_list(client, clean_before_and_after, a_copr_build_for_pr):
+    """Test Get Projects"""
+    response = client.get(url_for("api.projects_projects_list"))
+    response_dict = response.json
+    assert len(response_dict) == 1
+    assert response_dict[0]["namespace"] == SampleValues.repo_namespace
+    assert response_dict[0]["repo_name"] == SampleValues.repo_name
+    assert response_dict[0]["project_url"] == SampleValues.project_url
+    assert response_dict[0]["prs_handled"] == 1
+
+
+def test_get_projects_prs(client, clean_before_and_after, a_copr_build_for_pr):
+    """Test Get Project's Pull Requests"""
+    response = client.get(
+        url_for(
+            "api.projects_projects_p_rs",
+            forge="github.com",
+            namespace="the-namespace",
+            repo_name="the-repo-name",
+        )
+    )
+    response_dict = response.json
+    assert len(response_dict) == 1
+    assert response_dict[0]["pr_id"] is not None
+    assert response_dict[0]["builds"][0]["build_id"] == SampleValues.build_id
+    assert response_dict[0]["builds"][0]["status"] == "pending"
+
+
+def test_get_projects_issues(client, clean_before_and_after, an_issue_model):
+    """Test Get Project's Issues"""
+    response = client.get(
+        url_for(
+            "api.projects_project_issues",
+            forge="github.com",
+            namespace="the-namespace",
+            repo_name="the-repo-name",
+        )
+    )
+    response_dict = response.json
+    assert response_dict["issues"][0] == SampleValues.issue_id
+
+
+def test_get_projects_releases(client, clean_before_and_after, release_model):
+    """Test Get Project's Releases"""
+    response = client.get(
+        url_for(
+            "api.projects_project_releases",
+            forge="github.com",
+            namespace="the-namespace",
+            repo_name="the-repo-name",
+        )
+    )
+    response_dict = response.json
+    assert len(response_dict) == 1
+    assert response_dict[0]["tag_name"] == SampleValues.tag_name
+    assert response_dict[0]["commit_hash"] == SampleValues.commit_sha


### PR DESCRIPTION
/**projects** - with pagination 
```json
[
  {
    "namespace": "abrt",
    "repo_name": "abrt-java-connector",
    "project_url": "https://github.com/abrt/abrt-java-connector",
    "num_prs": 2,
    "num_branches": 2,
    "num_releases": 1,
    "num_issues": 0
  },
  {
    "namespace": "abrt",
    "repo_name": "gnome-abrt",
    "project_url": "https://github.com/abrt/gnome-abrt",
    "num_prs": 13,
    "num_branches": 1,
    "num_releases": 4,
    "num_issues": 0
  },
.
.
.
]
```
**/projects/{namespace}/{repo_name}/issues**
```json
{
  "issues": [
    883,
    880,
    804
  ]
}
```
**/projects/{namespace}/{repo_name}/prs** - with pagination for 10/20/50 PRs etc
```json
[
  {
    "pr_id": 886,
    "builds": [
      {
        "build_id": "1517042",
        "chroot": "fedora-rawhide-x86_64",
        "status": "success",
        "web_url": "https://copr.fedorainfracloud.org/coprs/build/1517042/"
      },
      {
        "build_id": "1517042",
        "chroot": "fedora-32-x86_64",
        "status": "success",
        "web_url": "https://copr.fedorainfracloud.org/coprs/build/1517042/"
      },
      {
        "build_id": "1517042",
        "chroot": "fedora-31-x86_64",
        "status": "success",
        "web_url": "https://copr.fedorainfracloud.org/coprs/build/1517042/"
      },
      {
        "build_id": "1516946",
        "chroot": "fedora-rawhide-x86_64",
        "status": "success",
        "web_url": "https://copr.fedorainfracloud.org/coprs/build/1516946/"
      },
      {
        "build_id": "1516946",
        "chroot": "fedora-32-x86_64",
        "status": "success",
        "web_url": "https://copr.fedorainfracloud.org/coprs/build/1516946/"
      },
      {
        "build_id": "1516946",
        "chroot": "fedora-31-x86_64",
        "status": "success",
        "web_url": "https://copr.fedorainfracloud.org/coprs/build/1516946/"
      }
    ],
    "tests": [
      {
        "pipeline_id": "a6d0448d-74a6-44ad-b691-82ac191bf823",
        "chroot": "fedora-32-x86_64",
        "status": "TestingFarmResult.passed",
        "web_url": "https://console-testing-farm.apps.ci.centos.org/pipeline/a6d0448d-74a6-44ad-b691-82ac191bf823"
      },
      {
        "pipeline_id": "20468bee-4595-4121-8ecf-8f0816028c9a",
        "chroot": "fedora-31-x86_64",
        "status": "TestingFarmResult.error",
        "web_url": "https://console-testing-farm.apps.ci.centos.org/pipeline/20468bee-4595-4121-8ecf-8f0816028c9a"
      },
      {
        "pipeline_id": "edf25482-ae9d-49bc-bd2a-55c49c2a39bf",
        "chroot": "fedora-32-x86_64",
        "status": "TestingFarmResult.failed",
        "web_url": "https://console-testing-farm.apps.ci.centos.org/pipeline/edf25482-ae9d-49bc-bd2a-55c49c2a39bf"
      },
      {
        "pipeline_id": "df3488bf-5f0d-4a4d-9ccd-14c5a0c8531f",
        "chroot": "fedora-31-x86_64",
        "status": "TestingFarmResult.failed",
        "web_url": "https://console-testing-farm.apps.ci.centos.org/pipeline/df3488bf-5f0d-4a4d-9ccd-14c5a0c8531f"
      }
    ]
  },
.
.
.
]
```
**/projects/{namespace}/{repo_name}/releases**
```json
[
  {
    "tag_name": "0.12.0",
    "commit_hash": "10eed27f405a9ccdf528d48ebe62ba33b07b5abc"
  },
  {
    "tag_name": "0.11.1",
    "commit_hash": "a0a59fd3c382cabf6ce35e2e4e558dba761669e4"
  },
.
.
.
]
```

Notes: 

- Wanted to have this reviewed before I start making tests. 
- Relevant #638 #709 #711
- Leaving koji for now because once the API is decided we can just copy-paste-edit to make it analogous to the copr endpoint.
- I went for this apprach
```
PR 2
-- Copr Builds
-- Test Runs
PR 1
-- Copr Builds
-- Test Runs
```
rather than separate endpoint for all builds and all test runs of a project because:
a) data is more structured this way (Project Page - PRs, Branches, Releases, Issues subsections)
b) it was way way easier to obtain data this way than go through unknown hurdles for every item (jobtriggermodel 👿👿 )