### PR TITLE
Use Fedora 31 as a base for the workers

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,6 +1,6 @@
 # Celery worker which runs tasks (packit) from the web service
 
-FROM fedora:32
+FROM fedora:31
 
 ENV LANG=en_US.UTF-8 \
     ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3 \


### PR DESCRIPTION
This is to make the tests work again. On the long run we should figure
out why the worker pods failed to start when the image was based on
Fedora 32 and why they had this issue only in the test environment but
not on the stage deployment.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>