### PR TITLE
Breaking image dependency: pacit-service-worker <- packit

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,6 +1,6 @@
 # Celery worker which runs tasks (packit) from the web service
 
-FROM docker.io/usercont/packit
+FROM fedora:32
 
 ENV LANG=en_US.UTF-8 \
     ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3 \
@@ -9,9 +9,11 @@ ENV LANG=en_US.UTF-8 \
     HOME=/home/packit \
     PS_PATH=/src-packit-service
 
+
 # Ansible doesn't like /tmp
 COPY files/install-deps-worker.yaml $PS_PATH/files/
-RUN cd $PS_PATH/ \
+RUN dnf install -y ansible \
+    && cd $PS_PATH/ \
     && ansible-playbook -vv -c local -i localhost, files/install-deps-worker.yaml \
     && dnf clean all
 

--- a/Dockerfile.worker.prod
+++ b/Dockerfile.worker.prod
@@ -1,7 +1,7 @@
 # Celery worker which runs tasks (packit) from the web service
 # The only difference between this and Dockerfile.worker is the ":prod" on first line
 
-FROM docker.io/usercont/packit:prod
+FROM fedora:32
 
 ENV LANG=en_US.UTF-8 \
     ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3 \
@@ -10,9 +10,11 @@ ENV LANG=en_US.UTF-8 \
     HOME=/home/packit \
     PS_PATH=/src-packit-service
 
+
 # Ansible doesn't like /tmp
 COPY files/install-deps-worker.yaml $PS_PATH/files/
-RUN cd $PS_PATH/ \
+RUN dnf install -y ansible \
+    && cd $PS_PATH/ \
     && ansible-playbook -vv -c local -i localhost, files/install-deps-worker.yaml \
     && dnf clean all
 

--- a/files/docker/Dockerfile
+++ b/files/docker/Dockerfile
@@ -1,0 +1,38 @@
+# Image for the web service (httpd), for celery worker see Dockerfile.worker
+
+FROM fedora:32
+
+ARG SOURCE_BRANCH
+
+ENV LANG=en_US.UTF-8 \
+    ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3 \
+    ANSIBLE_STDOUT_CALLBACK=debug \
+    USER=packit \
+    HOME=/home/packit
+
+RUN dnf install -y ansible
+
+COPY files/install-deps.yaml /src/files/
+
+RUN cd /src/ \
+    && ansible-playbook -vv -c local -i localhost, files/install-deps.yaml \
+    && dnf clean all
+
+COPY setup.py setup.cfg files/recipe.yaml files/tasks/httpd.yaml files/tasks/common.yaml files/packit.wsgi files/run_httpd.sh files/setup_env_in_openshift.sh files/packit-httpd.conf /src/
+# setuptools-scm
+COPY .git /src/.git
+COPY packit_service/ /src/packit_service/
+
+RUN cd /src/ \
+    && git rev-parse HEAD >/.packit-service.git.commit.hash \
+    && git show --quiet --format=%B HEAD >/.packit-service.git.commit.message \
+    && ansible-playbook -vv -c local -i localhost, recipe.yaml
+
+# no need to rm /src, it will stay in the image anyway
+
+COPY alembic.ini /src/
+COPY alembic/ /src/alembic/
+
+EXPOSE 8443
+
+CMD ["/usr/bin/run_httpd.sh"]

--- a/files/docker/Dockerfile.tests
+++ b/files/docker/Dockerfile.tests
@@ -1,0 +1,19 @@
+# For running tests locally, see check_in_container target in Makefile
+
+FROM docker.io/usercont/packit-service-worker:dev
+
+ENV ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3 \
+    ANSIBLE_STDOUT_CALLBACK=debug
+
+# Since we use worker base image, we need to install service deps manually
+COPY files/install-deps.yaml /src/files/
+RUN cd /src/ \
+    && ansible-playbook -vv -c local -i localhost, files/install-deps.yaml
+
+RUN set -ex; mkdir -p /home/packit/.config \
+    && ln -s $PS_PATH/files/packit-service.yaml /home/packit/.config/packit-service.yaml \
+    && ansible-playbook -vv -c local -i localhost, ./files/recipe-tests.yaml
+
+# we are doing the same here as in worker Df so that we don't need to rerun the
+# playbook above for every code change: iterating fast <3
+COPY . $PS_PATH

--- a/files/docker/Dockerfile.worker
+++ b/files/docker/Dockerfile.worker
@@ -1,0 +1,35 @@
+# Celery worker which runs tasks (packit) from the web service
+
+FROM fedora:32
+
+ARG SOURCE_BRANCH
+
+ENV LANG=en_US.UTF-8 \
+    ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3 \
+    ANSIBLE_STDOUT_CALLBACK=debug \
+    USER=packit \
+    HOME=/home/packit \
+    PS_PATH=/src-packit-service
+
+
+# Ansible doesn't like /tmp
+COPY files/install-deps-worker.yaml $PS_PATH/files/
+RUN dnf install -y ansible \
+    && cd $PS_PATH/ \
+    && ansible-playbook -vv -c local -i localhost, files/install-deps-worker.yaml \
+    && dnf clean all
+
+COPY setup.py setup.cfg files/recipe-worker.yaml files/tasks/common.yaml files/run_worker.sh files/gitconfig .git_archival.txt .gitattributes $PS_PATH/
+# setuptools-scm
+COPY .git $PS_PATH/.git
+COPY packit_service/ $PS_PATH/packit_service/
+
+RUN cd $PS_PATH \
+    && git rev-parse HEAD >/.packit-service.git.commit.hash \
+    && git show --quiet --format=%B HEAD >/.packit-service.git.commit.message \
+    && ansible-playbook -vv -c local -i localhost, recipe-worker.yaml
+
+COPY . $PS_PATH
+WORKDIR $PS_PATH
+
+CMD ["/usr/bin/run_worker.sh"]

--- a/files/docker/README.md
+++ b/files/docker/README.md
@@ -1,0 +1,1 @@
+For details about build configuration please check [deployment documentation](https://github.com/packit-service/deployment#image-build-process)

--- a/files/docker/hooks/build
+++ b/files/docker/hooks/build
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build -t $IMAGE_NAME -f $DOCKERFILE_PATH --build-arg SOURCE_BRANCH=$SOURCE_BRANCH .

--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -1,7 +1,15 @@
 ---
 - name: Install dependencies for packit-service worker.
   hosts: all
+  vars:
+    # added default value to not break functionality during implementing
+    # https://github.com/packit-service/packit-service/pull/717
+    # have to be removed once implemented
+    source_branch: "{{ lookup('env', 'SOURCE_BRANCH') or 'master' }}"
   tasks:
+    - name: Check source_branch value
+      debug:
+        msg: source_branch is set to {{ source_branch }}
     - name: Install all RPM/python packages needed to run packit-service worker.
       dnf:
         name:
@@ -28,7 +36,7 @@
           # provides dnf builddep, required for packit dep installation from spec file
           - dnf-plugins-core
         state: present
-    - name: Install dependencies for pakcit
+    - name: Install dependencies for packit
       block:
         - name: Download script setupcfg2rpm.py
           get_url:
@@ -37,7 +45,7 @@
             mode: "0744"
         - name: Download packit spec file
           get_url:
-            url: https://raw.githubusercontent.com/packit-service/packit/master/packit.spec
+            url: https://raw.githubusercontent.com/packit-service/packit/{{ source_branch }}/packit.spec
             dest: ./packit.spec
         - name: Install packit RPM build dependencies from packit.spec
           shell: dnf builddep packit.spec -y
@@ -50,9 +58,9 @@
           become: true
         - name: Download packit setup.cfg
           get_url:
-            url: https://raw.githubusercontent.com/packit-service/packit/master/setup.cfg
+            url: https://raw.githubusercontent.com/packit-service/packit/{{ source_branch }}/setup.cfg
             dest: ./packit_setup.cfg
-        - name: Install depndencies provided by setupcfg2rpm
+        - name: Install dependencies provided by setupcfg2rpm
           shell: dnf install $(./setupcfg2rpm.py packit_setup.cfg)
           become: true
     - name: Install dependencies from setup.cfg as rpm packages for ogr
@@ -60,9 +68,10 @@
         # setupcfg2rpm.py was downloaded in previous block
         - name: Download ogr setup.cfg
           get_url:
+            # ogr has only master branch
             url: https://raw.githubusercontent.com/packit-service/ogr/master/setup.cfg
             dest: ./ogr_setup.cfg
-        - name: Install dependencies provided by setupcfg2rpm
+        - name: Install ogr dependencies provided by setupcfg2rpm
           shell: dnf install $(./setupcfg2rpm.py ogr_setup.cfg)
           args:
             warn: no
@@ -74,11 +83,12 @@
           - sentry-sdk
           - flask-restx
         executable: pip3
-    # to avoid unwanted pip packages installations, because of not installed rpms
-    - name: Install pip deps with --no-deps
+    # --no-deps: to fail instead of installing from PyPI when we forget to add some dependency to packit.spec
+    - name: pip install packit & ogr with --no-deps
       pip:
         name:
-          - git+https://github.com/packit-service/packit.git
+          - git+https://github.com/packit-service/packit.git@{{ source_branch }}
+          # ogr has only master branch
           - git+https://github.com/packit-service/ogr.git
         executable: pip3
         extra_args: --no-deps

--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -22,7 +22,51 @@
           - python3-bugzilla # python-bugzilla (not bugzilla) on PyPI
           - python3-backoff # Bugzilla class
           #- python3-flask-restx # needs Fedora 32
+          - dnf-utils
+          - python3-pip
+          - make
+          # provides dnf builddep, required for packit dep installation from spec file
+          - dnf-plugins-core
         state: present
+    - name: Install dependencies for pakcit
+      block:
+        - name: Download script setupcfg2rpm.py
+          get_url:
+            url: https://raw.githubusercontent.com/packit-service/deployment/master/scripts/setupcfg2rpm.py
+            dest: ./setupcfg2rpm.py
+            mode: "0744"
+        - name: Download packit spec file
+          get_url:
+            url: https://raw.githubusercontent.com/packit-service/packit/master/packit.spec
+            dest: ./packit.spec
+        - name: Install packit RPM build dependencies from packit.spec
+          shell: dnf builddep packit.spec -y
+          args:
+            warn: no
+        - name: Install packit RPM runtime dependencies
+          shell: dnf install $(rpmspec -q --requires packit.spec | grep -v 'packit') -y
+          args:
+            warn: no
+          become: true
+        - name: Download packit setup.cfg
+          get_url:
+            url: https://raw.githubusercontent.com/packit-service/packit/master/setup.cfg
+            dest: ./packit_setup.cfg
+        - name: Install depndencies provided by setupcfg2rpm
+          shell: dnf install $(./setupcfg2rpm.py packit_setup.cfg)
+          become: true
+    - name: Install dependencies from setup.cfg as rpm packages for ogr
+      block:
+        # setupcfg2rpm.py was downloaded in previous block
+        - name: Download ogr setup.cfg
+          get_url:
+            url: https://raw.githubusercontent.com/packit-service/ogr/master/setup.cfg
+            dest: ./ogr_setup.cfg
+        - name: Install dependencies provided by setupcfg2rpm
+          shell: dnf install $(./setupcfg2rpm.py ogr_setup.cfg)
+          args:
+            warn: no
+          become: true
     - name: Install pip deps
       pip:
         name:
@@ -30,3 +74,13 @@
           - sentry-sdk
           - flask-restx
         executable: pip3
+    # to avoid unwanted pip packages installations, because of not installed rpms
+    - name: Install pip deps with --no-deps
+      pip:
+        name:
+          - git+https://github.com/packit-service/packit.git
+          - git+https://github.com/packit-service/ogr.git
+        executable: pip3
+        extra_args: --no-deps
+    - name: Chek if all pip packages have all dependencies installed
+      command: pip check

--- a/files/recipe-worker.yaml
+++ b/files/recipe-worker.yaml
@@ -4,14 +4,6 @@
   vars:
     home_path: "{{ lookup('env', 'HOME') }}"
     packit_service_path: /src-packit-service
-    ansible_bender:
-      base_image: docker.io/usercont/packit
-      target_image:
-        name: docker.io/usercont/packit-service-worker
-        cmd: run_worker.sh
-      working_container:
-        volumes:
-          - "{{ playbook_dir }}:{{ packit_service_path }}:Z"
   tasks:
     - import_tasks: common.yaml
     - name: Create /sandcastle


### PR DESCRIPTION
Docker and ansible configs updated, so dependencies are installed, 
without requirement to have them in base container image.

  Deployment related configuration was improved, so same branch for
all internal projects installed form github repositories will be used.
  This is achieved using docker build hook (files/docker/hooks)