### PR TITLE
Redis: don't use authentication if there is no password set

### DIFF
--- a/packit_service/celerizer.py
+++ b/packit_service/celerizer.py
@@ -37,10 +37,11 @@ class Celerizer:
     def celery_app(self):
         if self._celery_app is None:
             password = getenv("REDIS_PASSWORD", "")
+            authentication = f":{password}@" if password else ""
             host = getenv("REDIS_SERVICE_HOST", "redis")
             port = getenv("REDIS_SERVICE_PORT", "6379")
             db = getenv("REDIS_SERVICE_DB", "0")
-            redis_url = f"redis://:{password}@{host}:{port}/{db}"
+            redis_url = f"redis://{authentication}{host}:{port}/{db}"
 
             # https://docs.celeryproject.org/en/stable/userguide/configuration.html#database-url-examples
             postgres_url = f"db+{get_pg_url()}"


### PR DESCRIPTION
It seems that an empty password triggers:

`redis.exceptions.ResponseError: NOAUTH Authentication required.`

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>