### PR TITLE
copr builds: set commit status URL to FAQ when lack of perms

### DIFF
--- a/packit_service/constants.py
+++ b/packit_service/constants.py
@@ -1,6 +1,11 @@
 from enum import Enum
 
-FAQ_URL = "https://packit.dev/packit-as-a-service/#faq"
+DOCS_URL = "https://packit.dev/packit-as-a-service/"
+FAQ_URL = f"{DOCS_URL}#faq"
+FAQ_URL_HOW_TO_RETRIGGER = (
+    f"{DOCS_URL}#how-to-re-trigger-packit-service-actions-in-your-pull-request"
+)
+
 SANDCASTLE_WORK_DIR = "/sandcastle"
 SANDCASTLE_IMAGE = "docker.io/usercont/sandcastle"
 SANDCASTLE_DEFAULT_PROJECT = "myproject"

--- a/packit_service/worker/handlers/github_handlers.py
+++ b/packit_service/worker/handlers/github_handlers.py
@@ -38,7 +38,10 @@ from packit.exceptions import PackitException
 from packit.local_project import LocalProject
 
 from packit_service import sentry_integration
-from packit_service.constants import PERMISSIONS_ERROR_WRITE_OR_ADMIN
+from packit_service.constants import (
+    PERMISSIONS_ERROR_WRITE_OR_ADMIN,
+    FAQ_URL_HOW_TO_RETRIGGER,
+)
 from packit_service.models import (
     InstallationModel,
     AbstractTriggerDbType,
@@ -273,6 +276,7 @@ class PullRequestCoprBuildHandler(AbstractCoprBuildHandler):
                 self.copr_build_helper.report_status_to_all(
                     description=PERMISSIONS_ERROR_WRITE_OR_ADMIN,
                     state=CommitStatus.failure,
+                    url=FAQ_URL_HOW_TO_RETRIGGER,
                 )
                 return TaskResults(
                     success=True, details={"msg": PERMISSIONS_ERROR_WRITE_OR_ADMIN}


### PR DESCRIPTION
When a build doesn't get triggered because of lack of permissions, we
should guide the contributor - with this change, we'd point the commit
status URL to our FAQ.

Related: https://github.com/packit-service/packit-service/issues/481