### PR TITLE
actually check out PR when building it

### DIFF
--- a/packit_service/service/events.py
+++ b/packit_service/service/events.py
@@ -182,7 +182,8 @@ class EventData:
         project_url = event.get("project_url")
         tag_name = event.get("tag_name")
         git_ref = event.get("git_ref")
-        pr_id = event.get("pr_id")
+        # event has _pr_id as the attribute while pr_id is a getter property
+        pr_id = event.get("_pr_id") or event.get("pr_id")
         commit_sha = event.get("commit_sha")
         identifier = event.get("identifier")
 

--- a/packit_service/worker/jobs.py
+++ b/packit_service/worker/jobs.py
@@ -336,6 +336,14 @@ class SteveJobs:
         # failed because of missing whitelist approval
         whitelist = Whitelist()
         user_login = getattr(event, "user_login", None)
+
+        # VERY UGLY
+        # TODO: REFACTOR !!!
+        if handler_kls == GitHubPullRequestCommentCoprBuildHandler and isinstance(
+            event, PullRequestCommentPagureEvent
+        ):
+            handler_kls = PagurePullRequestCommentCoprBuildHandler
+
         jobs = get_config_for_handler_kls(
             handler_kls=handler_kls, event=event, package_config=event.package_config,
         )
@@ -349,17 +357,6 @@ class SteveJobs:
                     success=True, details={"msg": "Account is not whitelisted!"}
                 )
             }
-
-        # VERY UGLY
-        # TODO: REFACTOR !!!
-        if handler_kls == GitHubPullRequestCommentCoprBuildHandler and isinstance(
-            event, PullRequestCommentPagureEvent
-        ):
-            handler_kls = PagurePullRequestCommentCoprBuildHandler
-
-        jobs = get_config_for_handler_kls(
-            handler_kls=handler_kls, event=event, package_config=event.package_config,
-        )
 
         signatures = [handler_kls.get_signature(event=event, job=job) for job in jobs]
         # https://docs.celeryproject.org/en/stable/userguide/canvas.html#groups


### PR DESCRIPTION
    Event classes have _pr_id as the attribute while pr_id is a getter
    property, so the EventData should parse _pr_id, not pr_id. Since I'm not
    sure if some events parse pr_id, I want to keep things backwards compat.

<details>
<summary>When I didn't know what I was doing</summary>
I seriously don't understand what's going on. We are not checking out a
PR when we are building it. The worst is that all tests are passing and
all the code seems to be correct. But logs tell something else, can
anyone tell me what's wrong?

Here are the prod logs:
```
[2020-07-14 13:23:40,783: INFO/ForkPoolWorker-1] Task task.steve_jobs.process_message[81d16241-1292-4106-920b-9b851c626632] succeeded in 1.5510710068047047s: {'success': Tru
e, 'details': {'event': {'trigger': 'pull_request', 'created_at': 1594733019, 'project_url': 'https://github.com/psss/tmt', '_pr_id': 269, 'git_ref': None, 'identifier': '26
9', 'action': 'synchronize', 'base_repo_namespace': 'FrNecas', 'base_repo_name': 'tmt', 'base_ref': '534ba1123b3a09663000b4e5d46be52cb2267d28', 'target_repo_namespace': 'pss
s', 'target_repo_name': 'tmt', 'commit_sha': '534ba1123b3a09663000b4e5d46be52cb2267d28', 'user_login': 'FrNecas', 'event_type': 'PullRequestGithubEvent', 'trigger_id': 1139}
, 'package_config': {'synced_files': {...}, 'upstream_package_name': 'tmt', 'actions': {...}, 'dist_git_namespace': 'rpms', 'notifications': {...}, 'jobs': [...], 'specfile_
path': 'tmt.spec', 'spec_source_id': 'Source0', 'config_file_path': '.packit.yaml', 'downstream_package_name': 'tmt', 'patch_generation_ignore_paths': [...], 'upstream_proje
ct_url': 'https://github.com/psss/tmt', 'dist_git_base_url': 'https://src.fedoraproject.org/', 'current_version_command': [...], 'upstream_tag_te...', ...}}}   
...
13:23:40.788 abstract.py       DEBUG  Running handler <packit_service.worker.handlers.github_handlers.PullRequestCoprBuildHandler object at 0x7fd54c178fd0> for JobType.tests
obType.tests
13:23:41.820 reporting.py      DEBUG  Status reporter will report for GithubProject(namespace="psss", repo="tmt"), commit=534ba1123b3a09663000b4e5d46be52cb2267d28, pr=None
[2020-07-14 13:23:41,820: DEBUG/ForkPoolWorker-1] Status reporter will report for GithubProject(namespace="psss", repo="tmt"), commit=534ba1123b3a09663000b4e5d46be52cb2267d2
8, pr=None
13:23:41.820 reporting.py      DEBUG  Setting status for check 'packit/testing-farm-fedora-rawhide-x86_64': Building SRPM ...
[2020-07-14 13:23:41,820: DEBUG/ForkPoolWorker-1] Setting status for check 'packit/testing-farm-fedora-rawhide-x86_64': Building SRPM ...
13:23:42.406 reporting.py      DEBUG  Setting status for check 'packit/testing-farm-epel-8-x86_64': Building SRPM ...
[2020-07-14 13:23:42,406: DEBUG/ForkPoolWorker-1] Setting status for check 'packit/testing-farm-epel-8-x86_64': Building SRPM ...
13:23:45.469 reporting.py      DEBUG  Setting status for check 'packit/testing-farm-fedora-31-x86_64': Building SRPM ...
[2020-07-14 13:23:45,469: DEBUG/ForkPoolWorker-1] Setting status for check 'packit/testing-farm-fedora-31-x86_64': Building SRPM ...
13:23:45.908 reporting.py      DEBUG  Setting status for check 'packit/testing-farm-fedora-32-x86_64': Building SRPM ...
[2020-07-14 13:23:45,908: DEBUG/ForkPoolWorker-1] Setting status for check 'packit/testing-farm-fedora-32-x86_64': Building SRPM ...
[2020-07-14 13:23:46,352: DEBUG/ForkPoolWorker-1] Arguments received in the init method of the LocalProject class: 
git_repo: None
working_dir: /sandcastle
ref: None
git_project: GithubProject(namespace="psss", repo="tmt")
git_service: None
git_url: 
full_name: 
namespace: 
repo_name: 
offline: False
refresh True
remote: 
pr_id: None    <-- WHAT?!!!
```

why on earth is the commit sha set and pr_id not?
</details>