### PR TITLE
CoprBuildJobHelper: make sure metadata.pr_id is set

### DIFF
--- a/tests/unit/test_copr_build.py
+++ b/tests/unit/test_copr_build.py
@@ -118,6 +118,9 @@ def test_copr_build_check_names(github_pr_event):
         metadata=JobMetadataConfig(targets=["bright-future-x86_64"], owner="nobody"),
         db_trigger=trigger,
     )
+    # we need to make sure that pr_id is set
+    # so we can check it out and add it to spec's release field
+    assert helper.metadata.pr_id
 
     flexmock(copr_build).should_receive(
         "get_copr_build_info_url_from_flask"


### PR DESCRIPTION
we need to make sure that pr_id is set so we can check it out and add it
to spec's release field

Related: packit-service/packit#890