### PR TITLE
files/install-[deps-]worker.yaml - unpin sentry-sdk version

### DIFF
--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -27,6 +27,6 @@
       pip:
         name:
           - git+https://github.com/packit-service/sandcastle.git
-          - sentry-sdk==0.14.4
+          - sentry-sdk
           - flask-restx
         executable: pip3

--- a/files/install-deps.yaml
+++ b/files/install-deps.yaml
@@ -37,7 +37,6 @@
           # temporary workaround for sake of marhsmallow
           - git+https://github.com/packit-service/packit.git
           - persistentdict # still needed by one Alembic migration script
-          - sentry-sdk==0.14.4
-          - sentry-sdk[flask]==0.14.4
+          - sentry-sdk[flask]
           - flask-restx
         executable: pip3


### PR DESCRIPTION
The [newest version is 0.16.1](https://github.com/getsentry/sentry-python/releases).
Do we still want to have the version pinned and increase it once in a while or do we trust Sentry that they don't release broken versions?