### PR TITLE
Use the last release tag as the commit_sha in IssueCommentEvents

### DIFF
--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -690,7 +690,6 @@ class IssueCommentEvent(AddIssueDbTrigger, AbstractGithubEvent):
         self.user_login = user_login
         self.comment = comment
         self.identifier = str(issue_id)
-        self.commit_sha = None
 
     @property
     def tag_name(self):
@@ -698,6 +697,10 @@ class IssueCommentEvent(AddIssueDbTrigger, AbstractGithubEvent):
             releases = self.project.get_releases()
             self._tag_name = releases[0].tag_name if releases else ""
         return self._tag_name
+
+    @property
+    def commit_sha(self):
+        return self.tag_name
 
     def get_dict(self, default_dict: Optional[Dict] = None) -> dict:
         result = super().get_dict()

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -465,13 +465,16 @@ class TestEvents:
         assert event_object.project.full_repo_name == "packit-service/packit"
         assert not event_object.base_project
 
+        flexmock(event_object.project).should_receive("get_releases").and_return(
+            [flexmock(tag_name="0.5.0"), flexmock(tag_name="0.4.1")]
+        )
         flexmock(PackageConfigGetter).should_receive(
             "get_package_config_from_repo"
         ).with_args(
             base_project=event_object.base_project,
             project=event_object.project,
             pr_id=None,
-            reference=None,
+            reference="0.5.0",
             fail_when_missing=False,
             spec_file_path=None,
         ).and_return(


### PR DESCRIPTION
Currently getting the package configuration from IssueCommentEvents
fails as there is commit_sha is set to None, so there is no ref to be
checked out.

Packit commands in issues work with the last release from the repo, so
it's safe to return 'tag_name' as the 'commit_sha'.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>