### PR TITLE
Fix Docker Hub CI test builds and update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,17 +9,18 @@ AP ?= ansible-playbook -vv -c local -i localhost, -e ansible_python_interpreter=
 PATH_TO_SECRETS ?= $(CURDIR)/secrets/
 COV_REPORT ?= term-missing
 COLOR ?= yes
+SOURCE_BRANCH ?= $(git branch --show-current)
 
 service: files/install-deps.yaml files/recipe.yaml
-	$(CONTAINER_ENGINE) build --rm -t $(SERVICE_IMAGE) -f files/docker/Dockerfile .
+	$(CONTAINER_ENGINE) build --rm -t $(SERVICE_IMAGE) -f files/docker/Dockerfile --build-arg SOURCE_BRANCH=$SOURCE_BRANCH .
 
 worker: files/install-deps-worker.yaml files/recipe-worker.yaml
-	$(CONTAINER_ENGINE) build --rm -t $(WORKER_IMAGE) -f files/docker/Dockerfile.worker .
+	$(CONTAINER_ENGINE) build --rm -t $(WORKER_IMAGE) -f files/docker/Dockerfile.worker --build-arg SOURCE_BRANCH=$SOURCE_BRANCH .
 
 # This is for cases when you want to deploy into production and don't want to wait for dockerhub
 # Make sure you have latest docker.io/usercont/packit:prod prior to running this
 worker-prod: files/install-deps-worker.yaml files/recipe-worker.yaml
-	$(CONTAINER_ENGINE) build --rm -t $(WORKER_IMAGE_PROD) -f files/docker/Dockerfile.worker .
+	$(CONTAINER_ENGINE) build --rm -t $(WORKER_IMAGE_PROD) -f files/docker/Dockerfile.worker --build-arg SOURCE_BRANCH=$SOURCE_BRANCH .
 
 worker-prod-push: worker-prod
 	$(CONTAINER_ENGINE) push $(WORKER_IMAGE_PROD)

--- a/files/install-deps-worker.yaml
+++ b/files/install-deps-worker.yaml
@@ -2,11 +2,23 @@
 - name: Install dependencies for packit-service worker.
   hosts: all
   vars:
-    # added default value to not break functionality during implementing
-    # https://github.com/packit-service/packit-service/pull/717
-    # have to be removed once implemented
-    source_branch: "{{ lookup('env', 'SOURCE_BRANCH') or 'master' }}"
+    source_branch: "{{ lookup('env', 'SOURCE_BRANCH') }}"
   tasks:
+    - name: Check source_branch value
+      debug:
+        msg: source_branch is set to {{ source_branch }}
+    - name: Fail on empty source_branch variable
+      fail:
+        msg: Variable source_branch, which is set from env variable SOURCE_BRANCH is empty.
+      when: source_branch == ''
+    # Docker Hub CI test is build from non master/stable branch (eg. packit:fix_hook)
+    # source_branch is changed to master in that case
+    - name: Change source branch to master if is not master/stable
+      set_fact:
+        source_branch: "master"
+      when:
+        - source_branch != 'stable'
+        - source_branch != 'master'
     - name: Check source_branch value
       debug:
         msg: source_branch is set to {{ source_branch }}

--- a/files/zuul-tests.yaml
+++ b/files/zuul-tests.yaml
@@ -4,6 +4,12 @@
   hosts: all
   tasks:
     - include_tasks: tasks/zuul-project-setup.yaml
+    # Passing branch via env variable SOURCE_BRANCH is required because playbooks
+    # install-deps* are used in 2 different scenarios:
+    # 1. Dockerfile processed via Docker Hub custom build hook
+    # 2. Zuul tests (this config)
+    # TODO: try to unify source of this variable
+    # eg. trigger build via hook instead of autobuild triggered by repo push action
     - name: Install podman
       dnf:
         name:
@@ -14,6 +20,8 @@
       command: "make worker"
       args:
         chdir: "{{ project_dir }}"
+      environment:
+        SOURCE_BRANCH: "{{ zuul.branch }}"
     - name: Run tests within a container
       command: "make check_in_container"
       args:


### PR DESCRIPTION
Because of Docker Hub CI test builds are triggered for all branches we need
set SOURCE_BRANCH to master in case a custom branch is used.

Makefile was updated because image builds require SOURCE_BRANCH 
build variable.